### PR TITLE
Refactor trusswork modals to use react-modal

### DIFF
--- a/frontend/src/app/commonComponents/Modal.tsx
+++ b/frontend/src/app/commonComponents/Modal.tsx
@@ -7,7 +7,8 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 
 import iconClose from "../../img/close.svg";
 
-type ModalVariant = "warning";
+type ModalVariantWithIcon = "warning";
+type ModalVariant = ModalVariantWithIcon | "mobile-lg";
 
 interface Props {
   onClose: () => void;
@@ -15,15 +16,16 @@ interface Props {
   contentLabel: string;
   showClose?: boolean;
   containerClassName?: string;
-  variant?: "warning";
+  variant?: ModalVariant | null;
   title?: string;
   children?: React.ReactNode;
 }
 
 type IconDefinition = typeof faExclamationCircle;
 
-const variantIcons: Record<ModalVariant, IconDefinition> = {
+const variantIcons: Record<ModalVariant, IconDefinition | null> = {
   warning: faExclamationCircle,
+  "mobile-lg": null,
 };
 
 type HeaderProps = {
@@ -44,28 +46,54 @@ const Footer: React.FC<FooterProps> = ({ children, styleClassNames }) => (
   <div className={"modal__footer " + styleClassNames}>{children}</div>
 );
 
+const getVariantModalStyles = (variant: ModalVariant | null) => {
+  switch (variant) {
+    case "mobile-lg":
+      return {
+        width: 480,
+      };
+    case "warning":
+      return {
+        borderRadius: 0,
+      };
+    default:
+      return {};
+  }
+};
+
+const getVariantContainerClasses = (variant: ModalVariant | null) => {
+  if (variant === "warning") {
+    return "border-left-1 modal__variant border-gold";
+  } else {
+    return "";
+  }
+};
+
+const getVariantMainElemClasses = (variant: ModalVariant | null) => {
+  switch (variant) {
+    case "mobile-lg":
+      return "padding-4";
+    case "warning":
+      return "";
+    default:
+      return "padding-205";
+  }
+};
+
 const Modal = ({
   onClose,
   showModal,
   children,
   showClose = true,
   containerClassName,
-  variant,
+  variant = null,
   contentLabel,
 }: Props): JSX.Element => {
   const containerClasses = classnames(
-    containerClassName,
     "modal__container",
-    variant && "border-left-1 modal__variant",
-    variant === "warning" && "border-gold"
+    containerClassName,
+    getVariantContainerClasses(variant)
   );
-
-  const variantStyles = variant
-    ? {
-        padding: 0,
-        borderRadius: 0,
-      }
-    : {};
 
   return (
     <ReactModal
@@ -76,7 +104,8 @@ const Modal = ({
         content: {
           position: "initial",
           border: 0,
-          ...variantStyles,
+          padding: 0,
+          ...getVariantModalStyles(variant),
         },
       }}
       overlayClassName="prime-modal-overlay display-flex flex-align-center flex-justify-center"
@@ -93,9 +122,9 @@ const Modal = ({
             <img className="modal__close-img" src={iconClose} alt="Close" />
           </button>
         )}
-        <main>
-          <div className="modal__content grid-row">
-            {variant && (
+        <main className={getVariantMainElemClasses(variant)}>
+          <div className="modal__content grid-row usa-prose">
+            {variant && variantIcons[variant] && (
               <div className="grid-col flex-auto margin-right-2">
                 <FontAwesomeIcon
                   icon={variantIcons[variant] as IconProp}

--- a/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -28,11 +28,11 @@ Object {
           aria-modal="true"
           class="ReactModal__Content"
           role="dialog"
-          style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 20px;"
+          style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 0px;"
           tabindex="-1"
         >
           <div
-            class="unsupported-state-modal modal__container"
+            class="modal__container unsupported-state-modal"
           >
             <button
               class="modal__close-button"
@@ -44,9 +44,11 @@ Object {
                 src="close.svg"
               />
             </button>
-            <main>
+            <main
+              class="padding-205"
+            >
               <div
-                class="modal__content grid-row"
+                class="modal__content grid-row usa-prose"
               >
                 <div
                   class="grid-col"

--- a/frontend/src/app/supportAdmin/ManageFacility/__snapshots__/FacilityInformation.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/ManageFacility/__snapshots__/FacilityInformation.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`Facility Information Confirmation modal and go back 1`] = `
         aria-modal="true"
         class="ReactModal__Content"
         role="dialog"
-        style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 20px;"
+        style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 0px;"
         tabindex="-1"
       >
         <div
@@ -149,9 +149,11 @@ exports[`Facility Information Confirmation modal and go back 1`] = `
               src="close.svg"
             />
           </button>
-          <main>
+          <main
+            class="padding-205"
+          >
             <div
-              class="modal__content grid-row"
+              class="modal__content grid-row usa-prose"
             >
               <div
                 class="grid-col"

--- a/frontend/src/app/supportAdmin/ManageUsers/__snapshots__/AdminManageUser.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/ManageUsers/__snapshots__/AdminManageUser.test.tsx.snap
@@ -763,7 +763,7 @@ exports[`Admin manage users Undelete user 2`] = `
         aria-modal="true"
         class="ReactModal__Content"
         role="dialog"
-        style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 20px;"
+        style="position: initial; top: 40px; left: 40px; right: 40px; bottom: 40px; border: 0px; background: rgb(255, 255, 255); overflow: auto; border-radius: 4px; outline: none; padding: 0px;"
         tabindex="-1"
       >
         <div
@@ -779,9 +779,11 @@ exports[`Admin manage users Undelete user 2`] = `
               src="close.svg"
             />
           </button>
-          <main>
+          <main
+            class="padding-205"
+          >
             <div
-              class="modal__content grid-row"
+              class="modal__content grid-row usa-prose"
             >
               <div
                 class="grid-col"

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
@@ -262,7 +262,7 @@ describe("PendingOrganizationsContainer", () => {
           screen.getByText("Space Camp", { exact: false })
         ).toBeInTheDocument();
 
-        await user.click(screen.getByRole("button", { name: "Close" }));
+        await user.click(screen.getByAltText("Close"));
 
         expect(
           screen.getByText("Space Camp", { exact: false })

--- a/frontend/src/app/testQueue/TestCard/CloseTestCardModal.tsx
+++ b/frontend/src/app/testQueue/TestCard/CloseTestCardModal.tsx
@@ -1,54 +1,48 @@
-import {
-  ButtonGroup,
-  Modal,
-  ModalFooter,
-  ModalHeading,
-  ModalRef,
-  ModalToggleButton,
-} from "@trussworks/react-uswds";
 import React from "react";
 
-interface CloseTestCardModalProps {
-  closeModalRef: React.RefObject<ModalRef>;
+import Button from "../../commonComponents/Button/Button";
+import Modal from "../../commonComponents/Modal";
+
+export type CloseTestCardModalProps = {
   name: string;
   removeTestFromQueue: () => Promise<void>;
-}
+  showModal: boolean;
+  onClose: () => void;
+};
 
-const CloseTestCardModal = ({
-  closeModalRef,
+export const CloseTestCardModal: React.FC<CloseTestCardModalProps> = ({
   name,
   removeTestFromQueue,
-}: CloseTestCardModalProps) => {
+  showModal,
+  onClose,
+}) => {
   return (
     <Modal
-      ref={closeModalRef}
-      aria-labelledby={"close-modal-heading"}
-      id="close-modal"
+      onClose={onClose}
+      showModal={showModal}
+      showClose={true}
+      contentLabel={"Close test card"}
+      variant="mobile-lg"
     >
-      <ModalHeading id="close-modal-heading">
+      <Modal.Header styleClassNames={"font-sans-lg line-height-sans-3"}>
         Are you sure you want to stop {name}'s test?
-      </ModalHeading>
+      </Modal.Header>
       <p>
         Doing so will remove this person from the list. You can use the search
         bar to start their test again later.
       </p>
-      <ModalFooter id={"close-modal-footer"}>
-        <ButtonGroup>
-          <ModalToggleButton
-            modalRef={closeModalRef}
-            closer
-            className={"margin-right-1"}
-            onClick={removeTestFromQueue}
-          >
-            Yes, I'm sure
-          </ModalToggleButton>
-          <ModalToggleButton modalRef={closeModalRef} unstyled closer>
-            No, go back
-          </ModalToggleButton>
-        </ButtonGroup>
-      </ModalFooter>
+      <Modal.Footer styleClassNames={"margin-top-2 float-left"}>
+        <Button onClick={removeTestFromQueue} className={"margin-0"}>
+          Yes, I'm sure
+        </Button>
+        <Button
+          onClick={onClose}
+          variant={"unstyled"}
+          className={"font-sans-sm"}
+        >
+          No, go back
+        </Button>
+      </Modal.Footer>
     </Modal>
   );
 };
-
-export default CloseTestCardModal;

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -601,6 +601,12 @@ describe("TestCard", () => {
         )
       ).not.toBeInTheDocument();
 
+      // select results
+      await user.click(
+        within(
+          screen.getByTestId(`COVID-19-test-result-${testOrderInfo.internalId}`)
+        ).getByLabelText("Positive", { exact: false })
+      );
       await user.click(submitButton);
 
       // able to submit after selecting valid device

--- a/frontend/src/app/testQueue/TestCard/TestCard.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.tsx
@@ -1,11 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardBody,
-  CardHeader,
-  Icon,
-  ModalRef,
-} from "@trussworks/react-uswds";
+import { Card, CardBody, CardHeader, Icon } from "@trussworks/react-uswds";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 
@@ -21,7 +15,7 @@ import {
   QueriedTestOrder,
 } from "../TestCardForm/types";
 
-import CloseTestCardModal from "./CloseTestCardModal";
+import { CloseTestCardModal } from "./CloseTestCardModal";
 
 export interface TestCardProps {
   testOrder: QueriedTestOrder;
@@ -50,7 +44,8 @@ export const TestCard = ({
   const organization = useSelector<RootState, Organization>(
     (state: any) => state.organization as Organization
   );
-  const closeModalRef = useRef<ModalRef>(null);
+
+  const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
 
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -84,9 +79,10 @@ export const TestCard = ({
   return (
     <>
       <CloseTestCardModal
-        closeModalRef={closeModalRef}
         name={patientFullName}
         removeTestFromQueue={removeTestFromQueue}
+        showModal={isCloseModalOpen}
+        onClose={() => setIsCloseModalOpen(false)}
       />
       <Card
         className={"list-style-none margin-bottom-1em test-card-container"}
@@ -156,7 +152,7 @@ export const TestCard = ({
               <Button
                 className={"card-close-button"}
                 variant="unstyled"
-                onClick={closeModalRef.current?.toggleModal}
+                onClick={() => setIsCloseModalOpen(true)}
                 ariaLabel={`Close test for ${patientFullName}`}
               >
                 <Icon.Close size={3} focusable={true} role={"presentation"} />

--- a/frontend/src/app/testQueue/TestCardForm/IncompleteAOEWarningModal.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/IncompleteAOEWarningModal.tsx
@@ -1,51 +1,42 @@
-import {
-  ButtonGroup,
-  Modal,
-  ModalFooter,
-  ModalHeading,
-  ModalRef,
-  ModalToggleButton,
-} from "@trussworks/react-uswds";
 import React from "react";
 
-interface IncompleteAOEWarningModalProps {
-  submitModalRef: React.RefObject<ModalRef>;
+import Button from "../../commonComponents/Button/Button";
+import Modal from "../../commonComponents/Modal";
+
+export type IncompleteAOEWarningModalProps = {
   name: string;
   submitForm: (forceSubmit: boolean) => Promise<void>;
-}
+  showModal: boolean;
+  onClose: () => void;
+};
 
-const IncompleteAOEWarningModal = ({
-  submitModalRef,
-  name,
-  submitForm,
-}: IncompleteAOEWarningModalProps) => {
+export const IncompleteAOEWarningModal: React.FC<
+  IncompleteAOEWarningModalProps
+> = ({ name, submitForm, showModal, onClose }) => {
   return (
     <Modal
-      ref={submitModalRef}
-      aria-labelledby={"submit-modal-heading"}
-      id="submit-modal"
+      onClose={onClose}
+      showModal={showModal}
+      showClose={true}
+      variant="mobile-lg"
+      contentLabel={"Incomplete ask on entry"}
     >
-      <ModalHeading id="submit-modal-heading">
+      <Modal.Header styleClassNames={"font-sans-lg line-height-sans-3"}>
         The test questionnaire for {name} has not been completed.
-      </ModalHeading>
+      </Modal.Header>
       <p>Do you want to submit results anyway?</p>
-      <ModalFooter id={"submit-modal-footer"}>
-        <ButtonGroup>
-          <ModalToggleButton
-            modalRef={submitModalRef}
-            closer
-            className={"margin-right-1"}
-            onClick={() => submitForm(true)}
-          >
-            Submit anyway.
-          </ModalToggleButton>
-          <ModalToggleButton modalRef={submitModalRef} unstyled closer>
-            No, go back.
-          </ModalToggleButton>
-        </ButtonGroup>
-      </ModalFooter>
+      <Modal.Footer styleClassNames={"margin-top-2 float-left"}>
+        <Button onClick={() => submitForm(true)} className={"margin-0"}>
+          Submit anyway.
+        </Button>
+        <Button
+          onClick={onClose}
+          variant={"unstyled"}
+          className={"font-sans-sm"}
+        >
+          No, go back
+        </Button>
+      </Modal.Footer>
     </Modal>
   );
 };
-
-export default IncompleteAOEWarningModal;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -5,9 +5,8 @@ import {
   Checkbox,
   FormGroup,
   Label,
-  ModalRef,
 } from "@trussworks/react-uswds";
-import React, { useEffect, useReducer, useRef, useState } from "react";
+import React, { useEffect, useReducer, useState } from "react";
 
 import TextInput from "../../commonComponents/TextInput";
 import { formatDate } from "../../utils/date";
@@ -50,10 +49,10 @@ import {
   useSpecimenTypeOptions,
   useTestOrderPatient,
 } from "./TestCardForm.utils";
-import IncompleteAOEWarningModal from "./IncompleteAOEWarningModal";
 import { TestResultInputGroup } from "./diseaseSpecificComponents/TestResultInputGroup";
 import { HIVAoEForm } from "./diseaseSpecificComponents/HIVAoEForm";
 import { DevicesMap, QueriedFacility, QueriedTestOrder } from "./types";
+import { IncompleteAOEWarningModal } from "./IncompleteAOEWarningModal";
 
 const DEBOUNCE_TIME = 300;
 
@@ -103,7 +102,7 @@ const TestCardForm = ({
   const { trackSubmitTestResult, trackUpdateAoEResponse } =
     useAppInsightTestCardEvents();
 
-  const submitModalRef = useRef<ModalRef>(null);
+  const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false);
 
   const filteredDeviceTypes = useFilteredDeviceTypes(facility);
 
@@ -335,12 +334,12 @@ const TestCardForm = ({
     }
 
     if (!forceSubmit && !areAOEAnswersComplete(state, whichAOEFormOption)) {
-      submitModalRef.current?.toggleModal();
+      setIsSubmitModalOpen(true);
       return;
     }
 
     trackSubmitTestResult();
-
+    setIsSubmitModalOpen(false);
     const result = await submitTestResult({
       variables: {
         patientId: testOrder.patient?.internalId,
@@ -365,9 +364,10 @@ const TestCardForm = ({
     <>
       <QueueItemSubmitLoader show={submitLoading} name={patientFullName} />
       <IncompleteAOEWarningModal
-        submitModalRef={submitModalRef}
         name={patientFullName}
         submitForm={submitForm}
+        showModal={isSubmitModalOpen}
+        onClose={() => setIsSubmitModalOpen(false)}
       />
       <div className="grid-container">
         {/* error and warning alerts */}

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -485,104 +485,8 @@ Object {
       </div>
     </div>
     <div
-      aria-labelledby="submit-modal-heading"
-      class="usa-modal-wrapper is-hidden"
-      data-force-action="false"
-      id="submit-modal"
-      role="dialog"
-    >
-      <div
-        aria-controls="submit-modal"
-        class="usa-modal-overlay"
-        data-testid="modalOverlay"
-      >
-        <div
-          class="usa-modal"
-          data-force-action="false"
-          data-testid="modalWindow"
-          tabindex="-1"
-        >
-          <div
-            class="usa-modal__content"
-          >
-            <div
-              class="usa-modal__main"
-            >
-              <h2
-                class="usa-modal__heading"
-                id="submit-modal-heading"
-              >
-                The test questionnaire for 
-                Dixon, Althea Hedda Mclaughlin
-                 has not been completed.
-              </h2>
-              <p>
-                Do you want to submit results anyway?
-              </p>
-              <div
-                class="usa-modal__footer"
-                data-testid="modalFooter"
-                id="submit-modal-footer"
-              >
-                <ul
-                  class="usa-button-group"
-                >
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button margin-right-1"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      Submit anyway.
-                    </button>
-                  </li>
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button usa-button--unstyled"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      No, go back.
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <button
-              aria-controls="submit-modal"
-              aria-label="Close this window"
-              class="usa-button usa-modal__close"
-              data-close-modal="true"
-              data-testid="button"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="usa-icon"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+      class="modal--basic"
+    />
   </body>,
   "container": <div>
     <div
@@ -1538,9 +1442,7 @@ exports[`TestCardForm initial state matches snapshot for flu device 1`] = `
 exports[`TestCardForm initial state matches snapshot for hiv device 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": <body
-    style="padding-right: 0px;"
-  >
+  "baseElement": <body>
     <div>
       <div
         aria-hidden="true"
@@ -1950,104 +1852,8 @@ Object {
       </div>
     </div>
     <div
-      aria-labelledby="submit-modal-heading"
-      class="usa-modal-wrapper is-hidden"
-      data-force-action="false"
-      id="submit-modal"
-      role="dialog"
-    >
-      <div
-        aria-controls="submit-modal"
-        class="usa-modal-overlay"
-        data-testid="modalOverlay"
-      >
-        <div
-          class="usa-modal"
-          data-force-action="false"
-          data-testid="modalWindow"
-          tabindex="-1"
-        >
-          <div
-            class="usa-modal__content"
-          >
-            <div
-              class="usa-modal__main"
-            >
-              <h2
-                class="usa-modal__heading"
-                id="submit-modal-heading"
-              >
-                The test questionnaire for 
-                Dixon, Althea Hedda Mclaughlin
-                 has not been completed.
-              </h2>
-              <p>
-                Do you want to submit results anyway?
-              </p>
-              <div
-                class="usa-modal__footer"
-                data-testid="modalFooter"
-                id="submit-modal-footer"
-              >
-                <ul
-                  class="usa-button-group"
-                >
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button margin-right-1"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      Submit anyway.
-                    </button>
-                  </li>
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button usa-button--unstyled"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      No, go back.
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <button
-              aria-controls="submit-modal"
-              aria-label="Close this window"
-              class="usa-button usa-modal__close"
-              data-close-modal="true"
-              data-testid="button"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="usa-icon"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+      class="modal--basic"
+    />
   </body>,
   "container": <div>
     <div
@@ -2533,9 +2339,7 @@ Object {
 exports[`TestCardForm initial state matches snapshot for multiplex device 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": <body
-    style="padding-right: 0px;"
-  >
+  "baseElement": <body>
     <div>
       <div
         aria-hidden="true"
@@ -3172,104 +2976,8 @@ Object {
       </div>
     </div>
     <div
-      aria-labelledby="submit-modal-heading"
-      class="usa-modal-wrapper is-hidden"
-      data-force-action="false"
-      id="submit-modal"
-      role="dialog"
-    >
-      <div
-        aria-controls="submit-modal"
-        class="usa-modal-overlay"
-        data-testid="modalOverlay"
-      >
-        <div
-          class="usa-modal"
-          data-force-action="false"
-          data-testid="modalWindow"
-          tabindex="-1"
-        >
-          <div
-            class="usa-modal__content"
-          >
-            <div
-              class="usa-modal__main"
-            >
-              <h2
-                class="usa-modal__heading"
-                id="submit-modal-heading"
-              >
-                The test questionnaire for 
-                Dixon, Althea Hedda Mclaughlin
-                 has not been completed.
-              </h2>
-              <p>
-                Do you want to submit results anyway?
-              </p>
-              <div
-                class="usa-modal__footer"
-                data-testid="modalFooter"
-                id="submit-modal-footer"
-              >
-                <ul
-                  class="usa-button-group"
-                >
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button margin-right-1"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      Submit anyway.
-                    </button>
-                  </li>
-                  <li
-                    class="usa-button-group__item"
-                  >
-                    <button
-                      aria-controls="submit-modal"
-                      class="usa-button usa-button--unstyled"
-                      data-close-modal="true"
-                      data-testid="button"
-                      type="button"
-                    >
-                      No, go back.
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <button
-              aria-controls="submit-modal"
-              aria-label="Close this window"
-              class="usa-button usa-modal__close"
-              data-close-modal="true"
-              data-testid="button"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="usa-icon"
-                focusable="false"
-                height="1em"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+      class="modal--basic"
+    />
   </body>,
   "container": <div>
     <div

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Modal from "react-modal";
 import classnames from "classnames";
 
@@ -110,22 +111,17 @@ export const DetachedTestResultDetailsModal = ({
 
   return (
     <>
-      <div className="display-flex flex-justify">
-        <h1
-          id="result-detail-title"
-          className="font-heading-lg margin-top-05 margin-bottom-0"
-        >
+      <div className="display-flex flex-justify flex-align-center">
+        <h1 id="result-detail-title" className="font-heading-lg margin-0">
           Result details
         </h1>
-        <div className="sr-time-of-test-buttons">
-          <button
-            className="modal__close-button"
-            style={{ cursor: "pointer" }}
-            onClick={closeModal}
-          >
-            <img className="modal__close-img" src={iconClose} alt="Close" />
-          </button>
-        </div>
+        <button
+          className="modal__close-button margin-top-0"
+          style={{ cursor: "pointer" }}
+          onClick={closeModal}
+        >
+          <img className="modal__close-img" src={iconClose} alt="Close" />
+        </button>
       </div>
       <div className="border-top border-base-lighter margin-x-neg-205 margin-top-1"></div>
       <h2 className="font-sans-md margin-top-3">Patient</h2>

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
@@ -6,28 +6,24 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="display-flex flex-justify"
+        class="display-flex flex-justify flex-align-center"
       >
         <h1
-          class="font-heading-lg margin-top-05 margin-bottom-0"
+          class="font-heading-lg margin-0"
           id="result-detail-title"
         >
           Result details
         </h1>
-        <div
-          class="sr-time-of-test-buttons"
+        <button
+          class="modal__close-button margin-top-0"
+          style="cursor: pointer;"
         >
-          <button
-            class="modal__close-button"
-            style="cursor: pointer;"
-          >
-            <img
-              alt="Close"
-              class="modal__close-img"
-              src="close.svg"
-            />
-          </button>
-        </div>
+          <img
+            alt="Close"
+            class="modal__close-img"
+            src="close.svg"
+          />
+        </button>
       </div>
       <div
         class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
@@ -158,28 +154,24 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="display-flex flex-justify"
+      class="display-flex flex-justify flex-align-center"
     >
       <h1
-        class="font-heading-lg margin-top-05 margin-bottom-0"
+        class="font-heading-lg margin-0"
         id="result-detail-title"
       >
         Result details
       </h1>
-      <div
-        class="sr-time-of-test-buttons"
+      <button
+        class="modal__close-button margin-top-0"
+        style="cursor: pointer;"
       >
-        <button
-          class="modal__close-button"
-          style="cursor: pointer;"
-        >
-          <img
-            alt="Close"
-            class="modal__close-img"
-            src="close.svg"
-          />
-        </button>
-      </div>
+        <img
+          alt="Close"
+          class="modal__close-img"
+          src="close.svg"
+        />
+      </button>
     </div>
     <div
       class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
@@ -367,28 +359,24 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="display-flex flex-justify"
+        class="display-flex flex-justify flex-align-center"
       >
         <h1
-          class="font-heading-lg margin-top-05 margin-bottom-0"
+          class="font-heading-lg margin-0"
           id="result-detail-title"
         >
           Result details
         </h1>
-        <div
-          class="sr-time-of-test-buttons"
+        <button
+          class="modal__close-button margin-top-0"
+          style="cursor: pointer;"
         >
-          <button
-            class="modal__close-button"
-            style="cursor: pointer;"
-          >
-            <img
-              alt="Close"
-              class="modal__close-img"
-              src="close.svg"
-            />
-          </button>
-        </div>
+          <img
+            alt="Close"
+            class="modal__close-img"
+            src="close.svg"
+          />
+        </button>
       </div>
       <div
         class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
@@ -567,28 +555,24 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="display-flex flex-justify"
+      class="display-flex flex-justify flex-align-center"
     >
       <h1
-        class="font-heading-lg margin-top-05 margin-bottom-0"
+        class="font-heading-lg margin-0"
         id="result-detail-title"
       >
         Result details
       </h1>
-      <div
-        class="sr-time-of-test-buttons"
+      <button
+        class="modal__close-button margin-top-0"
+        style="cursor: pointer;"
       >
-        <button
-          class="modal__close-button"
-          style="cursor: pointer;"
-        >
-          <img
-            alt="Close"
-            class="modal__close-img"
-            src="close.svg"
-          />
-        </button>
-      </div>
+        <img
+          alt="Close"
+          class="modal__close-img"
+          src="close.svg"
+        />
+      </button>
     </div>
     <div
       class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
@@ -824,28 +808,24 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="display-flex flex-justify"
+        class="display-flex flex-justify flex-align-center"
       >
         <h1
-          class="font-heading-lg margin-top-05 margin-bottom-0"
+          class="font-heading-lg margin-0"
           id="result-detail-title"
         >
           Result details
         </h1>
-        <div
-          class="sr-time-of-test-buttons"
+        <button
+          class="modal__close-button margin-top-0"
+          style="cursor: pointer;"
         >
-          <button
-            class="modal__close-button"
-            style="cursor: pointer;"
-          >
-            <img
-              alt="Close"
-              class="modal__close-img"
-              src="close.svg"
-            />
-          </button>
-        </div>
+          <img
+            alt="Close"
+            class="modal__close-img"
+            src="close.svg"
+          />
+        </button>
       </div>
       <div
         class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
@@ -988,28 +968,24 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="display-flex flex-justify"
+      class="display-flex flex-justify flex-align-center"
     >
       <h1
-        class="font-heading-lg margin-top-05 margin-bottom-0"
+        class="font-heading-lg margin-0"
         id="result-detail-title"
       >
         Result details
       </h1>
-      <div
-        class="sr-time-of-test-buttons"
+      <button
+        class="modal__close-button margin-top-0"
+        style="cursor: pointer;"
       >
-        <button
-          class="modal__close-button"
-          style="cursor: pointer;"
-        >
-          <img
-            alt="Close"
-            class="modal__close-img"
-            src="close.svg"
-          />
-        </button>
-      </div>
+        <img
+          alt="Close"
+          class="modal__close-img"
+          src="close.svg"
+        />
+      </button>
     </div>
     <div
       class="border-top border-base-lighter margin-x-neg-205 margin-top-1"

--- a/frontend/src/scss/base/_prime-styles.scss
+++ b/frontend/src/scss/base/_prime-styles.scss
@@ -498,8 +498,8 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
     }
   }
 }
-// MODAL
 
+// MODAL
 // the background behind the modal
 .prime-modal-overlay {
   background-color: rgba(0, 0, 0, 0.5);
@@ -511,29 +511,12 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
   z-index: 1000;
 }
 
-.prime-modal-buttons {
-  display: flex;
-  justify-content: flex-end;
-  margin: 0 1em;
-}
-
-.prime-modal-buttons button {
-  margin-left: 1em;
-}
-
-.sr-modal-content p {
-  margin: 1em;
-}
-
-// Simple modal
 .modal--basic {
   .ReactModal__Content {
-    @include u-margin-x(4);
-
     max-height: 90vh;
     width: 700px;
 
-    @media (max-width: 768px) {
+    @media (max-width: 48rem) {
       width: units("mobile-lg");
     }
   }
@@ -593,17 +576,13 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
 
   display: block;
   margin-bottom: 0;
-  margin-right: units("neg-205");
-  margin-top: units("neg-205");
+  margin-right: 0;
+  margin-top: 0;
   text-align: center;
 }
 
 .modal__close-img {
   width: units(4);
-}
-
-.modal__content {
-  @extend .usa-prose;
 }
 
 .usa-alert--success {
@@ -1013,15 +992,6 @@ $results-dropdown-spacing: #{units(4)} - #{units(2)} - 22px - #{units(4)}; // he
 
 .sr-time-of-test-footer {
   margin-top: units(3);
-}
-
-.sr-time-of-test-buttons {
-  .modal__close-button {
-    height: auto;
-    padding-bottom: units(1);
-    padding-right: units(1);
-    padding-top: units(2);
-  }
 }
 
 .sr-time-of-test-buttons-footer {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Part one to resolve #7569

## Changes Proposed
- Refactor our usage of trussworks' modals to use our implementation of [react-modal](https://www.npmjs.com/package/react-modal)

## Additional Information
- Effort to upgrade our version of [trussworks/react-uswds](https://github.com/trussworks/react-uswds) to v9.0.0 
  - Trussworks uses the focus-trap-react library to manage focus inside their implementation of the <Modal> component.
   - However, there’s an issue with that library when running tests in Jest because Jest uses JSDom under the hood. So [there’s this warning](https://github.com/focus-trap/focus-trap?tab=readme-ov-file#testing-in-jsdom).
   - The Trussworks team recommends doing [something like this](https://github.com/trussworks/react-uswds/blob/144fc435b892d2b066cc6bd547ea546747d0bc39/docs/modal_tests.md#modal-tests).  
      - I did that [here](https://github.com/CDCgov/prime-simplereport/pull/7569/files#diff-157cbc99ab0c1c08434708d4fe6c16be8a4a1b1b7f67f2fe985d8a29f7ce1582R1) and mocked it [here](https://github.com/CDCgov/prime-simplereport/pull/7569/files#diff-bc6abb0836b5c207b4232e7db185278d9323082d639a06742779d251935692f4R19). 
      - The tests no longer show the ERROR: Your focus-trap must have at least one container with at least one tabbable node in it at all times but it [doesn’t look like the modals](https://github.com/CDCgov/prime-simplereport/actions/runs/8836296172/job/24262564021?pr=7569#step:6:3389) are being rendered in the tests with this change.

As a result, we are not using Trussworks' modals.

## Testing
- Deployed on dev2
- Verify the refactored close test modal and incomplete ask on entry modal in the test queue works as intended
- Ensure the styling of the other modals are the same as before

## Screenshots / Demos
**Before**
<img width="1509" alt="Screenshot 2024-05-02 at 17 57 09" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/0a4fda00-1601-4129-a09a-92de2840491d">

**After**
![Screenshot 2024-05-02 at 17 54 17](https://github.com/CDCgov/prime-simplereport/assets/20211771/ba6117f7-7f99-4d71-a333-9994e967bb32)

## Future work
- [New issue](https://github.com/CDCgov/prime-simplereport/issues/7649) created to leverage our common component modal and clean up our styling

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
