### PR TITLE
Add org.owasp.encoder

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     implementation 'com.squareup.okio:okio:3.4.0'
     implementation 'org.springframework:spring-core:6.0.16'
 
+    // non-pinned security dependencies
+    implementation 'org.owasp.encoder:encoder:1.2'
+
     // data layer dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/gradle.lockfile
+++ b/backend/gradle.lockfile
@@ -176,6 +176,7 @@ org.json:json:20231013=compileClasspath,runtimeClasspath
 org.liquibase:liquibase-core:4.20.0=compileClasspath,runtimeClasspath
 org.openapitools:jackson-databind-nullable:0.2.6=compileClasspath,runtimeClasspath
 org.ow2.asm:asm:9.3=compileClasspath,runtimeClasspath
+org.owasp.encoder:encoder:1.2=compileClasspath,runtimeClasspath
 org.postgresql:postgresql:42.6.0=compileClasspath,runtimeClasspath
 org.projectlombok:lombok:1.18.30=compileClasspath
 org.reactivestreams:reactive-streams:1.0.4=compileClasspath,runtimeClasspath

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -75,7 +76,8 @@ public class AccountRequestController {
       return;
     }
     if (log.isInfoEnabled()) {
-      log.info("Waitlist request submitted: {}", objectMapper.writeValueAsString(request));
+      String sanitizedLog = Encode.forJava(objectMapper.writeValueAsString(request));
+      log.info("Waitlist request submitted: {}", sanitizedLog);
     }
     String subject = "New waitlist request";
     _es.send(sendGridProperties.getWaitlistRecipient(), subject, request);
@@ -157,7 +159,8 @@ public class AccountRequestController {
   private void logOrganizationAccountRequest(@RequestBody @Valid OrganizationAccountRequest request)
       throws JsonProcessingException {
     if (log.isInfoEnabled()) {
-      log.info("Account request submitted: {}", objectMapper.writeValueAsString(request));
+      String sanitizedLog = Encode.forJava(objectMapper.writeValueAsString(request));
+      log.info("Account request submitted: {}", sanitizedLog);
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
@@ -90,10 +90,14 @@ public class LiveExperianService
 
     final JsonNodeFactory factory = JsonNodeFactory.instance;
     ObjectNode requestBody = factory.objectNode();
-    requestBody.put("username", _experianProperties.getCrosscoreUsername());
-    requestBody.put("password", _experianProperties.getCrosscorePassword());
-    requestBody.put("client_id", _experianProperties.getClientId());
-    requestBody.put("client_secret", _experianProperties.getClientSecret());
+    String crosscoreUsername = _experianProperties.getCrosscoreUsername();
+    String crosscorePassword = _experianProperties.getCrosscorePassword();
+    String clientId = _experianProperties.getClientId();
+    String clientSecret = _experianProperties.getClientSecret();
+    requestBody.put("username", crosscoreUsername);
+    requestBody.put("password", crosscorePassword);
+    requestBody.put("client_id", clientId);
+    requestBody.put("client_secret", clientSecret);
 
     HttpEntity<ObjectNode> entity = new HttpEntity<>(requestBody, headers);
     int retryOn500AuthCounter = 0;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/idverification/LiveExperianService.java
@@ -21,6 +21,7 @@ import gov.cdc.usds.simplereport.service.errors.ExperianPersonMatchException;
 import gov.cdc.usds.simplereport.service.errors.ExperianSubmitAnswersException;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpEntity;
@@ -186,7 +187,7 @@ public class LiveExperianService
       boolean passed = hasPassed(responseEntity);
 
       // Generate a searchable log message so we can monitor decisions from Experian
-      String requestData = _objectMapper.writeValueAsString(answersRequest);
+      String requestData = Encode.forJava(_objectMapper.writeValueAsString(answersRequest));
       log.info("EXPERIAN_DECISION ({}): {}", passed, requestData);
 
       return new IdentityVerificationAnswersResponse(passed);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -66,6 +66,7 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.ServiceRequest;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.stereotype.Component;
@@ -382,9 +383,9 @@ public class BulkUploadResultsToFhir {
     } else {
       log.info(
           "No device found for model ("
-              + modelName
+              + Encode.forJava(modelName)
               + ") and test performed code ("
-              + testPerformedCode
+              + Encode.forJava(testPerformedCode)
               + ")");
     }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7671 

## Changes Proposed
- add `org.owasp.encoder:encoder:1.2` dependency
- call [`Encode.forJava()` ](https://javadoc.io/doc/org.owasp.encoder/encoder/latest/index.html) on user inputted data that are being saved in our logs

> Encodes for a Java string. This method will use "\b", "\t", "\r", "\f", "\n", "\"", "\'", "\\", octal and unicode escapes. Valid surrogate pairing is not checked. The caller must provide the enclosing quotation characters. This method is useful for when writing code generators and outputting debug messages.

## Additional Information
- Checked in with @alismx and @shanice-skylight who were both OK-ed this library
- Had to fix a sonarcloud issue that was incorrectly thinking I was using a [deprecated method](https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&pullRequest=7731&id=CDCgov_prime-data-input-client&open=AY-skTWJigjYpA2EQZoF&tab=more_info) so just specified the values being set as `String`s since that usage of the [`put` method](https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.9.0.pr4/com/fasterxml/jackson/databind/node/ObjectNode.html) is not deprecated

## Testing
- Available on dev6 for testing (can create a new org request using the `/account-request/organization-add-to-queue` endpoint)
- Submitted a waitlist request locally and checked the server logs


**Before**
```
Waitlist request submitted: {"name":"e","email":"e@example.com\n","phone":"(111) 111-\t1111","state":"AL","organization":"org","disease-interest":"[Flu A, Flu B]","additional-conditions":"yes additional conditions","referral":"from a friend","form-honeypot":null}
```

**After**
```
Waitlist request submitted: {\"name\":\"e\",\"email\":\"e@example.com\\n\",\"phone\":\"(111) 111-\\t1111\",\"state\":\"AL\",\"organization\":\"org\",\"disease-interest\":\"[Flu A, Flu B]\",\"additional-conditions\":\"yes additional conditions\",\"referral\":\"from a friend\",\"form-honeypot\":null}
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
