### PR TITLE
Add OTC CLIA to validator

### DIFF
--- a/frontend/src/app/utils/clia.test.ts
+++ b/frontend/src/app/utils/clia.test.ts
@@ -1,6 +1,16 @@
 import { isValidCLIANumber } from "./clia";
 
 describe("isValidCLIANumber::string -> boolean", () => {
+  test("valid OTC number returns `true` if state is CA", () => {
+    const otcCliaNumber = "00Z0000014";
+    const state = "CA";
+    expect(isValidCLIANumber(otcCliaNumber, state)).toBe(true);
+  });
+  test("OTC number returns `false` if state is not CA", () => {
+    const otcCliaNumber = "00Z0000014";
+    const state = "NY";
+    expect(isValidCLIANumber(otcCliaNumber, state)).toBe(false);
+  });
   test("valid number returns `true`", () => {
     const cliaNumber = "12D4567890";
     const state = "VA";

--- a/frontend/src/app/utils/clia.ts
+++ b/frontend/src/app/utils/clia.ts
@@ -9,6 +9,10 @@ export function isValidCLIANumber(input: string, state: string): boolean {
   if (state === "WA") {
     cliaNumberValidator = /^\d{2}[DZ]\d{7}$/;
   } else if (state === "CA") {
+    if (input === "00Z0000014") {
+      // OTC CLIA
+      return true;
+    }
     cliaNumberValidator = /^\w{2}D\w{1}\d{6}$/;
   } else if (state === "NM" && input.substring(0, 3) === "32Z") {
     cliaNumberValidator = /^32Z\d{7}$/;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Resolves #7727

## Changes Proposed
- For facilities in CA, allow the OTC CLIA `00Z0000014`

## Additional Information
- N/A

## Testing
- Deployed on dev6
- Add a OTC CLIA `00Z0000014` for a CA facility and see that you cannot add an OTC CLIA for a non-CA facility

## Screenshots / Demos
- N/A

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
