### PR TITLE
Add facilities to the ApiUser class

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -4,14 +4,17 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import java.util.Date;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.NaturalId;
 
-/**
- * The bare minimum required to link an authenticated identity to actions and data elsewhere in the
- * schema.
- */
+/** An authenticated identity that may or may not be linked to authorization data. */
 @Entity
 @DynamicUpdate
 public class ApiUser extends EternalSystemManagedEntity implements PersonEntity {
@@ -24,6 +27,15 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
 
   @Column(nullable = true)
   private Date lastSeen;
+
+  @ManyToMany
+  @JoinTable(
+      name = "api_user_facility",
+      joinColumns = @JoinColumn(name = "api_user_id"),
+      inverseJoinColumns = @JoinColumn(name = "facility_id"))
+  @Getter
+  @Setter
+  private Set<Facility> facilities;
 
   protected ApiUser() {
     /* for hibernate */ }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5399,3 +5399,21 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Flu A and B';
+  - changeSet:
+      id: remove-internal_id-from-user-facility-table
+      author: tnd8@cdc.gov
+      comment: Remove internal_id column from join table
+      changes:
+        - dropColumn:
+            tableName: api_user_facility
+            columnName: internal_id
+      rollback:
+        - addColumn:
+            tableName: api_user_facility
+            column:
+              name: internal_id
+              type: uuid
+              remarks: The internal database identifier for this entity.
+              constraints:
+                primaryKey: true
+                nullable: false


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

This is part 1 of ?? for completing #7597. My [draft PR](https://github.com/CDCgov/prime-simplereport/pull/7703) for supporting updating facilities got a little big so I'm splitting out the first step.

## Changes Proposed

- Drop the internal ID column on api_user_facility to make it a pure join table. From what I can tell, if we don't do this we have to make a Java entity to represent this and I think this is cleaner.
- Add facilities to the user entity so we can call the getters and setters from the user context

## Additional Information

considering if we should pull facilities and role into a subclass called AuthorizedUser but would prefer to address that in a later PR

## Testing

deploying to `dev4` - just need to check that app builds and metabase shows table without the internal ID column
