### PR TITLE
"Start Test" button should always be available

### DIFF
--- a/frontend/src/app/patients/Components/PersonForm.tsx
+++ b/frontend/src/app/patients/Components/PersonForm.tsx
@@ -52,12 +52,16 @@ export enum PersonFormView {
 interface Props {
   patient: Nullable<PersonFormData>;
   patientId?: string;
-  savePerson: (person: Nullable<PersonFormData>, startTest?: boolean) => void;
+  savePerson: (
+    person: Nullable<PersonFormData>,
+    startTest: boolean,
+    formChanged: boolean
+  ) => void;
   onBlur?: (person: Nullable<PersonFormData>) => void;
   hideFacilitySelect?: boolean;
   getHeader?: (
     person: Nullable<PersonFormData>,
-    onSave: (startTest?: boolean) => void,
+    onSave: (startTest?: boolean, formChanged?: boolean) => void,
     formChanged: boolean
   ) => React.ReactNode;
   getFooter: (
@@ -357,10 +361,10 @@ const PersonForm = (props: Props) => {
     person.phoneNumbers = person.phoneNumbers
       ? person.phoneNumbers.filter((pn) => pn.number && pn.type)
       : person.phoneNumbers;
+    props.savePerson(person, shouldStartTest, formChanged);
     setPatient(person);
     setAddressModalOpen(false);
     setFormChanged(false);
-    props.savePerson(person, shouldStartTest);
   };
 
   const commonInputProps = {

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -400,9 +400,9 @@ describe("EditPatient", () => {
               role: "UNKNOWN",
               emails: ["foo@bar.com"],
               county: null,
-              race: "other",
-              ethnicity: "not_hispanic",
-              gender: "male",
+              race: null,
+              ethnicity: null,
+              gender: null,
               genderIdentity: null,
               residentCongregateSetting: true,
               employedInHealthcare: true,
@@ -481,9 +481,9 @@ describe("EditPatient", () => {
             birthDate: "1939-10-11",
             street: "736 Jackson PI NW",
             streetTwo: "DC",
-            city: "Washington, D.C.",
+            city: null,
             state: "DC",
-            zipCode: 20005,
+            zipCode: null,
             telephone: "(270) 867-5309",
             phoneNumbers: [
               {
@@ -493,8 +493,8 @@ describe("EditPatient", () => {
             ],
             role: "UNKNOWN",
             emails: ["foo@bar.com"],
-            county: "DC.",
-            country: "USA",
+            county: null,
+            country: null,
             race: "refused",
             ethnicity: "refused",
             gender: "refused",
@@ -722,10 +722,10 @@ describe("EditPatient", () => {
           fromQueue={false}
         />,
         store,
-        mocks,
-        false
+        mocks
       );
       const { user } = renderWithUser(elementToRender);
+      expect(await screen.findByText("Start test")).toBeInTheDocument();
       await screen.findAllByText("Franecki, Eugenia", { exact: false });
       const name = await screen.findByLabelText("First name", { exact: false });
       //start test switches to start and save test on edit

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -682,8 +682,10 @@ describe("EditPatient", () => {
       expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
       expect(screen.queryByText(PATIENT_TERM_CAP)).not.toBeInTheDocument();
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
+      expect(screen.queryByText("Start test")).not.toBeInTheDocument();
     });
   });
+
   describe("Start test and Save and start test from edit patient", () => {
     const renderWithUser = (
       elementToRender:
@@ -704,7 +706,7 @@ describe("EditPatient", () => {
         <EditPatient
           facilityId={mockFacilityID}
           patientId={mockPatientID}
-          fromQueue={true}
+          fromQueue={false}
         />,
         store,
         mocks,
@@ -712,7 +714,6 @@ describe("EditPatient", () => {
       );
       renderWithUser(elementToRender);
       expect(await screen.findByText("Start test")).toBeInTheDocument();
-      expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
     it("Prompts user to Save and start test when edits have been made ", async () => {
       const elementToRender = createGQLWrappedMemoryRouterWithDataApis(

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -687,45 +687,27 @@ describe("EditPatient", () => {
   });
 
   describe("Start test and Save and start test from edit patient", () => {
-    const renderWithUser = (
-      elementToRender:
-        | React.ReactElement<any, string | React.JSXElementConstructor<any>>
-        | undefined
-    ) => ({
+    const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
+      <EditPatient
+        facilityId={mockFacilityID}
+        patientId={mockPatientID}
+        fromQueue={false}
+      />,
+      store,
+      mocks,
+      false
+    );
+    const renderWithUser = () => ({
       user: userEvent.setup(),
-      ...render(
-        elementToRender as React.ReactElement<
-          any,
-          string | React.JSXElementConstructor<any>
-        >
-      ),
+      ...render(elementToRender),
     });
 
     it("Prompts user to start test when no edits have been made ", async () => {
-      const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
-        <EditPatient
-          facilityId={mockFacilityID}
-          patientId={mockPatientID}
-          fromQueue={false}
-        />,
-        store,
-        mocks,
-        false
-      );
-      renderWithUser(elementToRender);
+      renderWithUser();
       expect(await screen.findByText("Start test")).toBeInTheDocument();
     });
     it("Prompts user to Save and start test when edits have been made ", async () => {
-      const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
-        <EditPatient
-          facilityId={mockFacilityID}
-          patientId={mockPatientID}
-          fromQueue={false}
-        />,
-        store,
-        mocks
-      );
-      const { user } = renderWithUser(elementToRender);
+      const { user } = renderWithUser();
       expect(await screen.findByText("Start test")).toBeInTheDocument();
       await screen.findAllByText("Franecki, Eugenia", { exact: false });
       const name = await screen.findByLabelText("First name", { exact: false });

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -684,7 +684,7 @@ describe("EditPatient", () => {
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
   });
-  describe("Start test and Save and start test from edit paitient", () => {
+  describe("Start test and Save and start test from edit patient", () => {
     const renderWithUser = (
       elementToRender:
         | React.ReactElement<any, string | React.JSXElementConstructor<any>>
@@ -710,7 +710,7 @@ describe("EditPatient", () => {
         mocks,
         false
       );
-      const { user } = renderWithUser(elementToRender);
+      renderWithUser(elementToRender);
       expect(await screen.findByText("Start test")).toBeInTheDocument();
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -684,4 +684,34 @@ describe("EditPatient", () => {
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
   });
+  describe("Start test and Save and start test from edit paitient", () => {
+    const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
+      <EditPatient facilityId={mockFacilityID} patientId={mockPatientID} />,
+      store,
+      mocks,
+      false
+    );
+    const renderWithUser = () => ({
+      user: userEvent.setup(),
+      ...render(elementToRender),
+    });
+
+    it("Prompts user to start test when no edits have been made ", async () => {
+      const { user } = renderWithUser();
+      expect(await screen.findByText("Start test")).toBeInTheDocument();
+      //expect(await screen.findByText("Save and start test")).not.toBeInTheDocument();
+    });
+    it("Prompts user to Save and start test when edits have been made ", async () => {
+      const { user } = renderWithUser();
+      await screen.findAllByText("Franecki, Eugenia", { exact: false });
+      const name = await screen.findByLabelText("First name", { exact: false });
+      //start test switches to start and save test on edit
+      await user.clear(name);
+      await user.tab();
+      //expect(await screen.findByText("Start test")).not.toBeInTheDocument();
+      expect(
+        await screen.findByText("Save and start test")
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -400,9 +400,9 @@ describe("EditPatient", () => {
               role: "UNKNOWN",
               emails: ["foo@bar.com"],
               county: null,
-              race: null,
-              ethnicity: null,
-              gender: null,
+              race: "other",
+              ethnicity: "not_hispanic",
+              gender: "male",
               genderIdentity: null,
               residentCongregateSetting: true,
               employedInHealthcare: true,
@@ -481,9 +481,9 @@ describe("EditPatient", () => {
             birthDate: "1939-10-11",
             street: "736 Jackson PI NW",
             streetTwo: "DC",
-            city: null,
+            city: "Washington, D.C.",
             state: "DC",
-            zipCode: null,
+            zipCode: 20005,
             telephone: "(270) 867-5309",
             phoneNumbers: [
               {
@@ -493,8 +493,8 @@ describe("EditPatient", () => {
             ],
             role: "UNKNOWN",
             emails: ["foo@bar.com"],
-            county: null,
-            country: null,
+            county: "DC.",
+            country: "USA",
             race: "refused",
             ethnicity: "refused",
             gender: "refused",
@@ -685,24 +685,47 @@ describe("EditPatient", () => {
     });
   });
   describe("Start test and Save and start test from edit paitient", () => {
-    const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
-      <EditPatient facilityId={mockFacilityID} patientId={mockPatientID} />,
-      store,
-      mocks,
-      false
-    );
-    const renderWithUser = () => ({
+    const renderWithUser = (
+      elementToRender:
+        | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+        | undefined
+    ) => ({
       user: userEvent.setup(),
-      ...render(elementToRender),
+      ...render(
+        elementToRender as React.ReactElement<
+          any,
+          string | React.JSXElementConstructor<any>
+        >
+      ),
     });
 
     it("Prompts user to start test when no edits have been made ", async () => {
-      const { user } = renderWithUser();
+      const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
+        <EditPatient
+          facilityId={mockFacilityID}
+          patientId={mockPatientID}
+          fromQueue={true}
+        />,
+        store,
+        mocks,
+        false
+      );
+      const { user } = renderWithUser(elementToRender);
       expect(await screen.findByText("Start test")).toBeInTheDocument();
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
     it("Prompts user to Save and start test when edits have been made ", async () => {
-      const { user } = renderWithUser();
+      const elementToRender = createGQLWrappedMemoryRouterWithDataApis(
+        <EditPatient
+          facilityId={mockFacilityID}
+          patientId={mockPatientID}
+          fromQueue={false}
+        />,
+        store,
+        mocks,
+        false
+      );
+      const { user } = renderWithUser(elementToRender);
       await screen.findAllByText("Franecki, Eugenia", { exact: false });
       const name = await screen.findByLabelText("First name", { exact: false });
       //start test switches to start and save test on edit

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -699,7 +699,7 @@ describe("EditPatient", () => {
     it("Prompts user to start test when no edits have been made ", async () => {
       const { user } = renderWithUser();
       expect(await screen.findByText("Start test")).toBeInTheDocument();
-      //expect(await screen.findByText("Save and start test")).not.toBeInTheDocument();
+      expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
     });
     it("Prompts user to Save and start test when edits have been made ", async () => {
       const { user } = renderWithUser();
@@ -708,10 +708,8 @@ describe("EditPatient", () => {
       //start test switches to start and save test on edit
       await user.clear(name);
       await user.tab();
-      //expect(await screen.findByText("Start test")).not.toBeInTheDocument();
-      expect(
-        await screen.findByText("Save and start test")
-      ).toBeInTheDocument();
+      expect(screen.queryByText("Start test")).not.toBeInTheDocument();
+      expect(screen.getByText("Save and start test")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -322,7 +322,7 @@ const EditPatient = (props: Props) => {
               onSave(true);
             }}
             variant="outline"
-            label={loading ? `${t("common.button.saving")}...` : "Start test"}
+            label={formChanged ? `${t("Save and start test")}` : "Start test"}
           />
         )}
         <button

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -275,8 +275,8 @@ const EditPatient = (props: Props) => {
 
   const getHeader = (
     person: Nullable<PersonFormData>,
-    onSave: (startTest?: boolean) => void
-    //formChanged: boolean
+    onSave: (startTest?: boolean) => void,
+    formChanged: boolean
   ) => (
     <div className="display-flex flex-justify">
       <div>
@@ -322,16 +322,12 @@ const EditPatient = (props: Props) => {
               onSave(true);
             }}
             variant="outline"
-            label={
-              loading
-                ? `${t("common.button.saving")}...`
-                : "Save and start test"
-            }
+            label={loading ? `${t("common.button.saving")}...` : "Start test"}
           />
         )}
         <button
           className="prime-save-patient-changes usa-button margin-right-0"
-          disabled={editPersonLoading}
+          disabled={editPersonLoading || !formChanged}
           onClick={() => onSave(props.fromQueue)}
         >
           {editPersonLoading

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -321,7 +321,7 @@ const EditPatient = (props: Props) => {
         </div>
       </div>
       <div className="display-flex flex-align-center">
-        {!props.fromQueue && formChanged ? (
+        {!props.fromQueue && (
           <Button
             id="edit-patient-save-upper"
             className="prime-save-patient-changes-start-test"
@@ -333,19 +333,10 @@ const EditPatient = (props: Props) => {
             label={
               loading
                 ? `${t("common.button.saving")}...`
-                : "Save and start test"
+                : formChanged
+                ? "Save and start test"
+                : "Start test"
             }
-          />
-        ) : (
-          <Button
-            id="edit-patient-save-upper"
-            className="prime-save-patient-changes-start-test"
-            disabled={loading}
-            onClick={() => {
-              onSave(true);
-            }}
-            variant="outline"
-            label={"Start test"}
           />
         )}
         <button

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -330,7 +330,11 @@ const EditPatient = (props: Props) => {
               onSave(true);
             }}
             variant="outline"
-            label={"Save and start test"}
+            label={
+              loading
+                ? `${t("common.button.saving")}...`
+                : "Save and start test"
+            }
           />
         ) : (
           <Button

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -275,8 +275,8 @@ const EditPatient = (props: Props) => {
 
   const getHeader = (
     person: Nullable<PersonFormData>,
-    onSave: (startTest?: boolean) => void,
-    formChanged: boolean
+    onSave: (startTest?: boolean) => void
+    //formChanged: boolean
   ) => (
     <div className="display-flex flex-justify">
       <div>
@@ -317,7 +317,7 @@ const EditPatient = (props: Props) => {
           <Button
             id="edit-patient-save-upper"
             className="prime-save-patient-changes-start-test"
-            disabled={loading || !formChanged}
+            disabled={loading}
             onClick={() => {
               onSave(true);
             }}
@@ -331,7 +331,7 @@ const EditPatient = (props: Props) => {
         )}
         <button
           className="prime-save-patient-changes usa-button margin-right-0"
-          disabled={editPersonLoading || !formChanged}
+          disabled={editPersonLoading}
           onClick={() => onSave(props.fromQueue)}
         >
           {editPersonLoading

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -230,10 +230,7 @@ const EditPatient = (props: Props) => {
     return <p>error loading patient with id {props.patientId}...</p>;
   }
 
-  const savePerson = async (
-    person: Nullable<PersonFormData>,
-    startTest: boolean = false
-  ) => {
+  const savePerson = async (person: Nullable<PersonFormData>) => {
     await updatePatient({
       variables: {
         patientId: props.patientId,
@@ -258,7 +255,9 @@ const EditPatient = (props: Props) => {
       "Information record has been updated.",
       `${PATIENT_TERM_CAP} record saved`
     );
+  };
 
+  const beginTest = (startTest: boolean) => {
     if (startTest) {
       const facility = data?.patient.facility?.id || activeFacilityId;
       setRedirect({
@@ -272,7 +271,16 @@ const EditPatient = (props: Props) => {
       setRedirect(personPath);
     }
   };
-
+  const saveAndStartTest = async (
+    person: Nullable<PersonFormData>,
+    formChanged: boolean,
+    startTest: boolean
+  ) => {
+    if (formChanged) {
+      await savePerson(person);
+    }
+    beginTest(startTest);
+  };
   const getHeader = (
     person: Nullable<PersonFormData>,
     onSave: (startTest?: boolean) => void,
@@ -313,7 +321,18 @@ const EditPatient = (props: Props) => {
         </div>
       </div>
       <div className="display-flex flex-align-center">
-        {!props.fromQueue && (
+        {!props.fromQueue && formChanged ? (
+          <Button
+            id="edit-patient-save-upper"
+            className="prime-save-patient-changes-start-test"
+            disabled={loading}
+            onClick={() => {
+              onSave(true);
+            }}
+            variant="outline"
+            label={formChanged ? `${t("Save and start test")}` : "Start test"}
+          />
+        ) : (
           <Button
             id="edit-patient-save-upper"
             className="prime-save-patient-changes-start-test"

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -281,6 +281,9 @@ const EditPatient = (props: Props) => {
     }
     beginTest(startTest);
   };
+
+  const saveButtonLabel = (formChanged: boolean): string =>
+    formChanged ? "Save and start test" : "Start test";
   const getHeader = (
     person: Nullable<PersonFormData>,
     onSave: (startTest?: boolean) => void,
@@ -333,9 +336,7 @@ const EditPatient = (props: Props) => {
             label={
               loading
                 ? `${t("common.button.saving")}...`
-                : formChanged
-                ? "Save and start test"
-                : "Start test"
+                : saveButtonLabel(formChanged)
             }
           />
         )}

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -273,8 +273,8 @@ const EditPatient = (props: Props) => {
   };
   const saveAndStartTest = async (
     person: Nullable<PersonFormData>,
-    formChanged: boolean,
-    startTest: boolean
+    startTest: boolean,
+    formChanged: boolean
   ) => {
     if (formChanged) {
       await savePerson(person);
@@ -330,7 +330,7 @@ const EditPatient = (props: Props) => {
               onSave(true);
             }}
             variant="outline"
-            label={formChanged ? `${t("Save and start test")}` : "Start test"}
+            label={"Save and start test"}
           />
         ) : (
           <Button
@@ -341,7 +341,7 @@ const EditPatient = (props: Props) => {
               onSave(true);
             }}
             variant="outline"
-            label={formChanged ? `${t("Save and start test")}` : "Start test"}
+            label={"Start test"}
           />
         )}
         <button
@@ -410,7 +410,7 @@ const EditPatient = (props: Props) => {
                   data.patient.street === "** Unknown / Not Given **",
               }}
               patientId={props.patientId}
-              savePerson={savePerson}
+              savePerson={saveAndStartTest}
               getHeader={getHeader}
               getFooter={getFooter}
             />


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

resolves #7641 

## Changes Proposed

In the current [`savePerson`](https://github.com/CDCgov/prime-simplereport/pull/7728/files#diff-ba8808e8d86a114dea4b6fffa4a34eadbec012817a4016e2ec2a5f1115715d83L233) function, the logic for if a test should be started for a patient on save is baked into the function. In order to make it so that the button can be used for both the option of only starting a test and the option of saving a patient + starting a test, the start test logic has been broken out from the `savePerson` function into its own `beginTest` function. 

Both `savePerson` and `beginTest` are wrapped in a wrapper function, `saveAndStartTest`, that only calls `beginTest` if no edits to the patient have been made and calls `savePerson` and `beginTest` if changes to the patient have been made. The label on the button renders following this logic as well. 

## Additional Information

The logic for save and start test as is, is quite convoluted and I did my best to massage in our updated logic. Given the scope of the ticket, It did not seem worthwhile to completely break down the current implementation and build it back up in a more modular way. ie separate `startTest` and `savePerson` into their own individual props in `personForm.tsx.` 

## Testing
**This branch is live for testing in dev2**

1. Go to the patient tab for any facility and click into any patient. 
2. When the form to edit the patient opens up the two buttons at the top right corner should be `Start test` and `Save`.
3. Click `Start test` and ensure that the button starts the test for the patient. You should also not receive any prompt telling you that the patient has been updated/saved.
4. Repeat this process but this time make an edit to the patient. The `Start test` button should switch to a button that now says `Save and start test`.
5. Click on `Save and start test`, ensure that test has started for the patient and that you have been prompted that the patient has been saved/updated.
6. Go back to patient profile and ensure that changes have persisted.
7. Run a test for the patient, and click into editing them from the testing queue. Confirm that neither of the start test buttons are there and that the save button is disabled.

*Note that if a patient's form is not completely filled out you will never receive the `Start test` prompt.
