### PR TITLE
Hardcode base domain name for post dev deploy smoke test

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -52,6 +52,7 @@ jobs:
           okta_enabled: true
           okta_url: https://hhs-prime.oktapreview.com
           okta_client_id: ${{ vars.OKTA_CLIENT_ID }}
+          base_domain_name: ${{ inputs.deploy_env }}.simplereport.gov
 
   prerelease_backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/smokeTestDeployDev.yml
+++ b/.github/workflows/smokeTestDeployDev.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Smoke test the env
         uses: ./.github/actions/post-deploy-smoke-test
         with:
-          base_domain_name: ${{ vars.BASE_DOMAIN_NAME }}
+          base_domain_name: dev5.simplereport.gov
   slack_alert:
     runs-on: ubuntu-latest
     if: failure()


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- #7160 

## Changes Proposed

- Hardcodes the base domain name variable for the temporary post-deploy dev smoke test. This whole file is only temporarily needed to verify the functionality of the post-deploy prod smoke test.

## Additional Information

- The `smoke test deploy dev` workflow will only run after **this branch** successfully completes the `Deploy Dev` flow.