### PR TITLE
Add base domain name to deploy dev workflow

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -52,6 +52,7 @@ jobs:
           okta_enabled: true
           okta_url: https://hhs-prime.oktapreview.com
           okta_client_id: ${{ vars.OKTA_CLIENT_ID }}
+          base_domain_name: ${{ inputs.deploy_env }}.simplereport.gov
 
   prerelease_backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Related to testing #7160 

## Changes Proposed

- Adds base domain name to the deploy dev workflow for the `build-frontend` job which should then populate the `REACT_APP_BASE_URL`