### PR TITLE
Persist auth updates to api_user_facility table

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -171,11 +171,7 @@ public class UserMutationResolver {
       @Argument Role role) {
     List<UUID> facilityIdsToAssign = facilities == null ? List.of() : facilities;
     _us.updateUserPrivilegesAndGroupAccess(
-        username,
-        orgExternalId,
-        accessAllFacilities,
-        facilityIdsToAssign,
-        role.toOrganizationRole());
+        username, orgExternalId, accessAllFacilities, facilityIdsToAssign, role);
     return new User(_us.getUserByLoginEmail(username));
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -320,30 +320,6 @@ public class DemoOktaRepository implements OktaRepository {
             .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
   }
 
-  public void deleteFacility(Facility facility) {
-    String orgExternalId = facility.getOrganization().getExternalId();
-    if (!orgFacilitiesMap.containsKey(orgExternalId)) {
-      throw new IllegalGraphqlArgumentException(
-          "Cannot delete Okta facility from nonexistent organization.");
-    }
-    orgFacilitiesMap.get(orgExternalId).remove(facility.getInternalId());
-    // remove this facility from every user's OrganizationRoleClaims, as necessary
-    usernameOrgRolesMap =
-        usernameOrgRolesMap.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    e -> e.getKey(),
-                    e -> {
-                      OrganizationRoleClaims oldRoleClaims = e.getValue();
-                      Set<UUID> newFacilities =
-                          oldRoleClaims.getFacilities().stream()
-                              .filter(f -> !f.equals(facility.getInternalId()))
-                              .collect(Collectors.toSet());
-                      return new OrganizationRoleClaims(
-                          orgExternalId, newFacilities, oldRoleClaims.getGrantedRoles());
-                    }));
-  }
-
   private Optional<OrganizationRoleClaims> getOrganizationRoleClaimsFromTenantDataAccess(
       Collection<String> groupNames) {
     List<OrganizationRoleClaims> claims = organizationExtractor.convertClaims(groupNames);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -624,15 +624,6 @@ public class LiveOktaRepository implements OktaRepository {
     log.info("Created Okta group={}", facilityGroupName);
   }
 
-  public void deleteFacility(Facility facility) {
-    String orgExternalId = facility.getOrganization().getExternalId();
-    String groupName = generateFacilityGroupName(orgExternalId, facility.getInternalId());
-    var groups = groupApi.listGroups(groupName, null, null, null, null, null, null, null);
-    for (Group group : groups) {
-      groupApi.deleteGroup(group.getId());
-    }
-  }
-
   @Override
   public void deleteOrganization(Organization org) {
     String externalId = org.getExternalId();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -79,8 +79,6 @@ public interface OktaRepository {
 
   void deleteOrganization(Organization org);
 
-  void deleteFacility(Facility facility);
-
   Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username);
 
   Integer getUsersInSingleFacility(Facility facility);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -727,6 +727,9 @@ public class ApiUserService {
   /*
   Given a list of facility UUIDs, validate that they belong in the given org, and return the list of facility entities
   that the user should be given access to.
+
+  Open question: do we trust the frontend to accurately tell us whether the user has allfacilities access or should we
+  be checking if their role has UserPermission.ACCESS_ALL_FACILITIES?
    */
   private Set<Facility> getFacilitiesToGiveAccess(
       Organization org, boolean accessAllFacilities, Set<UUID> facilities) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -21,6 +21,7 @@ import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.IdentifiedEntity;
 import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
@@ -151,10 +152,7 @@ public class ApiUserService {
     IdentityAttributes userIdentity = new IdentityAttributes(apiUser.getLoginEmail(), name);
     _oktaRepo.reprovisionUser(userIdentity);
 
-    Set<Facility> facilitiesFound = Set.of();
-    if (!facilities.isEmpty()) {
-      facilitiesFound = _orgService.getFacilities(org, facilities);
-    }
+    Set<Facility> facilitiesFound = getFacilitiesToGiveAccess(org, accessAllFacilities, facilities);
     Optional<OrganizationRoleClaims> roleClaims =
         _oktaRepo.updateUserPrivileges(
             apiUser.getLoginEmail(),
@@ -164,6 +162,7 @@ public class ApiUserService {
 
     apiUser.setNameInfo(name);
     apiUser.setIsDeleted(false);
+    apiUser.setFacilities(facilitiesFound);
 
     Optional<OrganizationRoles> orgRoles = roleClaims.map(c -> _orgService.getOrganizationRoles(c));
     UserInfo user = new UserInfo(apiUser, orgRoles, false);
@@ -187,10 +186,10 @@ public class ApiUserService {
     IdentityAttributes userIdentity = new IdentityAttributes(username, name);
     ApiUser apiUser = _apiUserRepo.save(new ApiUser(username, userIdentity));
     boolean active = org.getIdentityVerified();
-    Set<Facility> facilitiesFound = Set.of();
-    if (!facilities.isEmpty()) {
-      facilitiesFound = _orgService.getFacilities(org, facilities);
-    }
+
+    Set<Facility> facilitiesFound = getFacilitiesToGiveAccess(org, accessAllFacilities, facilities);
+    apiUser.setFacilities(facilitiesFound);
+
     Optional<OrganizationRoleClaims> roleClaims =
         _oktaRepo.createUser(
             userIdentity,
@@ -242,13 +241,16 @@ public class ApiUserService {
             .getOrganizationRoleClaimsForUser(username)
             .orElseThrow(MisconfiguredUserException::new);
     Organization org = _orgService.getOrganization(orgClaims.getOrganizationExternalId());
-    Set<Facility> facilitiesFound = _orgService.getFacilities(org, facilities);
+    Set<Facility> facilitiesFound = getFacilitiesToGiveAccess(org, accessAllFacilities, facilities);
+
     Optional<OrganizationRoleClaims> newOrgClaims =
         _oktaRepo.updateUserPrivileges(
             username, org, facilitiesFound, getOrganizationRoles(role, accessAllFacilities));
     Optional<OrganizationRoles> orgRoles =
         newOrgClaims.map(c -> _orgService.getOrganizationRoles(org, c));
     UserInfo user = new UserInfo(apiUser, orgRoles, false);
+
+    apiUser.setFacilities(facilitiesFound);
 
     createUserUpdatedAuditLog(apiUser.getInternalId(), getCurrentApiUser().getInternalId());
 
@@ -709,33 +711,53 @@ public class ApiUserService {
       OrganizationRole role)
       throws IllegalGraphqlArgumentException {
 
-    if (!allFacilitiesAccess && facilities.isEmpty()) {
+    Organization newOrg = _orgService.getOrganization(orgExternalId);
+
+    Set<Facility> facilitiesToGiveAccessTo =
+        getFacilitiesToGiveAccess(newOrg, allFacilitiesAccess, new HashSet<>(facilities));
+
+    Optional<ApiUser> foundUser = _apiUserRepo.findByLoginEmail(username);
+    ApiUser apiUser = foundUser.orElseThrow(NonexistentUserException::new);
+    apiUser.setFacilities(facilitiesToGiveAccessTo);
+
+    _oktaRepo.updateUserPrivilegesAndGroupAccess(
+        username, newOrg, facilitiesToGiveAccessTo, role, allFacilitiesAccess);
+  }
+
+  /*
+  Given a list of facility UUIDs, validate that they belong in the given org, and return the list of facility entities
+  that the user should be given access to.
+   */
+  private Set<Facility> getFacilitiesToGiveAccess(
+      Organization org, boolean accessAllFacilities, Set<UUID> facilities) {
+    if (!accessAllFacilities && facilities.isEmpty()) {
       throw new PrivilegeUpdateFacilityAccessException();
     }
 
-    Organization newOrg = _orgService.getOrganization(orgExternalId);
     Set<UUID> facilityIdsToGiveAccess =
-        allFacilitiesAccess
+        accessAllFacilities
             // use an empty set of facilities if user can access all facilities anyway
             ? Set.of()
-            : new HashSet<>(facilities);
+            : facilities;
 
     Set<Facility> facilitiesToGiveAccessTo =
-        _orgService.getFacilities(newOrg, facilityIdsToGiveAccess);
+        _orgService.getFacilities(org, facilityIdsToGiveAccess);
 
     if (facilitiesToGiveAccessTo.size() != facilityIdsToGiveAccess.size()) {
       Set<UUID> facilityIdDiff =
           dedupeFoundAndPassedInFacilityIds(facilitiesToGiveAccessTo, facilityIdsToGiveAccess);
-      throw new UnidentifiedFacilityException(facilityIdDiff, orgExternalId);
+      throw new UnidentifiedFacilityException(facilityIdDiff, org.getExternalId());
     }
-    _oktaRepo.updateUserPrivilegesAndGroupAccess(
-        username, newOrg, facilitiesToGiveAccessTo, role, allFacilitiesAccess);
+
+    return facilitiesToGiveAccessTo;
   }
 
   private Set<UUID> dedupeFoundAndPassedInFacilityIds(
       Set<Facility> facilitiesToGiveAccessTo, Set<UUID> facilityIdsToGiveAccess) {
     Set<UUID> facilityIdsFound =
-        facilitiesToGiveAccessTo.stream().map(f -> f.getInternalId()).collect(Collectors.toSet());
+        facilitiesToGiveAccessTo.stream()
+            .map(IdentifiedEntity::getInternalId)
+            .collect(Collectors.toSet());
     return facilityIdsToGiveAccess.stream()
         .filter(id -> !facilityIdsFound.contains(id))
         .collect(Collectors.toSet());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -307,9 +307,9 @@ public class OrganizationInitializingService {
     for (DemoUser user : users) {
       IdentityAttributes identity = user.getIdentity();
       Optional<ApiUser> userProbe = _apiUserRepo.findByLoginEmail(identity.getUsername());
-      if (!userProbe.isPresent()) {
-        _apiUserRepo.save(new ApiUser(identity.getUsername(), identity));
-      }
+      ApiUser apiUser =
+          userProbe.orElseGet(
+              () -> _apiUserRepo.save(new ApiUser(identity.getUsername(), identity)));
       DemoAuthorization authorization = user.getAuthorization();
       if (authorization != null) {
         Set<OrganizationRole> roles = authorization.getGrantedRoles();
@@ -340,6 +340,7 @@ public class OrganizationInitializingService {
               identity.getUsername(),
               authorization.getOrganizationExternalId());
         } else {
+          apiUser.setFacilities(authorizedFacilities);
           log.info(
               "User={} will have access to facilities={} in organization={}",
               identity.getUsername(),

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/PatientManagementTest.java
@@ -378,14 +378,6 @@ class PatientManagementTest extends BaseGraphqlTest {
                 Optional.empty())
             .get("addPatient");
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
-
-    executeDeletePersonMutation(
-        UUID.fromString(p2.get("internalId").asText()), Optional.of(ACCESS_ERROR));
-
-    executeDeletePersonMutation(
-        UUID.fromString(p3.get("internalId").asText()), Optional.of(ACCESS_ERROR));
-
     updateSelfPrivileges(Role.USER, false, Set.of(facility1Id));
     executeDeletePersonMutation(UUID.fromString(p2.get("internalId").asText()), Optional.empty());
     executeDeletePersonMutation(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/TestResultTest.java
@@ -239,7 +239,7 @@ class TestResultTest extends BaseGraphqlTest {
 
     // The test default standard user is configured to access _site by default,
     // so we need to remove access to establish a baseline in this test
-    updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
     Map<String, Object> submitP1Variables =
         Map.of(
             "deviceId",
@@ -272,7 +272,7 @@ class TestResultTest extends BaseGraphqlTest {
     submitQueueItem(submitP1Variables, Optional.empty());
     submitQueueItem(submitP2Variables, Optional.empty());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
     Map<String, Object> fetchVariables = getFacilityScopedArguments();
     fetchTestResultsWithError(fetchVariables, ACCESS_ERROR);
 
@@ -282,7 +282,7 @@ class TestResultTest extends BaseGraphqlTest {
     UUID t1Id = UUID.fromString(testResults.get(0).get("internalId").asText());
     UUID t2Id = UUID.fromString(testResults.get(1).get("internalId").asText());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
 
     Map<String, Object> correctT1Variables =
         Map.of("id", t1Id.toString(), "reason", "nobody's perfect");
@@ -297,7 +297,7 @@ class TestResultTest extends BaseGraphqlTest {
     correctTest(correctT1Variables, Optional.empty());
     correctTest(correctT2Variables, Optional.empty());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
     Map<String, Object> fetchT1Variables = Map.of("id", t1Id.toString());
     Map<String, Object> fetchT2Variables = Map.of("id", t2Id.toString());
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/organization/OrganizationMutationResolverTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.api.model.AddFacilityInput;
 import gov.cdc.usds.simplereport.api.model.AddressInput;
 import gov.cdc.usds.simplereport.api.model.ProviderInput;
+import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.UpdateFacilityInput;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
@@ -74,7 +75,8 @@ class OrganizationMutationResolverTest extends BaseServiceTest<PersonService> {
     facility = _dataFactory.createValidFacility(org);
     pendingOrg = _dataFactory.saveOrganizationQueueItem();
     address = facility.getAddress();
-    orgUserInfo = _dataFactory.createValidApiUser("demo@example.com", org);
+    orgUserInfo =
+        _dataFactory.createValidApiUser("demo@example.com", org, Role.USER, Set.of(facility));
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -408,17 +408,7 @@ class DemoOktaRepositoryTest {
         Set.of(ABC_2),
         Set.of(OrganizationRole.ENTRY_ONLY, OrganizationRole.ALL_FACILITIES),
         true);
-    _repo.deleteFacility(ABC_1);
 
-    OrganizationRoleClaims amos_expected =
-        new OrganizationRoleClaims(
-            ABC.getExternalId(),
-            Set.of(),
-            Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
-
-    assertTrue(
-        new OrganizationRoleClaimsMatcher(amos_expected)
-            .matches(_repo.getOrganizationRoleClaimsForUser(AMOS.getUsername()).get()));
     assertTrue(_repo.getAllUsersForOrganization(ABC).contains(AMOS.getUsername()));
     assertTrue(_repo.getAllUsersForOrganization(ABC).contains(BRAD.getUsername()));
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -1051,26 +1051,6 @@ class LiveOktaRepositoryTest {
   }
 
   @Test
-  void deleteFacility() {
-    var org = new Organization("orgName", "orgType", "1", true);
-    var facilityID = UUID.randomUUID();
-    var groupName = "SR-UNITTEST-TENANT:1:FACILITY_ACCESS:" + facilityID;
-    var mockFacility = mock(Facility.class);
-    var mockGroup = mock(Group.class);
-    var mockGroupList = List.of(mockGroup);
-    when(mockFacility.getOrganization()).thenReturn(org);
-    when(mockFacility.getInternalId()).thenReturn(facilityID);
-    when(groupApi.listGroups(
-            eq(groupName), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull()))
-        .thenReturn(mockGroupList);
-    when(mockGroup.getId()).thenReturn("1234");
-
-    _repo.deleteFacility(mockFacility);
-
-    verify(groupApi).deleteGroup("1234");
-  }
-
-  @Test
   void deleteOrganization() {
     var org = new Organization("orgName", "orgType", "1", true);
     var mockGroup = mock(Group.class);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -498,7 +498,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     String orgToMoveExternalId = orgToTestMovementTo.getExternalId();
 
     _service.updateUserPrivilegesAndGroupAccess(
-        email, orgToMoveExternalId, true, List.of(), OrganizationRole.ADMIN);
+        email, orgToMoveExternalId, true, List.of(), Role.ADMIN);
     verify(_oktaRepo, times(1))
         .updateUserPrivilegesAndGroupAccess(
             email, orgToTestMovementTo, Set.of(), OrganizationRole.ADMIN, true);
@@ -518,7 +518,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
             PrivilegeUpdateFacilityAccessException.class,
             () ->
                 _service.updateUserPrivilegesAndGroupAccess(
-                    email, moveOrgExternalId, false, emptyList, OrganizationRole.USER));
+                    email, moveOrgExternalId, false, emptyList, Role.USER));
     assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught.getMessage());
 
     PrivilegeUpdateFacilityAccessException caught2 =
@@ -526,7 +526,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
             PrivilegeUpdateFacilityAccessException.class,
             () ->
                 _service.updateUserPrivilegesAndGroupAccess(
-                    email, moveOrgExternalId, false, OrganizationRole.USER));
+                    email, moveOrgExternalId, false, Role.USER));
     assertEquals(PRIVILEGE_UPDATE_FACILITY_ACCESS_ERROR, caught2.getMessage());
   }
 
@@ -549,11 +549,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
             UnidentifiedFacilityException.class,
             () ->
                 _service.updateUserPrivilegesAndGroupAccess(
-                    email,
-                    moveOrgExternalId,
-                    false,
-                    facilityListThatShouldThrowId,
-                    OrganizationRole.USER));
+                    email, moveOrgExternalId, false, facilityListThatShouldThrowId, Role.USER));
     String expectedError =
         "Facilities with id(s) "
             + facilityListThatShouldThrowId

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -285,14 +285,19 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
   @WithSimpleReportSiteAdminUser
   void getAllUsersByOrganization_success() {
     Organization org = _dataFactory.saveValidOrganization();
-    _dataFactory.createValidApiUser("allfacilities@example.com", org);
-    _dataFactory.createValidApiUser("nofacilities@example.com", org);
-    UserInfo userToBeDeleted = _dataFactory.createValidApiUser("somefacilities@example.com", org);
+    Facility facility = _dataFactory.createValidFacility(org);
+    _dataFactory.createValidApiUser("allfacilities@example.com", org, Role.USER, Set.of(facility));
+    _dataFactory.createValidApiUser("nofacilities@example.com", org, Role.USER, Set.of(facility));
+    UserInfo userToBeDeleted =
+        _dataFactory.createValidApiUser(
+            "somefacilities@example.com", org, Role.USER, Set.of(facility));
     _service.setIsDeleted(userToBeDeleted.getInternalId(), true);
 
     Organization differentOrg =
         _dataFactory.saveOrganization("other org", "k12", "OTHER_ORG", true);
-    _dataFactory.createValidApiUser("otherorgfacilities@example.com", differentOrg);
+    Facility differentFacility = _dataFactory.createValidFacility(differentOrg);
+    _dataFactory.createValidApiUser(
+        "otherorgfacilities@example.com", differentOrg, Role.USER, Set.of(differentFacility));
 
     List<ApiUser> activeUsers = _service.getAllUsersByOrganization(org);
     assertEquals(3, activeUsers.size());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -154,8 +155,9 @@ public class TestDataFactory {
 
   public UserInfo createValidApiUser(String username, Organization org, Role role) {
     PersonName name = new PersonName("John", null, "June", null);
+    Facility facility = createValidFacility(org);
     return apiUserService.createUser(
-        username, name, org.getExternalId(), role, false, Collections.emptySet());
+        username, name, org.getExternalId(), role, false, Set.of(facility.getInternalId()));
   }
 
   public OrganizationQueueItem saveOrganizationQueueItem(

--- a/backend/src/test/resources/graphql-test/add-user-to-current-org.graphql
+++ b/backend/src/test/resources/graphql-test/add-user-to-current-org.graphql
@@ -5,6 +5,7 @@ mutation addUserToCurrentOrgOp(
     $suffix: String
     $email: String!
     $role: Role!
+    $facilities: [ID!]
 ){
     addUserToCurrentOrg(
         userInput: {
@@ -16,6 +17,7 @@ mutation addUserToCurrentOrgOp(
             }
             email: $email
             role: $role
+            facilities: $facilities
         }
     ) {
         id,
@@ -45,6 +47,7 @@ mutation addUserToCurrentOrgLegacyOp(
     $suffix: String
     $email: String!
     $role: Role!
+    $facilities: [ID!]
 ){
     addUserToCurrentOrg(
         userInput: {
@@ -54,6 +57,7 @@ mutation addUserToCurrentOrgLegacyOp(
             suffix: $suffix
             email: $email
             role: $role
+            facilities: $facilities
         }
     ) {
         id,
@@ -82,6 +86,7 @@ mutation addUserToCurrentOrgNovel(
     $name: NameInput
     $email: String!
     $role: Role!
+    $facilities: [ID!]
 ){
     addUserToCurrentOrg(
         userInput: {
@@ -90,6 +95,7 @@ mutation addUserToCurrentOrgNovel(
             lastName: $lastName
             email: $email
             role: $role
+            facilities: $facilities
         }
     ) {
         id,


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
next part of #7597, persist updating facility access 
work remaining: persist org and role updates

## Changes Proposed
- anywhere we would update a user's groups in Okta, persist changes to facility table as well
  - I went through LiveOktaRepo looking for all the places where we update a user's groups, but if something pops out at you as a place we update auth that I missed, please call it out
- moved logic of getting which facilities to give a user access to into a single consolidated method, which includes some validations

## Additional Information
- when implementing the manage users tool in the support admin dashboard, we called out a requirement that all users should have access to at least 1 facility. when I refactored our code to consolidate our validation logic, this requirement broke a lot of tests. hence the large number of updated test files

## Testing
deployed to `dev4`
try updating facility access via the org admin screen as well as the support admin screen
try creating a new user with facility access
try deleting a user and undeleting them (should retain same permissions since this is what we do currently with Okta)