### PR TITLE
Add temporary dev smoke test

### DIFF
--- a/.github/workflows/smokeTestDeployDev.yml
+++ b/.github/workflows/smokeTestDeployDev.yml
@@ -1,0 +1,50 @@
+name: Smoke test deploy Dev
+run-name: Smoke test the deploy for dev by @${{ github.actor }}
+
+on:
+  workflow_run:
+    workflows: [ "Deploy Dev" ]
+    types:
+      - completed
+    branches:
+      - "mike/7160-post-deploy-alert**"
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  smoke-test-front-and-back-end:
+    runs-on: ubuntu-latest
+    environment: dev5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{env.NODE_VERSION}}
+      - name: Cache yarn
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up dependencies
+        working-directory: frontend
+        run: yarn install --prefer-offline
+      - name: Smoke test the env
+        uses: ./.github/actions/post-deploy-smoke-test
+        with:
+          base_domain_name: ${{ vars.BASE_DOMAIN_NAME }}
+  slack_alert:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs: [ smoke-test-front-and-back-end ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Send alert to Slack
+        uses: ./.github/actions/slack-message
+        with:
+          username: ${{ github.actor }}
+          description: |
+            :construction: Dev testing to confirm post-deploy smoke test works correctly. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :construction:
+          webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
+          user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Temporarily needed for testing the post-deploy smoke test on a lower environment #7160 

## Changes Proposed

- Enables a new workflow that runs after a Deploy Dev run, but restricted to only branches matching this one `mike/7160-post-deploy-alert`

## Additional Information

- Will be removed once the testing for #7160 is done

## Testing

- Proofread workflow file