### PR TITLE
syphilis card support pt 4

### DIFF
--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -138,16 +138,14 @@ describe("Conducting a COVID test from:", () => {
       "exist",
     );
 
-    cy.contains("label", "When did the patient's symptoms start?")
-      .next("input")
-      .type("2021-10-05");
+    cy.get("[data-testid='symptom-date']").within(() => {
+      cy.get("input").type("2021-10-05");
+    });
 
-    cy.contains("legend", "Select any symptoms the patient is experiencing")
-      .next("div")
-      .within(() => {
-        cy.contains("label", "Chills").click();
-        cy.contains("label", "Headache").click();
-      });
+    cy.get("[data-testid='symptom-selection']").within(() => {
+      cy.contains("label", "Chills").click();
+      cy.contains("label", "Headache").click();
+    });
 
     cy.checkAccessibility();
 

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -899,7 +899,7 @@ describe("TestCard", () => {
   });
 
   describe("on device specimen type change", () => {
-    it.only("updates test order on device type and specimen type change", async () => {
+    it("updates test order on device type and specimen type change", async () => {
       const mocks = [
         generateEditQueueMock(
           MULTIPLEX_DISEASES.COVID_19,

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -30,6 +30,7 @@ import {
   generateEditQueueMock,
   generateEmptyEditQueueMock,
   generateSubmitQueueMock,
+  blankUpdateAoeEventMock,
 } from "../TestCardForm/testUtils/submissionMocks";
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
@@ -441,7 +442,9 @@ describe("TestCard", () => {
   });
 
   it("renders dropdown of device types", async () => {
-    const { user } = await renderQueueItem();
+    const { user } = await renderQueueItem({
+      mocks: [blankUpdateAoeEventMock],
+    });
 
     const deviceDropdown = (await screen.findByTestId(
       "device-type-dropdown"
@@ -513,6 +516,7 @@ describe("TestCard", () => {
             },
           }
         ),
+        blankUpdateAoeEventMock,
       ];
 
       const props = {
@@ -824,6 +828,8 @@ describe("TestCard", () => {
             },
           }
         ),
+        blankUpdateAoeEventMock,
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -976,6 +982,7 @@ describe("TestCard", () => {
             },
           }
         ),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -1010,6 +1017,7 @@ describe("TestCard", () => {
           MULTIPLEX_DISEASES.COVID_19,
           TEST_RESULTS.POSITIVE
         ),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -1035,6 +1043,7 @@ describe("TestCard", () => {
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.POSITIVE),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -1054,6 +1063,7 @@ describe("TestCard", () => {
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.POSITIVE),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -1083,6 +1093,7 @@ describe("TestCard", () => {
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.UNKNOWN),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -1110,6 +1121,7 @@ describe("TestCard", () => {
           MULTIPLEX_DISEASES.COVID_19,
           TEST_RESULTS.POSITIVE
         ),
+        blankUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -34,6 +34,8 @@ import {
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
 import { TestCard, TestCardProps } from "./TestCard";
+import { TEST_CARD_SYMPTOM_ONSET_DATE_STRING, allFalseSymptomUpdateAoeEventMock, allFalseSymptomUpdateAoeEventMockWithSymptomOnset, blankUpdateAoeEventMock, generateEditQueueMock, testOrderInfo } from "../TestCardForm/testUtils/submissionMocks";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
 jest.mock("../../TelemetryService", () => ({
   getAppInsights: jest.fn(),
@@ -109,53 +111,6 @@ describe("TestCard", () => {
   const removePatientFromQueueMock = jest.fn();
   const trackMetricMock = jest.fn();
   const trackExceptionMock = jest.fn();
-
-  const testOrderInfo: QueriedTestOrder = {
-    internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
-    dateAdded: "2022-11-08 13:33:07.503",
-    symptoms:
-      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
-    symptomOnset: null,
-    noSymptoms: true,
-    deviceType: {
-      internalId: device1Id,
-      name: device1Name,
-      model: "LumiraDx SARS-CoV-2 Ag Test*",
-      testLength: 15,
-    },
-    specimenType: {
-      internalId: specimen1Id,
-      name: specimen1Name,
-      typeCode: "445297001",
-    },
-    patient: {
-      internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
-      telephone: "(571) 867-5309",
-      birthDate: "2015-09-20",
-      firstName: "Althea",
-      middleName: "Hedda Mclaughlin",
-      lastName: "Dixon",
-      gender: "refused",
-      testResultDelivery: null,
-      preferredLanguage: null,
-      email: "sywaporoce@mailinator.com",
-      emails: ["sywaporoce@mailinator.com"],
-      phoneNumbers: [
-        {
-          type: PhoneType.Mobile,
-          number: "(553) 223-0559",
-        },
-        {
-          type: PhoneType.Landline,
-          number: "(669) 789-0799",
-        },
-      ],
-    },
-    results: [],
-    dateTested: null,
-    correctionStatus: "ORIGINAL",
-    reasonForCorrection: null,
-  };
 
   const facilityInfo: QueriedFacility = {
     id: "f02cfff5-1921-4293-beff-e2a5d03e1fda",
@@ -944,7 +899,7 @@ describe("TestCard", () => {
   });
 
   describe("on device specimen type change", () => {
-    it("updates test order on device type and specimen type change", async () => {
+    it.only("updates test order on device type and specimen type change", async () => {
       const mocks = [
         generateEditQueueMock(
           MULTIPLEX_DISEASES.COVID_19,

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -34,8 +34,6 @@ import {
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
 import { TestCard, TestCardProps } from "./TestCard";
-import { TEST_CARD_SYMPTOM_ONSET_DATE_STRING, allFalseSymptomUpdateAoeEventMock, allFalseSymptomUpdateAoeEventMockWithSymptomOnset, blankUpdateAoeEventMock, generateEditQueueMock, testOrderInfo } from "../TestCardForm/testUtils/submissionMocks";
-import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
 jest.mock("../../TelemetryService", () => ({
   getAppInsights: jest.fn(),
@@ -610,7 +608,7 @@ describe("TestCard", () => {
   });
 
   describe("SMS delivery failure", () => {
-    it("displays delivery failure alert on submit for invalid patient phone number", async () => {
+    it.only("displays delivery failure alert on submit for invalid patient phone number", async () => {
       const mocks = [
         generateEditQueueMock(
           MULTIPLEX_DISEASES.COVID_19,

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -1049,7 +1049,7 @@ describe("TestCard", () => {
       expect(screen.getByText("HIV result")).toBeInTheDocument();
     });
 
-    it("shows required HIV AOE questions when a positive HIV result is present", async function () {
+    it.only("shows required HIV AOE questions when a positive HIV result is present", async function () {
       mockDiseaseEnabledFlag("HIV");
 
       const mocks = [

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -294,8 +294,6 @@ describe("TestCard", () => {
     ],
   };
 
-
-
   const DEFAULT_DEVICE_ORDER = [
     device1Name,
     device2Name,

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -1049,7 +1049,7 @@ describe("TestCard", () => {
       expect(screen.getByText("HIV result")).toBeInTheDocument();
     });
 
-    it.only("shows required HIV AOE questions when a positive HIV result is present", async function () {
+    it("shows required HIV AOE questions when a positive HIV result is present", async function () {
       mockDiseaseEnabledFlag("HIV");
 
       const mocks = [

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -110,6 +110,53 @@ describe("TestCard", () => {
   const trackMetricMock = jest.fn();
   const trackExceptionMock = jest.fn();
 
+  const testOrderInfo: QueriedTestOrder = {
+    internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
+    dateAdded: "2022-11-08 13:33:07.503",
+    symptoms:
+      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+    symptomOnset: null,
+    noSymptoms: true,
+    deviceType: {
+      internalId: device1Id,
+      name: device1Name,
+      model: "LumiraDx SARS-CoV-2 Ag Test*",
+      testLength: 15,
+    },
+    specimenType: {
+      internalId: specimen1Id,
+      name: specimen1Name,
+      typeCode: "445297001",
+    },
+    patient: {
+      internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
+      telephone: "(571) 867-5309",
+      birthDate: "2015-09-20",
+      firstName: "Althea",
+      middleName: "Hedda Mclaughlin",
+      lastName: "Dixon",
+      gender: "refused",
+      testResultDelivery: null,
+      preferredLanguage: null,
+      email: "sywaporoce@mailinator.com",
+      emails: ["sywaporoce@mailinator.com"],
+      phoneNumbers: [
+        {
+          type: PhoneType.Mobile,
+          number: "(553) 223-0559",
+        },
+        {
+          type: PhoneType.Landline,
+          number: "(669) 789-0799",
+        },
+      ],
+    },
+    results: [],
+    dateTested: null,
+    correctionStatus: "ORIGINAL",
+    reasonForCorrection: null,
+  };
+
   const facilityInfo: QueriedFacility = {
     id: "f02cfff5-1921-4293-beff-e2a5d03e1fda",
     name: "Testing Site",
@@ -247,52 +294,7 @@ describe("TestCard", () => {
     ],
   };
 
-  const testOrderInfo: QueriedTestOrder = {
-    internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
-    dateAdded: "2022-11-08 13:33:07.503",
-    symptoms:
-      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
-    symptomOnset: null,
-    noSymptoms: true,
-    deviceType: {
-      internalId: device1Id,
-      name: device1Name,
-      model: "LumiraDx SARS-CoV-2 Ag Test*",
-      testLength: 15,
-    },
-    specimenType: {
-      internalId: specimen1Id,
-      name: specimen1Name,
-      typeCode: "445297001",
-    },
-    patient: {
-      internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
-      telephone: "(571) 867-5309",
-      birthDate: "2015-09-20",
-      firstName: "Althea",
-      middleName: "Hedda Mclaughlin",
-      lastName: "Dixon",
-      gender: "refused",
-      testResultDelivery: null,
-      preferredLanguage: null,
-      email: "sywaporoce@mailinator.com",
-      emails: ["sywaporoce@mailinator.com"],
-      phoneNumbers: [
-        {
-          type: PhoneType.Mobile,
-          number: "(553) 223-0559",
-        },
-        {
-          type: PhoneType.Landline,
-          number: "(669) 789-0799",
-        },
-      ],
-    },
-    results: [],
-    dateTested: null,
-    correctionStatus: "ORIGINAL",
-    reasonForCorrection: null,
-  };
+
 
   const DEFAULT_DEVICE_ORDER = [
     device1Name,

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -25,14 +25,15 @@ import mockSupportedDiseaseTestPerformedHIV from "../../supportAdmin/DeviceType/
 import { QueriedFacility, QueriedTestOrder } from "../TestCardForm/types";
 import {
   TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
-  allFalseSymptomUpdateAoeEventMock,
-  allFalseSymptomUpdateAoeEventMockWithSymptomOnset,
   generateEditQueueMock,
   generateEmptyEditQueueMock,
   generateSubmitQueueMock,
   blankUpdateAoeEventMock,
+  falseNoSymptomWithSymptomOnsetUpdateAoeEventMock,
+  falseNoSymptomUpdateAoeEventMock,
 } from "../TestCardForm/testUtils/submissionMocks";
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
+import { ONSET_DATE_LABEL } from "../../../patientApp/timeOfTest/constants";
 
 import { TestCard, TestCardProps } from "./TestCard";
 
@@ -914,8 +915,8 @@ describe("TestCard", () => {
 
     it("tracks AoE form updates as custom event", async () => {
       const mocks = [
-        allFalseSymptomUpdateAoeEventMock,
-        allFalseSymptomUpdateAoeEventMockWithSymptomOnset,
+        falseNoSymptomWithSymptomOnsetUpdateAoeEventMock,
+        falseNoSymptomUpdateAoeEventMock,
       ];
 
       const { user } = await renderQueueItem({ mocks });
@@ -933,12 +934,13 @@ describe("TestCard", () => {
         ).toBeChecked()
       );
 
-      await user.type(
-        screen.getByTestId("symptom-date"),
-        TEST_CARD_SYMPTOM_ONSET_DATE_STRING
-      );
+      const symptomDateInput = within(
+        screen.getByTestId("symptom-date")
+      ).getByLabelText(ONSET_DATE_LABEL);
+
+      await user.type(symptomDateInput, TEST_CARD_SYMPTOM_ONSET_DATE_STRING);
       await waitFor(() =>
-        expect(screen.getByTestId("symptom-date")).toHaveValue(
+        expect(symptomDateInput).toHaveValue(
           TEST_CARD_SYMPTOM_ONSET_DATE_STRING
         )
       );

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -247,6 +247,53 @@ describe("TestCard", () => {
     ],
   };
 
+  const testOrderInfo: QueriedTestOrder = {
+    internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
+    dateAdded: "2022-11-08 13:33:07.503",
+    symptoms:
+      '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+    symptomOnset: null,
+    noSymptoms: true,
+    deviceType: {
+      internalId: device1Id,
+      name: device1Name,
+      model: "LumiraDx SARS-CoV-2 Ag Test*",
+      testLength: 15,
+    },
+    specimenType: {
+      internalId: specimen1Id,
+      name: specimen1Name,
+      typeCode: "445297001",
+    },
+    patient: {
+      internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
+      telephone: "(571) 867-5309",
+      birthDate: "2015-09-20",
+      firstName: "Althea",
+      middleName: "Hedda Mclaughlin",
+      lastName: "Dixon",
+      gender: "refused",
+      testResultDelivery: null,
+      preferredLanguage: null,
+      email: "sywaporoce@mailinator.com",
+      emails: ["sywaporoce@mailinator.com"],
+      phoneNumbers: [
+        {
+          type: PhoneType.Mobile,
+          number: "(553) 223-0559",
+        },
+        {
+          type: PhoneType.Landline,
+          number: "(669) 789-0799",
+        },
+      ],
+    },
+    results: [],
+    dateTested: null,
+    correctionStatus: "ORIGINAL",
+    reasonForCorrection: null,
+  };
+
   const DEFAULT_DEVICE_ORDER = [
     device1Name,
     device2Name,
@@ -608,7 +655,7 @@ describe("TestCard", () => {
   });
 
   describe("SMS delivery failure", () => {
-    it.only("displays delivery failure alert on submit for invalid patient phone number", async () => {
+    it("displays delivery failure alert on submit for invalid patient phone number", async () => {
       const mocks = [
         generateEditQueueMock(
           MULTIPLEX_DISEASES.COVID_19,

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockedProvider } from "@apollo/client/testing";
 
@@ -20,8 +20,6 @@ import {
 } from "./testUtils/testConstants";
 import {
   generateSubmitQueueMock,
-  TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
-  updateAoeMocks,
 } from "./testUtils/submissionMocks";
 
 jest.mock("../../TelemetryService", () => ({

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -184,7 +184,11 @@ describe("TestCardForm", () => {
         },
       };
 
-      const { user } = await renderTestCardForm({ props });
+      const { user } = await renderTestCardForm({
+        props,
+      });
+
+      // Submit to start form validation
       await user.click(screen.getByText("Submit results"));
 
       expect(

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -20,7 +20,6 @@ import {
 } from "./testUtils/testConstants";
 import {
   generateSubmitQueueMock,
-  submitEventMock,
   TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
   updateAoeMocks,
 } from "./testUtils/submissionMocks";
@@ -230,64 +229,6 @@ describe("TestCardForm", () => {
       await user.click(screen.getByText("Submit anyway."));
       expect(
         screen.queryByText("Do you want to submit results anyway?")
-      ).not.toBeInTheDocument();
-    });
-
-    it("should show error messages when symptomatic patient doesn't have onset date or symptom list", async () => {
-      const props = {
-        ...testProps,
-        testOrder: {
-          ...asymptomaticTestOrderInfo,
-          results: [
-            { testResult: "POSITIVE", disease: { name: "COVID-19" } },
-            { testResult: "UNKNOWN", disease: { name: "Flu A" } },
-            { testResult: "UNKNOWN", disease: { name: "Flu B" } },
-          ],
-        },
-      };
-
-      const { user } = await renderTestCardForm({
-        props,
-        mocks: [submitEventMock, submitEventMock, ...updateAoeMocks],
-      });
-
-      const pregnancyAoeGroup = screen.getByRole("group", {
-        name: /is the patient pregnant\?/i,
-      });
-      await user.click(within(pregnancyAoeGroup).getByText(/yes/i));
-
-      const symptomsAoeGroup = screen.getByRole("group", {
-        name: /is the patient currently experiencing any symptoms\?/i,
-      });
-      await user.click(within(symptomsAoeGroup).getByText(/yes/i));
-      await user.click(screen.getByText("Submit results"));
-      expect(
-        screen.getAllByText(
-          "This question is required if the patient has symptoms"
-        ).length
-      ).toBe(2);
-
-      await user.click(
-        screen.getByRole("checkbox", {
-          name: /cough/i,
-        })
-      );
-      await user.click(screen.getByText("Submit results"));
-      expect(
-        screen.getAllByText(
-          "This question is required if the patient has symptoms"
-        ).length
-      ).toBe(1);
-
-      await user.type(
-        screen.getByLabelText(/when did the patient's symptoms start\?/i),
-        TEST_CARD_SYMPTOM_ONSET_DATE_STRING
-      );
-
-      expect(
-        screen.queryByText(
-          "This question is required if the patient has symptoms"
-        )
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -18,9 +18,7 @@ import {
   multiplexDeviceId,
   multiplexDeviceName,
 } from "./testUtils/testConstants";
-import {
-  generateSubmitQueueMock,
-} from "./testUtils/submissionMocks";
+import { generateSubmitQueueMock } from "./testUtils/submissionMocks";
 
 jest.mock("../../TelemetryService", () => ({
   getAppInsights: jest.fn(),

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -12,7 +12,7 @@ import TextInput from "../../commonComponents/TextInput";
 import { formatDate } from "../../utils/date";
 import { TextWithTooltip } from "../../commonComponents/TextWithTooltip";
 import Dropdown from "../../commonComponents/Dropdown";
-import { TEST_RESULTS } from "../../testResults/constants";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 import {
   MultiplexResultInput,
   useEditQueueItemMutation,

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -50,7 +50,6 @@ import {
   useSpecimenTypeOptions,
   useTestOrderPatient,
   AoeValidationErrorMessages,
-  whichAoeFormToDisplay,
 } from "./TestCardForm.utils";
 import { TestResultInputGroup } from "./diseaseSpecificComponents/TestResultInputGroup";
 import { DevicesMap, QueriedFacility, QueriedTestOrder } from "./types";
@@ -271,8 +270,7 @@ const TestCardForm = ({
     return null;
   };
 
-  const whichAoeFormOption = useAOEFormOption(state.deviceId, devicesMap);
-  const aoeFormToDisplay = whichAoeFormToDisplay(whichAoeFormOption, state);
+  const whichAoeFormOption = useAOEFormOption(state, devicesMap);
 
   const validateAoeForm = () => {
     const aoeValidationMessage = generateAoeValidationState(
@@ -557,7 +555,7 @@ const TestCardForm = ({
             ></TestResultInputGroup>
           </FormGroup>
         </div>
-        {aoeFormToDisplay === AOEFormOption.COVID && (
+        {whichAoeFormOption === AOEFormOption.COVID && (
           <div className="grid-row grid-gap">
             <CovidAoEForm
               testOrder={testOrder}
@@ -572,7 +570,7 @@ const TestCardForm = ({
             />
           </div>
         )}
-        {aoeFormToDisplay === AOEFormOption.HIV && (
+        {whichAoeFormOption === AOEFormOption.HIV && (
           <div className="grid-row grid-gap">
             <HIVAoEForm
               testOrder={testOrder}

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -281,19 +281,19 @@ const TestCardForm = ({
       state,
       whichAOEFormOption
     );
-    if (aoeValidationMessage === AoeValidationErrorMessages.COMPLETE)
+    if (aoeValidationMessage === AoeValidationErrorMessages.COMPLETE) {
       return true;
+    }
     if (aoeValidationMessage === AoeValidationErrorMessages.INCOMPLETE) {
       if (whichAOEFormOption === AOEFormOption.COVID) {
         setIsSubmitModalOpen(true);
-        return false;
       } else {
         showError(
           "Please complete the required questions",
           "Invalid test questionnaire"
         );
-        return false;
       }
+      return false;
     }
     if (
       aoeValidationMessage ===

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -12,7 +12,7 @@ import TextInput from "../../commonComponents/TextInput";
 import { formatDate } from "../../utils/date";
 import { TextWithTooltip } from "../../commonComponents/TextWithTooltip";
 import Dropdown from "../../commonComponents/Dropdown";
-import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
+import { TEST_RESULTS } from "../../testResults/constants";
 import {
   MultiplexResultInput,
   useEditQueueItemMutation,

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -272,14 +272,7 @@ const TestCardForm = ({
   };
 
   const whichAoeFormOption = useAOEFormOption(state.deviceId, devicesMap);
-
-  const positiveResultIndicated = state.testResults.some(
-    (x) => x.testResult === TEST_RESULTS.POSITIVE
-  );
-  const aoeFormToDisplay = whichAoeFormToDisplay(
-    whichAoeFormOption,
-    positiveResultIndicated
-  );
+  const aoeFormToDisplay = whichAoeFormToDisplay(whichAoeFormOption, state);
 
   const validateAoeForm = () => {
     const aoeValidationMessage = generateAoeValidationState(

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -276,7 +276,7 @@ const TestCardForm = ({
     whichAOEFormOption !== AOEFormOption.COVID
       ? whichAOEFormOption
       : null;
-  const areAoeQuestionsComplete = () => {
+  const validateAoeForm = () => {
     const aoeValidationMessage = generateAoeValidationState(
       state,
       whichAOEFormOption
@@ -350,7 +350,7 @@ const TestCardForm = ({
   const submitForm = async (forceSubmit: boolean = false) => {
     setHasAttemptedSubmit(true);
     if (!validateForm()) return;
-    if (!forceSubmit && !areAoeQuestionsComplete()) return;
+    if (!forceSubmit && !validateAoeForm()) return;
 
     trackSubmitTestResult();
     setIsSubmitModalOpen(false);

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -50,6 +50,7 @@ import {
   useSpecimenTypeOptions,
   useTestOrderPatient,
   AoeValidationErrorMessages,
+  whichAoeFormToDisplay,
 } from "./TestCardForm.utils";
 import { TestResultInputGroup } from "./diseaseSpecificComponents/TestResultInputGroup";
 import { DevicesMap, QueriedFacility, QueriedTestOrder } from "./types";
@@ -270,22 +271,26 @@ const TestCardForm = ({
     return null;
   };
 
-  const whichAOEFormOption = useAOEFormOption(state.deviceId, devicesMap);
-  const whichAoeFormRequiredForPositives =
-    state.testResults.some((x) => x.testResult === TEST_RESULTS.POSITIVE) &&
-    whichAOEFormOption !== AOEFormOption.COVID
-      ? whichAOEFormOption
-      : null;
+  const whichAoeFormOption = useAOEFormOption(state.deviceId, devicesMap);
+
+  const positiveResultIndicated = state.testResults.some(
+    (x) => x.testResult === TEST_RESULTS.POSITIVE
+  );
+  const aoeFormToDisplay = whichAoeFormToDisplay(
+    whichAoeFormOption,
+    positiveResultIndicated
+  );
+
   const validateAoeForm = () => {
     const aoeValidationMessage = generateAoeValidationState(
       state,
-      whichAOEFormOption
+      whichAoeFormOption
     );
     if (aoeValidationMessage === AoeValidationErrorMessages.COMPLETE) {
       return true;
     }
     if (aoeValidationMessage === AoeValidationErrorMessages.INCOMPLETE) {
-      if (whichAOEFormOption === AOEFormOption.COVID) {
+      if (whichAoeFormOption === AOEFormOption.COVID) {
         setIsSubmitModalOpen(true);
       } else {
         showError(
@@ -559,7 +564,7 @@ const TestCardForm = ({
             ></TestResultInputGroup>
           </FormGroup>
         </div>
-        {whichAOEFormOption === AOEFormOption.COVID && (
+        {aoeFormToDisplay === AOEFormOption.COVID && (
           <div className="grid-row grid-gap">
             <CovidAoEForm
               testOrder={testOrder}
@@ -574,7 +579,7 @@ const TestCardForm = ({
             />
           </div>
         )}
-        {whichAoeFormRequiredForPositives === AOEFormOption.HIV && (
+        {aoeFormToDisplay === AOEFormOption.HIV && (
           <div className="grid-row grid-gap">
             <HIVAoEForm
               testOrder={testOrder}

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -349,9 +349,8 @@ const TestCardForm = ({
 
   const submitForm = async (forceSubmit: boolean = false) => {
     setHasAttemptedSubmit(true);
-    const isValidForm = validateForm();
-    if (!isValidForm) return;
-    if (!areAoeQuestionsComplete() && !forceSubmit) return;
+    if (!validateForm()) return;
+    if (!forceSubmit && !areAoeQuestionsComplete()) return;
 
     trackSubmitTestResult();
     setIsSubmitModalOpen(false);

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -182,6 +182,21 @@ export const hasAnySupportedDiseaseTests = (
   }
   return false;
 };
+export const whichAoeFormToDisplay = (
+  whichAoeFormOption: AOEFormOption,
+  resultHasPositive: boolean
+): AOEFormOption => {
+  switch (whichAoeFormOption) {
+    case AOEFormOption.COVID:
+      return AOEFormOption.COVID;
+    case AOEFormOption.HIV:
+      return resultHasPositive ? AOEFormOption.HIV : AOEFormOption.NONE;
+    case AOEFormOption.SYPHILIS:
+      return resultHasPositive ? AOEFormOption.SYPHILIS : AOEFormOption.NONE;
+    case AOEFormOption.NONE:
+      return AOEFormOption.NONE;
+  }
+};
 
 // when other diseases are added, update this to use the correct AOE for that disease
 export const useAOEFormOption = (deviceId: string, devicesMap: DevicesMap) => {

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -182,51 +182,39 @@ export const hasAnySupportedDiseaseTests = (
   }
   return false;
 };
-export const whichAoeFormToDisplay = (
-  whichAoeFormOption: AOEFormOption,
-  testFormState: TestFormState
-): AOEFormOption => {
+
+// when other diseases are added, update this to use the correct AOE for that disease
+export const useAOEFormOption = (
+  testFormState: TestFormState,
+  devicesMap: DevicesMap
+) => {
   const resultHasPositive = testFormState.testResults.some(
     (x) => x.testResult === TEST_RESULTS.POSITIVE
   );
-  switch (whichAoeFormOption) {
-    case AOEFormOption.COVID:
-      return AOEFormOption.COVID;
-    case AOEFormOption.HIV:
-      return resultHasPositive ? AOEFormOption.HIV : AOEFormOption.NONE;
-    case AOEFormOption.SYPHILIS:
-      return resultHasPositive ? AOEFormOption.SYPHILIS : AOEFormOption.NONE;
-    case AOEFormOption.NONE:
-      return AOEFormOption.NONE;
-  }
-};
-
-// when other diseases are added, update this to use the correct AOE for that disease
-export const useAOEFormOption = (deviceId: string, devicesMap: DevicesMap) => {
   // some devices don't have any supported disease tests saved because historically they only supported COVID
   // this is often seen in some of the dev environments
-  if (!hasAnySupportedDiseaseTests(deviceId, devicesMap)) {
+  if (!hasAnySupportedDiseaseTests(testFormState.deviceId, devicesMap)) {
     return AOEFormOption.COVID;
   }
   if (
     devicesMap
-      .get(deviceId)
+      .get(testFormState.deviceId)
       ?.supportedDiseaseTestPerformed.filter(
         (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.HIV
       ).length === 1
   ) {
-    return AOEFormOption.HIV;
+    return resultHasPositive ? AOEFormOption.HIV : AOEFormOption.NONE;
   }
   if (
     devicesMap
-      .get(deviceId)
+      .get(testFormState.deviceId)
       ?.supportedDiseaseTestPerformed.filter(
         (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.SYPHILIS
       ).length === 1
   ) {
-    return AOEFormOption.SYPHILIS;
+    return resultHasPositive ? AOEFormOption.SYPHILIS : AOEFormOption.NONE;
   }
-  return isDeviceFluOnly(deviceId, devicesMap)
+  return isDeviceFluOnly(testFormState.deviceId, devicesMap)
     ? AOEFormOption.NONE
     : AOEFormOption.COVID;
 };

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -20,9 +20,7 @@ import {
   QueriedFacility,
   QueriedTestOrder,
 } from "./types";
-import {
-  mapSymptomBoolLiteralsToBool,
-} from "./diseaseSpecificComponents/aoeUtils";
+import { mapSymptomBoolLiteralsToBool } from "./diseaseSpecificComponents/aoeUtils";
 
 /** Add more options as other disease AOEs are needed */
 export enum AOEFormOption {

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -260,19 +260,18 @@ export function generateAoeValidationState(
     symptomOnsetAndSelectionQuestionsAnswered,
   } = validateAoeQuestions(formState, whichAOE);
 
-  switch (true) {
-    case !allNonSymptomAoeQuestionsAnswered || !hasSymptomsQuestionAnswered:
-      return AoeValidationErrorMessages.INCOMPLETE;
-    case allNonSymptomAoeQuestionsAnswered &&
-      hasSymptomsQuestionAnswered &&
-      symptomOnsetAndSelectionQuestionsAnswered:
+  if (allNonSymptomAoeQuestionsAnswered && hasSymptomsQuestionAnswered) {
+    if (symptomOnsetAndSelectionQuestionsAnswered) {
       return AoeValidationErrorMessages.COMPLETE;
-    case allNonSymptomAoeQuestionsAnswered &&
-      hasSymptomsQuestionAnswered &&
-      !symptomOnsetAndSelectionQuestionsAnswered:
-      return AoeValidationErrorMessages.SYMPTOM_VALIDATION_ERROR;
-    default:
-      return AoeValidationErrorMessages.UNKNOWN;
+    }
+    return AoeValidationErrorMessages.SYMPTOM_VALIDATION_ERROR;
+  } else if (
+    !allNonSymptomAoeQuestionsAnswered ||
+    !hasSymptomsQuestionAnswered
+  ) {
+    return AoeValidationErrorMessages.INCOMPLETE;
+  } else {
+    return AoeValidationErrorMessages.UNKNOWN;
   }
 }
 

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -258,7 +258,7 @@ export function generateAoeValidationState(
     allNonSymptomAoeQuestionsAnswered,
     hasSymptomsQuestionAnswered,
     symptomOnsetAndSelectionQuestionsAnswered,
-  } = validateAoeQuestions(formState, whichAOE);
+  } = areAoeQuestionsAnswered(formState, whichAOE);
 
   if (allNonSymptomAoeQuestionsAnswered && hasSymptomsQuestionAnswered) {
     if (symptomOnsetAndSelectionQuestionsAnswered) {
@@ -275,7 +275,7 @@ export function generateAoeValidationState(
   }
 }
 
-export function validateAoeQuestions(
+export function areAoeQuestionsAnswered(
   formState: TestFormState,
   whichAOE: AOEFormOption
 ) {

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -184,8 +184,11 @@ export const hasAnySupportedDiseaseTests = (
 };
 export const whichAoeFormToDisplay = (
   whichAoeFormOption: AOEFormOption,
-  resultHasPositive: boolean
+  testFormState: TestFormState
 ): AOEFormOption => {
+  const resultHasPositive = testFormState.testResults.some(
+    (x) => x.testResult === TEST_RESULTS.POSITIVE
+  );
   switch (whichAoeFormOption) {
     case AOEFormOption.COVID:
       return AOEFormOption.COVID;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -13,14 +13,14 @@ import {
 import { showError, showSuccess } from "../../utils/srToast";
 import { respiratorySymptomDefinitions } from "../../../patientApp/timeOfTest/constants";
 
-import { TestFormState } from "./TestCardFormReducer";
+import { AoeQuestionResponses, TestFormState } from "./TestCardFormReducer";
 import {
   DevicesMap,
   QueriedDeviceType,
   QueriedFacility,
   QueriedTestOrder,
 } from "./types";
-import { mapSymptomBoolLiteralsToBool } from "./diseaseSpecificComponents/aoeUtils";
+import { mapSpecifiedSymptomBoolLiteralsToBool } from "./diseaseSpecificComponents/aoeUtils";
 
 /** Add more options as other disease AOEs are needed */
 export enum AOEFormOption {
@@ -228,45 +228,141 @@ export const convertFromMultiplexResponse = (
   });
 };
 
-export const areAOEAnswersComplete = (
+export const AoeValidationErrorMessages = {
+  COMPLETE: "COMPLETE",
+  SYMPTOM_VALIDATION_ERROR: "SYMPTOM_VALIDATION_ERROR",
+  INCOMPLETE: "INCOMPLETE",
+  UNKNOWN: "UNKNOWN",
+} as const;
+
+const REQUIRED_AOE_QUESTIONS_BY_DISEASE: {
+  [key in AOEFormOption]: Array<keyof AoeQuestionResponses>;
+} = {
+  // AOE responses for COVID not required, but include in completion validation
+  // to show "are you sure" modal if not filled
+  [AOEFormOption.COVID]: ["pregnancy", "noSymptoms"],
+  [AOEFormOption.HIV]: ["pregnancy", "genderOfSexualPartners"],
+  [AOEFormOption.SYPHILIS]: [
+    "pregnancy",
+    "syphilisHistory",
+    "genderOfSexualPartners",
+    "noSymptoms",
+  ],
+  [AOEFormOption.NONE]: [],
+};
+
+export function generateAoeValidationState(
   formState: TestFormState,
   whichAOE: AOEFormOption
-) => {
-  if (whichAOE === AOEFormOption.COVID) {
-    const isPregnancyAnswered = !!formState.aoeResponses.pregnancy;
-    const hasNoSymptoms = formState.aoeResponses.noSymptoms;
-    if (formState.aoeResponses.noSymptoms === false) {
-      const symptoms = mapSymptomBoolLiteralsToBool(
-        formState.aoeResponses.symptoms,
-        respiratorySymptomDefinitions
-      );
-      const areSymptomsFilledIn = Object.values(symptoms).some((x) =>
-        x?.valueOf()
-      );
-      const isSymptomOnsetDateAnswered = !!formState.aoeResponses.symptomOnset;
-      return (
-        isPregnancyAnswered &&
-        !hasNoSymptoms &&
-        areSymptomsFilledIn &&
-        isSymptomOnsetDateAnswered
-      );
+): keyof typeof AoeValidationErrorMessages {
+  const {
+    allNonSymptomAoeQuestionsAnswered,
+    hasSymptomsQuestionAnswered,
+    symptomOnsetAndSelectionQuestionsAnswered,
+  } = validateAoeQuestions(formState, whichAOE);
+
+  switch (true) {
+    case !allNonSymptomAoeQuestionsAnswered || !hasSymptomsQuestionAnswered:
+      return AoeValidationErrorMessages.INCOMPLETE;
+    case allNonSymptomAoeQuestionsAnswered &&
+      hasSymptomsQuestionAnswered &&
+      symptomOnsetAndSelectionQuestionsAnswered:
+      return AoeValidationErrorMessages.COMPLETE;
+    case allNonSymptomAoeQuestionsAnswered &&
+      hasSymptomsQuestionAnswered &&
+      !symptomOnsetAndSelectionQuestionsAnswered:
+      return AoeValidationErrorMessages.SYMPTOM_VALIDATION_ERROR;
+    default:
+      return AoeValidationErrorMessages.UNKNOWN;
+  }
+}
+
+export function validateAoeQuestions(
+  formState: TestFormState,
+  whichAOE: AOEFormOption
+) {
+  const aoeQuestionsToCheck = REQUIRED_AOE_QUESTIONS_BY_DISEASE[whichAOE];
+  const nonSymptomAoeStatusMap: {
+    [key in keyof AoeQuestionResponses]: boolean;
+  } = {};
+  const symptomAoeStatusMap: {
+    [key in keyof AoeQuestionResponses]: boolean;
+  } = {};
+  aoeQuestionsToCheck.forEach((aoeQuestionKey) => {
+    if (aoeQuestionKey === "noSymptoms") {
+      const {
+        hasSymptomsQuestionAnswered,
+        symptomOnsetAndSelectionQuestionsAnswered,
+      } = areSymptomAoeQuestionsAnswered(formState, whichAOE);
+      symptomAoeStatusMap["noSymptoms"] = hasSymptomsQuestionAnswered;
+      symptomAoeStatusMap["symptoms"] =
+        symptomOnsetAndSelectionQuestionsAnswered;
+      symptomAoeStatusMap["symptomOnset"] =
+        symptomOnsetAndSelectionQuestionsAnswered;
+    } else {
+      nonSymptomAoeStatusMap[aoeQuestionKey] =
+        areNonSymptomAoeQuestionsAnswered(aoeQuestionKey, formState);
     }
-    return isPregnancyAnswered && hasNoSymptoms;
+  });
+  const allNonSymptomAoeQuestionsAnswered = Object.values(
+    nonSymptomAoeStatusMap
+  ).every(Boolean);
+
+  // if undefined, symptoms questions are not required for that disease. Coerce the status of those questions to true
+  const hasSymptomsQuestionAnswered = symptomAoeStatusMap["noSymptoms"] ?? true;
+  const symptomOnsetAndSelectionQuestionsAnswered =
+    symptomAoeStatusMap["symptomOnset"] ??
+    symptomAoeStatusMap["symptoms"] ??
+    true;
+
+  return {
+    allNonSymptomAoeQuestionsAnswered,
+    hasSymptomsQuestionAnswered,
+    symptomOnsetAndSelectionQuestionsAnswered,
+  };
+}
+
+export function areNonSymptomAoeQuestionsAnswered(
+  aoeQuestionKey: keyof AoeQuestionResponses,
+  formState: TestFormState
+) {
+  const aoeResponse = formState.aoeResponses[aoeQuestionKey];
+  if (Array.isArray(aoeResponse)) return aoeResponse.length > 0;
+  return Boolean(aoeResponse);
+}
+
+export function areSymptomAoeQuestionsAnswered(
+  formState: TestFormState,
+  whichAOE: AOEFormOption
+): {
+  hasSymptomsQuestionAnswered: boolean;
+  symptomOnsetAndSelectionQuestionsAnswered: boolean;
+} {
+  if (formState.aoeResponses.noSymptoms == null) {
+    return {
+      hasSymptomsQuestionAnswered: false,
+      symptomOnsetAndSelectionQuestionsAnswered: false,
+    };
   }
-  const hasPositiveHIVResult = formState.testResults.some(
-    (x) =>
-      x.diseaseName === MULTIPLEX_DISEASES.HIV &&
-      x.testResult === TEST_RESULTS.POSITIVE
+  if (formState.aoeResponses.noSymptoms) {
+    return {
+      hasSymptomsQuestionAnswered: true,
+      symptomOnsetAndSelectionQuestionsAnswered: true,
+    };
+  }
+
+  const symptoms = mapSpecifiedSymptomBoolLiteralsToBool(
+    formState.aoeResponses.symptoms,
+    whichAOE
   );
-  if (whichAOE === AOEFormOption.HIV && hasPositiveHIVResult) {
-    const isPregnancyAnswered = !!formState.aoeResponses.pregnancy;
-    const isGenderOfSexualPartnersAnswered =
-      !!formState.aoeResponses.genderOfSexualPartners &&
-      formState.aoeResponses.genderOfSexualPartners.length > 0;
-    return isPregnancyAnswered && isGenderOfSexualPartnersAnswered;
-  }
-  return true;
-};
+  const areSymptomsFilledIn = Object.values(symptoms).some((x) => x?.valueOf());
+  const isSymptomOnsetDateAnswered = !!formState.aoeResponses.symptomOnset;
+  return {
+    hasSymptomsQuestionAnswered: true,
+    symptomOnsetAndSelectionQuestionsAnswered:
+      areSymptomsFilledIn && isSymptomOnsetDateAnswered,
+  };
+}
 
 export const showTestResultDeliveryStatusAlert = (
   deliverySuccess: boolean | null | undefined,

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -11,7 +11,6 @@ import {
   SomeoneWithName,
 } from "../constants";
 import { showError, showSuccess } from "../../utils/srToast";
-import { respiratorySymptomDefinitions } from "../../../patientApp/timeOfTest/constants";
 
 import { AoeQuestionResponses, TestFormState } from "./TestCardFormReducer";
 import {

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -20,7 +20,9 @@ import {
   QueriedFacility,
   QueriedTestOrder,
 } from "./types";
-import { mapSymptomBoolLiteralsToBool } from "./diseaseSpecificComponents/aoeUtils";
+import {
+  mapSymptomBoolLiteralsToBool,
+} from "./diseaseSpecificComponents/aoeUtils";
 
 /** Add more options as other disease AOEs are needed */
 export enum AOEFormOption {

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -275,10 +275,7 @@ export function generateAoeValidationState(
   if (!allNonSymptomAoeQuestionsAnswered || !hasSymptomsQuestionAnswered) {
     return AoeValidationErrorMessages.INCOMPLETE;
   }
-  if (
-    hasSymptomsQuestionAnswered &&
-    symptomOnsetAndSelectionQuestionsAnswered
-  ) {
+  if (symptomOnsetAndSelectionQuestionsAnswered) {
     return AoeValidationErrorMessages.COMPLETE;
   }
   return AoeValidationErrorMessages.UNKNOWN;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -266,19 +266,22 @@ export function generateAoeValidationState(
     symptomOnsetAndSelectionQuestionsAnswered,
   } = areAoeQuestionsAnswered(formState, whichAOE);
 
-  if (allNonSymptomAoeQuestionsAnswered && hasSymptomsQuestionAnswered) {
-    if (symptomOnsetAndSelectionQuestionsAnswered) {
-      return AoeValidationErrorMessages.COMPLETE;
-    }
-    return AoeValidationErrorMessages.SYMPTOM_VALIDATION_ERROR;
-  } else if (
-    !allNonSymptomAoeQuestionsAnswered ||
-    !hasSymptomsQuestionAnswered
+  if (
+    hasSymptomsQuestionAnswered &&
+    !symptomOnsetAndSelectionQuestionsAnswered
   ) {
-    return AoeValidationErrorMessages.INCOMPLETE;
-  } else {
-    return AoeValidationErrorMessages.UNKNOWN;
+    return AoeValidationErrorMessages.SYMPTOM_VALIDATION_ERROR;
   }
+  if (!allNonSymptomAoeQuestionsAnswered || !hasSymptomsQuestionAnswered) {
+    return AoeValidationErrorMessages.INCOMPLETE;
+  }
+  if (
+    hasSymptomsQuestionAnswered &&
+    symptomOnsetAndSelectionQuestionsAnswered
+  ) {
+    return AoeValidationErrorMessages.COMPLETE;
+  }
+  return AoeValidationErrorMessages.UNKNOWN;
 }
 
 export function areAoeQuestionsAnswered(

--- a/frontend/src/app/testQueue/TestCardForm/TestCardFormReducer.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardFormReducer.tsx
@@ -117,6 +117,7 @@ export const testCardFormReducer = (
           prevState.devicesMap.get(payload)?.swabTypes[0].internalId ??
           prevState.specimenId,
         testResults: [],
+        aoeResponses: {},
         dirty: true,
       };
     }

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -8,7 +8,9 @@ import { formatDate } from "../../../utils/date";
 import Checkboxes from "../../../commonComponents/Checkboxes";
 import {
   getPregnancyResponses,
+  ONSET_DATE_LABEL,
   respiratorySymptomDefinitions,
+  SYMPTOM_SUBQUESTION_ERROR,
 } from "../../../../patientApp/timeOfTest/constants";
 import { AoeQuestionResponses } from "../TestCardFormReducer";
 import { QueriedTestOrder } from "../types";
@@ -78,7 +80,7 @@ const CovidAoEForm = ({
             <TextInput
               name={`symptom-date-${testOrder.internalId}`}
               type="date"
-              label="When did the patient's symptoms start?"
+              label={ONSET_DATE_LABEL}
               aria-label="Symptom onset date"
               min={formatDate(new Date("Jan 1, 2020"))}
               max={formatDate(moment().toDate())}
@@ -93,7 +95,7 @@ const CovidAoEForm = ({
               validationStatus={showSymptomOnsetDateError ? "error" : undefined}
               errorMessage={
                 showSymptomOnsetDateError
-                  ? "This question is required if the patient has symptoms."
+                  ? SYMPTOM_SUBQUESTION_ERROR
                   : undefined
               }
             ></TextInput>
@@ -110,9 +112,7 @@ const CovidAoEForm = ({
               onChange={(e) => onSymptomsChange(e, symptoms)}
               validationStatus={showSymptomOnsetError ? "error" : undefined}
               errorMessage={
-                showSymptomOnsetError
-                  ? "This question is required if the patient has symptoms."
-                  : undefined
+                showSymptomOnsetError ? SYMPTOM_SUBQUESTION_ERROR : undefined
               }
             />
           </div>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -44,7 +44,7 @@ const CovidAoEForm = ({
   const {
     hasSymptoms,
     symptoms,
-    showSymptomOnsetError,
+    showSymptomSelectionError,
     showSymptomOnsetDateError,
   } = generateSymptomAoeConstants(
     responses,
@@ -110,9 +110,11 @@ const CovidAoEForm = ({
               legend="Select any symptoms the patient is experiencing"
               name={`symptoms-${testOrder.internalId}`}
               onChange={(e) => onSymptomsChange(e, symptoms)}
-              validationStatus={showSymptomOnsetError ? "error" : undefined}
+              validationStatus={showSymptomSelectionError ? "error" : undefined}
               errorMessage={
-                showSymptomOnsetError ? SYMPTOM_SUBQUESTION_ERROR : undefined
+                showSymptomSelectionError
+                  ? SYMPTOM_SUBQUESTION_ERROR
+                  : undefined
               }
             />
           </div>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -74,9 +74,8 @@ const CovidAoEForm = ({
       </div>
       {hasSymptoms === "YES" && (
         <>
-          <div className="grid-row grid-gap">
+          <div className="grid-row grid-gap" data-testid="symptom-date">
             <TextInput
-              data-testid="symptom-date"
               name={`symptom-date-${testOrder.internalId}`}
               type="date"
               label="When did the patient's symptoms start?"
@@ -99,7 +98,7 @@ const CovidAoEForm = ({
               }
             ></TextInput>
           </div>
-          <div className="grid-row grid-gap">
+          <div className="grid-row grid-gap" data-testid="symptom-selection">
             <Checkboxes
               boxes={respiratorySymptomDefinitions.map(({ label, value }) => ({
                 label,

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -16,7 +16,6 @@ import { QueriedTestOrder } from "../types";
 import {
   generateAoeListenerHooks,
   generateSymptomAoeConstants,
-  mapSymptomBoolLiteralsToBool,
 } from "./aoeUtils";
 
 export interface CovidAoEFormProps {
@@ -40,7 +39,7 @@ const CovidAoEForm = ({
     onSymptomsChange,
     onSymptomOnsetDateChange,
   } = generateAoeListenerHooks(onResponseChange, responses);
-  const { hasSymptoms, symptoms} = generateSymptomAoeConstants(
+  const { hasSymptoms, symptoms } = generateSymptomAoeConstants(
     responses,
     hasAttemptedSubmit,
     respiratorySymptomDefinitions

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -39,7 +39,12 @@ const CovidAoEForm = ({
     onSymptomsChange,
     onSymptomOnsetDateChange,
   } = generateAoeListenerHooks(onResponseChange, responses);
-  const { hasSymptoms, symptoms } = generateSymptomAoeConstants(
+  const {
+    hasSymptoms,
+    symptoms,
+    showSymptomOnsetError,
+    showSymptomOnsetDateError,
+  } = generateSymptomAoeConstants(
     responses,
     hasAttemptedSubmit,
     respiratorySymptomDefinitions
@@ -86,6 +91,12 @@ const CovidAoEForm = ({
                   : ""
               }
               onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
+              validationStatus={showSymptomOnsetDateError ? "error" : undefined}
+              errorMessage={
+                showSymptomOnsetDateError
+                  ? "This question is required if the patient has symptoms."
+                  : undefined
+              }
             ></TextInput>
           </div>
           <div className="grid-row grid-gap">
@@ -98,6 +109,12 @@ const CovidAoEForm = ({
               legend="Select any symptoms the patient is experiencing"
               name={`symptoms-${testOrder.internalId}`}
               onChange={(e) => onSymptomsChange(e, symptoms)}
+              validationStatus={showSymptomOnsetError ? "error" : undefined}
+              errorMessage={
+                showSymptomOnsetError
+                  ? "This question is required if the patient has symptoms."
+                  : undefined
+              }
             />
           </div>
         </>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -98,9 +98,13 @@ const CovidAoEForm = ({
                   ? SYMPTOM_SUBQUESTION_ERROR
                   : undefined
               }
+              className={showSymptomOnsetDateError ? "margin-left-0" : ""}
             ></TextInput>
           </div>
-          <div className="grid-row grid-gap" data-testid="symptom-selection">
+          <div
+            className="grid-row grid-gap margin-left-0"
+            data-testid="symptom-selection"
+          >
             <Checkboxes
               boxes={respiratorySymptomDefinitions.map(({ label, value }) => ({
                 label,

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -34,17 +34,13 @@ const CovidAoEForm = ({
   onResponseChange,
   hasAttemptedSubmit,
 }: CovidAoEFormProps) => {
-  const symptoms: Record<string, boolean> = mapSymptomBoolLiteralsToBool(
-    responses.symptoms,
-    respiratorySymptomDefinitions
-  );
   const {
     onPregnancyChange,
     onHasAnySymptomsChange,
     onSymptomsChange,
     onSymptomOnsetDateChange,
   } = generateAoeListenerHooks(onResponseChange, responses);
-  const { hasSymptoms } = generateSymptomAoeConstants(
+  const { hasSymptoms, symptoms} = generateSymptomAoeConstants(
     responses,
     hasAttemptedSubmit,
     respiratorySymptomDefinitions

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -133,7 +133,7 @@ export function generateSymptomAoeConstants(
   const isSymptomOnsetAnswered =
     !!responses.symptoms && Object.values(symptoms).some((x) => x?.valueOf());
 
-  const showSymptomOnsetError =
+  const showSymptomSelectionError =
     hasAttemptedSubmit &&
     isSymptomsAnswered &&
     responses.noSymptoms === false &&
@@ -143,7 +143,7 @@ export function generateSymptomAoeConstants(
     showSymptomsError,
     showSymptomOnsetDateError,
     hasSymptoms,
-    showSymptomOnsetError,
+    showSymptomSelectionError,
     symptoms,
   };
 }

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -182,7 +182,7 @@ export function mapSpecifiedSymptomBoolLiteralsToBool(
     symptomDefinitionToParse = syphilisSymptomDefinitions;
   }
   // there are no symptoms for that test card, so return true
-  if(!symptomDefinitionToParse) return {shouldReturn: true}
+  if (!symptomDefinitionToParse) return { shouldReturn: true };
   return mapSymptomBoolLiteralsToBool(
     symptomsJsonString,
     symptomDefinitionToParse

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -174,22 +174,19 @@ export function mapSpecifiedSymptomBoolLiteralsToBool(
   symptomsJsonString: string | null | undefined,
   disease: AOEFormOption
 ) {
+  let symptomDefinitionToParse;
   if (disease === AOEFormOption.COVID) {
-    return mapSymptomBoolLiteralsToBool(
-      symptomsJsonString,
-      respiratorySymptomDefinitions
-    );
+    symptomDefinitionToParse = respiratorySymptomDefinitions;
   }
   if (disease === AOEFormOption.SYPHILIS) {
-    return mapSymptomBoolLiteralsToBool(
-      symptomsJsonString,
-      syphilisSymptomDefinitions
-    );
+    symptomDefinitionToParse = syphilisSymptomDefinitions;
   }
   // there are no symptoms for that test card, so return true
-  return {
-    shouldReturn: true,
-  };
+  if(!symptomDefinitionToParse) return {shouldReturn: true}
+  return mapSymptomBoolLiteralsToBool(
+    symptomsJsonString,
+    symptomDefinitionToParse
+  );
 }
 
 export const mapSymptomBoolLiteralsToBool = (

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -197,7 +197,7 @@ export function generateEmptyEditQueueMock() {
 export function generateEditQueueMock(
   disease: MULTIPLEX_DISEASES,
   testResult: TEST_RESULTS,
-  overrideParams?: EditQueueMockParams,
+  overrideParams?: EditQueueMockParams
 ) {
   return {
     request: {

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -1,21 +1,13 @@
 import {
   EditQueueItemDocument,
+  PhoneType,
   SubmitQueueItemDocument,
   SubmitQueueItemMutationVariables,
   UpdateAoeDocument,
   UpdateAoeMutationVariables,
 } from "../../../../generated/graphql";
-import {
-  MULTIPLEX_DISEASES,
-  TEST_RESULTS,
-} from "../../../testResults/constants";
-
-import {
-  device1Id,
-  specimen1Id,
-  sharedTestOrderInfo,
-  symptomaticTestOrderInfo,
-} from "./testConstants";
+import { QueriedTestOrder } from "../types";
+import { MULTIPLEX_DISEASES } from "../../../testResults/constants";
 
 const SYMPTOM_TRUE_OVERRIDE = { noSymptoms: false };
 const PREGNANCY_OVERRIDE = { pregnancy: "77386006" };
@@ -164,18 +156,11 @@ export const updateAoeMocks = [
 ];
 
 type EditQueueMockParams = {
-  diseaseResults?:
-    | []
-    | [{ diseaseName: MULTIPLEX_DISEASES; testResult: TEST_RESULTS }];
+  diseaseResults: [{ diseaseName: MULTIPLEX_DISEASES; testResult: TestResult }];
   dateTested?: string;
   device?: {
-    deviceName?: string;
+    deviceName: string;
     deviceId: string;
-    supportedDiseases?: {
-      internalId: string;
-      loinc: string;
-      name: MULTIPLEX_DISEASES;
-    }[];
   };
   specimen?: {
     specimenName: string;
@@ -183,45 +168,30 @@ type EditQueueMockParams = {
   };
 };
 
-export function generateEmptyEditQueueMock() {
-  // dummy covid unknown submission that's overrided by the empty array
-  return generateEditQueueMock(
-    MULTIPLEX_DISEASES.COVID_19,
-    TEST_RESULTS.UNKNOWN,
-    {
-      diseaseResults: [],
-    }
-  );
-}
+const device1Name = "LumiraDX";
+const device1Id = "DEVICE-1-ID";
+const specimen1Name = "Swab of internal nose";
+const specimen1Id = "SPECIMEN-1-ID";
 
-export function generateEditQueueMock(
-  disease: MULTIPLEX_DISEASES,
-  testResult: TEST_RESULTS,
-  overrideParams?: EditQueueMockParams
-) {
+export function generateEditQueueMock(params: EditQueueMockParams) {
   return {
     request: {
       query: EditQueueItemDocument,
       variables: {
-        id: sharedTestOrderInfo.internalId,
-        deviceTypeId: overrideParams?.device?.deviceId ?? device1Id,
-        specimenTypeId: overrideParams?.specimen?.specimenId ?? specimen1Id,
-        results: overrideParams?.diseaseResults ?? [
-          {
-            diseaseName: disease,
-            testResult: testResult,
-          },
-        ],
-        dateTested: overrideParams?.dateTested,
+        id: testOrderInfo.internalId,
+        deviceTypeId: params.device?.deviceId ?? device1Id,
+        specimenTypeId: params.specimen?.specimenId ?? specimen1Id,
+        results: params.diseaseResults,
+        dateTested: params.dateTested,
       },
       result: {
         data: {
           editQueueItem: {
-            results: overrideParams?.diseaseResults,
+            results: params.diseaseResults,
           },
-          dateTested: overrideParams?.dateTested,
+          dateTested: params.dateTested,
           deviceType: {
-            internalId: overrideParams?.device?.deviceId ?? device1Id,
+            internalId: params.device?.deviceId ?? device1Id,
             testLength: 15,
           },
         },
@@ -230,37 +200,49 @@ export function generateEditQueueMock(
   };
 }
 
-type SubmitQueueMockParams = EditQueueMockParams & {
-  deliverySuccess?: boolean;
-};
-
-export function generateSubmitQueueMock(
-  disease: MULTIPLEX_DISEASES,
-  testResult: TEST_RESULTS,
-  overrideParams?: SubmitQueueMockParams
-) {
-  return {
-    request: {
-      query: SubmitQueueItemDocument,
-      variables: {
-        patientId: symptomaticTestOrderInfo.patient.internalId,
-        deviceTypeId: overrideParams?.device?.deviceId ?? device1Id,
-        specimenTypeId: overrideParams?.specimen?.specimenId ?? specimen1Id,
-        results: overrideParams?.diseaseResults ?? [
-          { diseaseName: disease, testResult: testResult },
-        ],
-        dateTested: overrideParams?.dateTested ?? null,
-      } as SubmitQueueItemMutationVariables,
-    },
-    result: {
-      data: {
-        submitQueueItem: {
-          testResult: {
-            internalId: symptomaticTestOrderInfo.internalId,
-          },
-          deliverySuccess: overrideParams?.deliverySuccess ?? true,
-        },
+const testOrderInfo: QueriedTestOrder = {
+  internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
+  dateAdded: "2022-11-08 13:33:07.503",
+  symptoms:
+    '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
+  symptomOnset: null,
+  noSymptoms: true,
+  deviceType: {
+    internalId: device1Id,
+    name: device1Name,
+    model: "LumiraDx SARS-CoV-2 Ag Test*",
+    testLength: 15,
+  },
+  specimenType: {
+    internalId: specimen1Id,
+    name: specimen1Name,
+    typeCode: "445297001",
+  },
+  patient: {
+    internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
+    telephone: "(571) 867-5309",
+    birthDate: "2015-09-20",
+    firstName: "Althea",
+    middleName: "Hedda Mclaughlin",
+    lastName: "Dixon",
+    gender: "refused",
+    testResultDelivery: null,
+    preferredLanguage: null,
+    email: "sywaporoce@mailinator.com",
+    emails: ["sywaporoce@mailinator.com"],
+    phoneNumbers: [
+      {
+        type: PhoneType.Mobile,
+        number: "(553) 223-0559",
       },
-    },
-  };
-}
+      {
+        type: PhoneType.Landline,
+        number: "(669) 789-0799",
+      },
+    ],
+  },
+  results: [],
+  dateTested: null,
+  correctionStatus: "ORIGINAL",
+  reasonForCorrection: null,
+};

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -1,13 +1,16 @@
 import {
   EditQueueItemDocument,
-  PhoneType,
   SubmitQueueItemDocument,
   SubmitQueueItemMutationVariables,
   UpdateAoeDocument,
   UpdateAoeMutationVariables,
 } from "../../../../generated/graphql";
-import { QueriedTestOrder } from "../types";
-import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../../testResults/constants";
+import {
+  MULTIPLEX_DISEASES,
+  TEST_RESULTS,
+} from "../../../testResults/constants";
+
+import { device1Id, specimen1Id, sharedTestOrderInfo } from "./testConstants";
 
 const SYMPTOM_TRUE_OVERRIDE = { noSymptoms: false };
 const PREGNANCY_OVERRIDE = { pregnancy: "77386006" };
@@ -15,13 +18,15 @@ const COUGH_OVERRIDE = {
   symptoms:
     '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":true,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
 };
-const ALL_FALSE_SYMPTOM_OVERRIDE =  {
+const ALL_FALSE_SYMPTOM_OVERRIDE = {
   noSymptoms: false,
   symptoms:
     '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":false,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
 };
-export const TEST_CARD_SYMPTOM_ONSET_DATE_STRING = "2024-05-14"
-const SYMPTOM_ONSET_DATE_OVERRIDE = { symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING };
+export const TEST_CARD_SYMPTOM_ONSET_DATE_STRING = "2024-05-14";
+const SYMPTOM_ONSET_DATE_OVERRIDE = {
+  symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
+};
 export const updateAoeMutationRequest = (
   variableOverrides?: Partial<UpdateAoeMutationVariables>
 ) => {
@@ -98,14 +103,18 @@ export const blankUpdateAoeEventMock = {
   ...mutationResponse,
 };
 
-
 export const allFalseSymptomUpdateAoeEventMock = {
-  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({...ALL_FALSE_SYMPTOM_OVERRIDE}),
+  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
+    ...ALL_FALSE_SYMPTOM_OVERRIDE,
+  }),
   ...mutationResponse,
 };
 
 export const allFalseSymptomUpdateAoeEventMockWithSymptomOnset = {
-  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({...ALL_FALSE_SYMPTOM_OVERRIDE, symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING}),
+  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
+    ...ALL_FALSE_SYMPTOM_OVERRIDE,
+    symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
+  }),
   ...mutationResponse,
 };
 
@@ -150,7 +159,9 @@ export const updateAoeMocks = [
 ];
 
 type EditQueueMockParams = {
-  diseaseResults: [{ diseaseName: MULTIPLEX_DISEASES, testResult: TEST_RESULTS }];
+  diseaseResults: [
+    { diseaseName: MULTIPLEX_DISEASES; testResult: TEST_RESULTS }
+  ];
   dateTested?: string;
   device?: {
     deviceName: string;
@@ -162,17 +173,12 @@ type EditQueueMockParams = {
   };
 };
 
-const device1Name = "LumiraDX";
-const device1Id = "DEVICE-1-ID";
-const specimen1Name = "Swab of internal nose";
-const specimen1Id = "SPECIMEN-1-ID";
-
 export function generateEditQueueMock(params: EditQueueMockParams) {
   return {
     request: {
       query: EditQueueItemDocument,
       variables: {
-        id: testOrderInfo.internalId,
+        id: sharedTestOrderInfo.internalId,
         deviceTypeId: params.device?.deviceId ?? device1Id,
         specimenTypeId: params.specimen?.specimenId ?? specimen1Id,
         results: params.diseaseResults,
@@ -193,50 +199,3 @@ export function generateEditQueueMock(params: EditQueueMockParams) {
     },
   };
 }
-
-export const testOrderInfo: QueriedTestOrder = {
-  internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
-  dateAdded: "2022-11-08 13:33:07.503",
-  symptoms:
-    '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
-  symptomOnset: null,
-  noSymptoms: true,
-  deviceType: {
-    internalId: device1Id,
-    name: device1Name,
-    model: "LumiraDx SARS-CoV-2 Ag Test*",
-    testLength: 15,
-  },
-  specimenType: {
-    internalId: specimen1Id,
-    name: specimen1Name,
-    typeCode: "445297001",
-  },
-  patient: {
-    internalId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
-    telephone: "(571) 867-5309",
-    birthDate: "2015-09-20",
-    firstName: "Althea",
-    middleName: "Hedda Mclaughlin",
-    lastName: "Dixon",
-    gender: "refused",
-    testResultDelivery: null,
-    preferredLanguage: null,
-    email: "sywaporoce@mailinator.com",
-    emails: ["sywaporoce@mailinator.com"],
-    phoneNumbers: [
-      {
-        type: PhoneType.Mobile,
-        number: "(553) 223-0559",
-      },
-      {
-        type: PhoneType.Landline,
-        number: "(669) 789-0799",
-      },
-    ],
-  },
-  results: [],
-  dateTested: null,
-  correctionStatus: "ORIGINAL",
-  reasonForCorrection: null,
-};

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -7,7 +7,7 @@ import {
   UpdateAoeMutationVariables,
 } from "../../../../generated/graphql";
 import { QueriedTestOrder } from "../types";
-import { MULTIPLEX_DISEASES } from "../../../testResults/constants";
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../../testResults/constants";
 
 const SYMPTOM_TRUE_OVERRIDE = { noSymptoms: false };
 const PREGNANCY_OVERRIDE = { pregnancy: "77386006" };
@@ -15,15 +15,13 @@ const COUGH_OVERRIDE = {
   symptoms:
     '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":true,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
 };
-const ALL_FALSE_SYMPTOM_OVERRIDE = {
+const ALL_FALSE_SYMPTOM_OVERRIDE =  {
   noSymptoms: false,
   symptoms:
     '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":false,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
 };
-export const TEST_CARD_SYMPTOM_ONSET_DATE_STRING = "2024-05-14";
-const SYMPTOM_ONSET_DATE_OVERRIDE = {
-  symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
-};
+export const TEST_CARD_SYMPTOM_ONSET_DATE_STRING = "2024-05-14"
+const SYMPTOM_ONSET_DATE_OVERRIDE = { symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING };
 export const updateAoeMutationRequest = (
   variableOverrides?: Partial<UpdateAoeMutationVariables>
 ) => {
@@ -100,18 +98,14 @@ export const blankUpdateAoeEventMock = {
   ...mutationResponse,
 };
 
+
 export const allFalseSymptomUpdateAoeEventMock = {
-  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
-    ...ALL_FALSE_SYMPTOM_OVERRIDE,
-  }),
+  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({...ALL_FALSE_SYMPTOM_OVERRIDE}),
   ...mutationResponse,
 };
 
 export const allFalseSymptomUpdateAoeEventMockWithSymptomOnset = {
-  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
-    ...ALL_FALSE_SYMPTOM_OVERRIDE,
-    symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
-  }),
+  ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({...ALL_FALSE_SYMPTOM_OVERRIDE, symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING}),
   ...mutationResponse,
 };
 
@@ -156,7 +150,7 @@ export const updateAoeMocks = [
 ];
 
 type EditQueueMockParams = {
-  diseaseResults: [{ diseaseName: MULTIPLEX_DISEASES; testResult: TestResult }];
+  diseaseResults: [{ diseaseName: MULTIPLEX_DISEASES, testResult: TEST_RESULTS }];
   dateTested?: string;
   device?: {
     deviceName: string;
@@ -200,7 +194,7 @@ export function generateEditQueueMock(params: EditQueueMockParams) {
   };
 }
 
-const testOrderInfo: QueriedTestOrder = {
+export const testOrderInfo: QueriedTestOrder = {
   internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
   dateAdded: "2022-11-08 13:33:07.503",
   symptoms:

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -23,11 +23,6 @@ const COUGH_OVERRIDE = {
   symptoms:
     '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":true,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
 };
-const ALL_FALSE_SYMPTOM_OVERRIDE = {
-  noSymptoms: false,
-  symptoms:
-    '{"25064002":false,"36955009":false,"43724002":false,"44169009":false,"49727002":false,"62315008":false,"64531003":false,"68235000":false,"68962001":false,"84229001":false,"103001002":false,"162397003":false,"230145002":false,"267036007":false,"422400008":false,"422587007":false,"426000000":false}',
-};
 export const TEST_CARD_SYMPTOM_ONSET_DATE_STRING = "2024-05-14";
 const SYMPTOM_ONSET_DATE_OVERRIDE = {
   symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
@@ -82,43 +77,22 @@ const mutationResponse = {
   },
 };
 
-export const submitEventMock = {
-  request: {
-    query: SubmitQueueItemDocument,
-    variables: {
-      patientId: "72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0",
-      deviceTypeId: "MULTIPLEX-DEVICE-ID",
-      specimenTypeId: "SPECIMEN-1-ID",
-      dateTested: null,
-      results: [
-        { diseaseName: "COVID-19", testResult: "POSITIVE" },
-        {
-          diseaseName: "Flu A",
-          testResult: "UNKNOWN",
-        },
-        { diseaseName: "Flu B", testResult: "UNKNOWN" },
-      ],
-    },
-  },
-  ...mutationResponse,
-};
-
 export const blankUpdateAoeEventMock = {
   ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy(),
   ...mutationResponse,
 };
 
-export const allFalseSymptomUpdateAoeEventMock = {
+export const falseNoSymptomUpdateAoeEventMock = {
   ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
-    ...ALL_FALSE_SYMPTOM_OVERRIDE,
+    noSymptoms: false,
   }),
   ...mutationResponse,
 };
 
-export const allFalseSymptomUpdateAoeEventMockWithSymptomOnset = {
+export const falseNoSymptomWithSymptomOnsetUpdateAoeEventMock = {
   ...updateAoeMutationRequestWithoutNoSymptomsAndPregnancy({
-    ...ALL_FALSE_SYMPTOM_OVERRIDE,
     symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
+    noSymptoms: false,
   }),
   ...mutationResponse,
 };

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/submissionMocks.ts
@@ -10,7 +10,12 @@ import {
   TEST_RESULTS,
 } from "../../../testResults/constants";
 
-import { device1Id, specimen1Id, sharedTestOrderInfo } from "./testConstants";
+import {
+  device1Id,
+  specimen1Id,
+  sharedTestOrderInfo,
+  symptomaticTestOrderInfo,
+} from "./testConstants";
 
 const SYMPTOM_TRUE_OVERRIDE = { noSymptoms: false };
 const PREGNANCY_OVERRIDE = { pregnancy: "77386006" };
@@ -159,13 +164,20 @@ export const updateAoeMocks = [
 ];
 
 type EditQueueMockParams = {
-  diseaseResults: [
+  diseaseResults: [] | [
     { diseaseName: MULTIPLEX_DISEASES; testResult: TEST_RESULTS }
   ];
   dateTested?: string;
   device?: {
-    deviceName: string;
+    deviceName?: string;
     deviceId: string;
+    supportedDiseases?: {
+      internalId: string
+      loinc: string 
+      name: MULTIPLEX_DISEASES
+    }[
+      
+    ]
   };
   specimen?: {
     specimenName: string;
@@ -194,6 +206,35 @@ export function generateEditQueueMock(params: EditQueueMockParams) {
             internalId: params.device?.deviceId ?? device1Id,
             testLength: 15,
           },
+        },
+      },
+    },
+  };
+}
+
+type SubmitQueueMockParams = EditQueueMockParams & {
+  deliverySuccess?: boolean;
+};
+
+export function generateSubmitQueueMock(params: SubmitQueueMockParams) {
+  return {
+    request: {
+      query: SubmitQueueItemDocument,
+      variables: {
+        patientId: symptomaticTestOrderInfo.patient.internalId,
+        deviceTypeId: params.device?.deviceId ?? device1Id,
+        specimenTypeId: params.specimen?.specimenId ?? specimen1Id,
+        results: params.diseaseResults,
+        dateTested: params.dateTested ?? null,
+      } as SubmitQueueItemMutationVariables,
+    },
+    result: {
+      data: {
+        submitQueueItem: {
+          testResult: {
+            internalId: symptomaticTestOrderInfo.internalId,
+          },
+          deliverySuccess: params.deliverySuccess ?? true,
         },
       },
     },

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
@@ -180,10 +180,3 @@ export const symptomaticTestOrderInfo: QueriedTestOrder = {
   symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
   noSymptoms: false,
 };
-
-export const invalidSymptomaticTestOrderInfo: QueriedTestOrder = {
-  ...sharedTestOrderInfo,
-  symptoms: null,
-  symptomOnset: null,
-  noSymptoms: true,
-};

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
@@ -173,11 +173,17 @@ export const asymptomaticTestOrderInfo: QueriedTestOrder = {
   ...sharedTestOrderInfo,
   ...asymptomaticTestOrderPartialInfo,
 };
-
 export const symptomaticTestOrderInfo: QueriedTestOrder = {
   ...sharedTestOrderInfo,
   symptoms:
     '{"64531003":"false","103001002":"false","84229001":"false","68235000":"false","426000000":"false","49727002":"false","68962001":"false","422587007":"false","267036007":"false","62315008":"false","43724002":"false","36955009":"false","44169009":"false","422400008":"false","230145002":"false","25064002":"false","162397003":"false"}',
   symptomOnset: TEST_CARD_SYMPTOM_ONSET_DATE_STRING,
   noSymptoms: false,
+};
+
+export const invalidSymptomaticTestOrderInfo: QueriedTestOrder = {
+  ...sharedTestOrderInfo,
+  symptoms: null,
+  symptomOnset: null,
+  noSymptoms: true,
 };

--- a/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
+++ b/frontend/src/app/testQueue/TestCardForm/testUtils/testConstants.ts
@@ -125,9 +125,9 @@ export const sharedTestOrderInfo = {
   internalId: "1b02363b-ce71-4f30-a2d6-d82b56a91b39",
   dateAdded: "2022-11-08 13:33:07.503",
   deviceType: {
-    internalId: device1Id,
-    name: device1Name,
-    model: device1Name,
+    internalId: covidDeviceId,
+    name: covidDeviceName,
+    model: covidDeviceName,
     testLength: 15,
   },
   specimenType: {

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -678,7 +678,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap"
+                        class="grid-row grid-gap margin-left-0"
                         data-testid="symptom-selection"
                       >
                         <div
@@ -1649,7 +1649,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap"
+                        class="grid-row grid-gap margin-left-0"
                         data-testid="symptom-selection"
                       >
                         <div

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -653,6 +653,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                       <div
                         class="grid-row grid-gap"
+                        data-testid="symptom-date"
                       >
                         <div
                           class="usa-form-group"
@@ -667,7 +668,6 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-label="Symptom onset date"
                             aria-required="false"
                             class="usa-input"
-                            data-testid="symptom-date"
                             id="6"
                             max="2023-10-17"
                             min="2020-01-01"
@@ -679,6 +679,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                       <div
                         class="grid-row grid-gap"
+                        data-testid="symptom-selection"
                       >
                         <div
                           class="usa-form-group"
@@ -984,6 +985,23 @@ exports[`TestQueue should render the test queue 1`] = `
                                     for="symptom-422400008"
                                   >
                                     Vomiting
+                                  </label>
+                                </div>
+                                <div
+                                  class="usa-checkbox"
+                                >
+                                  <input
+                                    class="usa-checkbox__input"
+                                    id="symptom-261665006"
+                                    name="symptoms-abc"
+                                    type="checkbox"
+                                    value="261665006"
+                                  />
+                                  <label
+                                    class="usa-checkbox__label"
+                                    for="symptom-261665006"
+                                  >
+                                    Other symptom not listed
                                   </label>
                                 </div>
                               </div>
@@ -1606,6 +1624,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                       <div
                         class="grid-row grid-gap"
+                        data-testid="symptom-date"
                       >
                         <div
                           class="usa-form-group"
@@ -1620,7 +1639,6 @@ exports[`TestQueue should render the test queue 1`] = `
                             aria-label="Symptom onset date"
                             aria-required="false"
                             class="usa-input"
-                            data-testid="symptom-date"
                             id="12"
                             max="2023-10-17"
                             min="2020-01-01"
@@ -1632,6 +1650,7 @@ exports[`TestQueue should render the test queue 1`] = `
                       </div>
                       <div
                         class="grid-row grid-gap"
+                        data-testid="symptom-selection"
                       >
                         <div
                           class="usa-form-group"
@@ -1937,6 +1956,23 @@ exports[`TestQueue should render the test queue 1`] = `
                                     for="symptom-422400008"
                                   >
                                     Vomiting
+                                  </label>
+                                </div>
+                                <div
+                                  class="usa-checkbox"
+                                >
+                                  <input
+                                    class="usa-checkbox__input"
+                                    id="symptom-261665006"
+                                    name="symptoms-def"
+                                    type="checkbox"
+                                    value="261665006"
+                                  />
+                                  <label
+                                    class="usa-checkbox__label"
+                                    for="symptom-261665006"
+                                  >
+                                    Other symptom not listed
                                   </label>
                                 </div>
                               </div>

--- a/frontend/src/patientApp/timeOfTest/constants.test.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.test.ts
@@ -1,4 +1,7 @@
-import { alphabetizeSymptomKeysFromMapValues } from "./constants";
+import {
+  alphabetizeSymptomKeysFromMapValues,
+  OTHER_SYMPTOM_NOT_LISTED_LITERAL,
+} from "./constants";
 
 describe("utils", () => {
   it("alphabetizeSymptomKeysFromMapValues produces an alphabetized list of keys based on values when given a map", () => {
@@ -11,6 +14,7 @@ describe("utils", () => {
       "91554004": "e",
       "15188001": "z",
       "246636008": "y",
+      "100000000": OTHER_SYMPTOM_NOT_LISTED_LITERAL,
     } as const;
     const symptomOrder = alphabetizeSymptomKeysFromMapValues(testSymptomMap);
 
@@ -23,6 +27,8 @@ describe("utils", () => {
       "56940005",
       "246636008",
       "15188001",
+      // OTHER_SYMPTOM_NOT_LISTED_LITERAL should come last
+      "100000000",
     ]);
   });
 });

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -130,3 +130,7 @@ export const syphilisSymptomDefinitions: SymptomDefinitionMap[] =
     value,
     label: syphilisSymptomsMap[value],
   }));
+
+export const SYMPTOM_SUBQUESTION_ERROR =
+  "This question is required if the patient has symptoms.";
+export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -18,6 +18,7 @@ const pregnancyOrder: PregnancyCode[] = ["77386006", "60001007", "261665006"];
 
 export const getPregnancyResponses = (): PregnancyResponses =>
   pregnancyOrder.map((value) => ({ value, label: pregnancyMap[value] }));
+export const OTHER_SYMPTOM_NOT_LISTED_LITERAL = "Other symptom not listed";
 
 export const respiratorySymptomsMap = {
   "426000000": "Fever over 100.4F",
@@ -37,6 +38,7 @@ export const respiratorySymptomsMap = {
   "422587007": "Nausea",
   "422400008": "Vomiting",
   "62315008": "Diarrhea",
+  "261665006": OTHER_SYMPTOM_NOT_LISTED_LITERAL,
 } as const;
 
 export type RespiratorySymptoms = typeof respiratorySymptomsMap;
@@ -109,7 +111,11 @@ export function alphabetizeSymptomKeysFromMapValues(dict: {
   [key: string]: string;
 }) {
   const values = Object.values(dict);
-  values.sort((a, b) => a.localeCompare(b));
+  values.sort((a, b) => {
+    if (a === OTHER_SYMPTOM_NOT_LISTED_LITERAL) return 1;
+    if (b === OTHER_SYMPTOM_NOT_LISTED_LITERAL) return -1;
+    else return a.localeCompare(b);
+  });
   const reversedMap = Object.fromEntries(
     Object.entries(dict).map((a) => a.reverse())
   );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Part 4 of the syphilis work that builds on the previous PR's
     - See [part 3](https://github.com/CDCgov/prime-simplereport/pull/7674) for more context
- Actual syphilis UI implementation / logic will come in a fifth and final (TM) PR

Sonar is failing bc of code coverage but going to call the high 70% coverage good enough for the 80% threshold. 

## Changes Proposed

- Genericizes the AOE validation process by pulling any disease-specific logic out of the test card and into their own separate functions
- Makes the validation more declarative by separating the "what questions should be validated" out from the actual validation, hopefully making things more extendable / readable
- Separates this validation logic away from the error states in the test card, defining a validation interface for the test card to consume / render error UI accordingly. Hopefully this will also make the card more extendable by allowing new diseases and to react / render new error UI as needed

## Testing

- Validate all the AOE testing flows are working as expected (screen demos below)

## Screenshots / Demos
### COVID interactions
https://github.com/CDCgov/prime-simplereport/assets/29645040/e70b6e9f-3c54-424b-9570-38278075355e

### HIV interactions
https://github.com/CDCgov/prime-simplereport/assets/29645040/2bedc5ca-0873-4231-ace3-c2dd1a98c5b1



<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
