### PR TITLE
Improve smoke testing lower dev deploys

### DIFF
--- a/.github/actions/pagerduty-alert/action.yml
+++ b/.github/actions/pagerduty-alert/action.yml
@@ -1,0 +1,34 @@
+name: Pagerduty Alert
+description: Triggers an alert event for Pagerduty
+inputs:
+  summary:
+    description: A brief text summary of the event, used to generate the summaries/titles of any associated alerts. The maximum permitted length of this property is 1024 characters.
+    required: true
+  severity:
+    description: The perceived severity of the status the event is describing with respect to the affected system. This can be critical, error, warning or info.
+    required: true
+  routing_key:
+    description: This is the 32 character Integration Key for an integration on a service or on a global ruleset.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Send alert to Pagerduty
+      id: curl
+      shell: bash
+      run: |
+        curl --request 'POST' \
+        --url 'https://events.pagerduty.com/v2/enqueue' \
+        --header 'Content-Type: application/json' \
+        --data '{
+          "payload": {
+              "summary": ${{ inputs.summary }}
+              "severity": ${{ inputs.severity }}
+              "source": "GitHub Actions using PagerDuty Events API V2"
+          },
+          "routing_key": ${{ inputs.routing_key }},
+          "event_action": "trigger"
+        }'

--- a/.github/workflows/smokeTestDeployDev.yml
+++ b/.github/workflows/smokeTestDeployDev.yml
@@ -57,3 +57,17 @@ jobs:
             :construction: Post-deploy smoke test for ${{ inputs.deploy_env }} couldn't verify that the frontend is talking to the backend. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :construction:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}
+  pagerduty_alert:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs: [ smoke-test-front-and-back-end ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger PagerDuty alert
+        uses: ./.github/actions/pagerduty-alert
+        with:
+          summary: |
+            :construction: Post-deploy smoke test for ${{ inputs.deploy_env }} couldn't verify that the frontend is talking to the backend. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :construction:
+          severity: info
+          routing_key: ${{ secrets.pagerduty_dev_integration_key }}
+

--- a/.github/workflows/smokeTestDeployDev.yml
+++ b/.github/workflows/smokeTestDeployDev.yml
@@ -2,12 +2,6 @@ name: Smoke test deploy Dev
 run-name: Smoke test the deploy for dev by @${{ github.actor }}
 
 on:
-  workflow_run:
-    workflows: [ "Deploy Dev" ]
-    types:
-      - completed
-    branches:
-      - "mike/7160-post-deploy-alert**"
   workflow_dispatch:
     inputs:
       deploy_env:
@@ -60,6 +54,6 @@ jobs:
         with:
           username: ${{ github.actor }}
           description: |
-            :construction: Dev testing to confirm post-deploy smoke test works correctly. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :construction:
+            :construction: Post-deploy smoke test for ${{ inputs.deploy_env }} couldn't verify that the frontend is talking to the backend. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :construction:
           webhook_url: ${{ secrets.SR_ALERTS_SLACK_WEBHOOK_URL }}
           user_map: $${{ secrets.SR_ALERTS_GITHUB_SLACK_MAP }}

--- a/.github/workflows/smokeTestDeployDev.yml
+++ b/.github/workflows/smokeTestDeployDev.yml
@@ -8,6 +8,21 @@ on:
       - completed
     branches:
       - "mike/7160-post-deploy-alert**"
+  workflow_dispatch:
+    inputs:
+      deploy_env:
+        description: 'The environment to deploy to'
+        required: true
+        type: choice
+        options:
+          - ""
+          - dev
+          - dev2
+          - dev3
+          - dev4
+          - dev5
+          - dev6
+          - pentest
 
 env:
   NODE_VERSION: 20
@@ -15,7 +30,7 @@ env:
 jobs:
   smoke-test-front-and-back-end:
     runs-on: ubuntu-latest
-    environment: dev5
+    environment: ${{ inputs.deploy_env }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -33,7 +48,7 @@ jobs:
       - name: Smoke test the env
         uses: ./.github/actions/post-deploy-smoke-test
         with:
-          base_domain_name: dev5.simplereport.gov
+          base_domain_name: ${{ inputs.deploy_env }}.simplereport.gov
   slack_alert:
     runs-on: ubuntu-latest
     if: failure()

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -30,6 +30,14 @@ driver
     return value;
   })
   .then((value) => {
-    if (value.includes("success")) process.exit(0);
+    if (value.includes("success")) {
+      console.log(`Smoke test returned success status for ${appUrl}`);
+      process.exit(0);
+    }
+    if (value.includes("failure")) {
+      console.log(`Smoke test returned failure status for ${appUrl}`);
+      process.exit(1);
+    }
+    console.log("Smoke test encountered unknown failure.");
     process.exit(1);
   });


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Related to #7160 

## Changes Proposed

- Updates the smoke test to be a dispatch only action as opposed to an action run after successful deploy dev workflows
- Adds additional logging to the smoke test script
- Adds a PagerDuty alert as a github action
    - currently set up only for the SimpleReport - Non-Prod service on PagerDuty
    - once this alert is tested in the lower environments, I'll add a follow up PR to enable the alert for production

## Testing

- Review the changes, but it can only really be tested after being merged
- I triggered a test alert for PagerDuty via their events api [shown by this PagerDuty slack message here](https://skylight-hq.slack.com/archives/C01FPLGB0VD/p1715632981368319)