### PR TITLE
DB migration to add flu a+b support

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5381,3 +5381,21 @@ databaseChangeLog:
             REVOKE SELECT ON TABLE ${database.defaultSchemaName}.role FROM ${noPhiUsername};
             REVOKE SELECT ON TABLE ${database.defaultSchemaName}.api_user_facility FROM ${noPhiUsername};
             REVOKE SELECT ON TABLE ${database.defaultSchemaName}.api_user_role FROM ${noPhiUsername};
+  - changeSet:
+      id: add-flu-a-and-b-to-supported_disease-table
+      author: tmz1@cdc.gov
+      comment: Add Flu A and B to the supported_disease table.
+      changes:
+        - tagDatabase:
+            tag: add-flu-a-and-b-to-supported_disease-table
+        - sql:
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.supported_disease (
+                   internal_id,
+                   name,
+                   loinc)
+              VALUES
+                   (gen_random_uuid(), 'Flu A and B', '44567-6')
+      rollback:
+        - sql:
+            sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Flu A and B';


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue
resolves #7677 

- Support request to add a new test device that tests for Flu A+B simultaneously, needs to be added to the db to be able to create the device in the UI.
- We have already confirmed with ReportStream that this device looks good.


## Changes Proposed

- DB migration

## Additional Information

## Testing

- Deploy to an Env, see new disease available when creating a device
- Verify rollback
 
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->

---