### PR TITLE
Revert "Bump hashicorp/setup-terraform from 3.0.0 to 3.1.1 (#7687)"

### DIFF
--- a/.github/workflows/terraformChecks.yml
+++ b/.github/workflows/terraformChecks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: 1.3.3
       - name: Terraform fmt
@@ -35,7 +35,7 @@ jobs:
           global
     steps:
       - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: 1.3.3
       - name: Terraform Init
@@ -72,7 +72,7 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: hashicorp/setup-terraform@v3.0.0
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           terraform_version: 1.3.3

--- a/.github/workflows/terraformPlan.yml
+++ b/.github/workflows/terraformPlan.yml
@@ -63,7 +63,7 @@ jobs:
         if: ${{ matrix.env == 'prod' || matrix.env == 'stg' || matrix.env == 'training' }}
         run: |
           echo "OKTA_API_TOKEN=${{ secrets.OKTA_API_TOKEN }}" >> "$GITHUB_ENV"
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: 1.3.3
       - name: Terraform Init


### PR DESCRIPTION
This reverts commit c5299fd423842c48d9c6e9f22829840aa270bd04.

[Production post-deploy smoke test failed here](https://skylight-hq.slack.com/archives/C01FPLGB0VD/p1716910236064559) and unable to log into production,