### PR TITLE
Add waiting delay on smoke test

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -136,6 +136,6 @@ jobs:
       - name: Trigger PagerDuty alert
         uses: ./.github/actions/pagerduty-alert
         with:
-          summary: ":siren-gif: Post-deploy smoke test for ${{ env.DEPLOY_ENV }} couldn't verify that the frontend is talking to the backend. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:"
+          summary: ":siren-gif: Post-deploy smoke test for ${{ env.DEPLOY_ENV }} could not verify that the frontend is talking to the backend. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} :siren-gif:"
           severity: critical
           routing_key: ${{ secrets.pagerduty_prod_integration_key }}

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -26,8 +26,7 @@ driver
   .to(`${appUrl}`)
   .sleep(TIMEOUT_DURATION_MS)
   .then(() => {
-    let value = driver.findElement({ id: "root" }).getText();
-    return value;
+    return driver.findElement({ id: "root" }).getText();
   })
   .then((value) => {
     driver.quit();

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -18,9 +18,13 @@ const driver = new Builder()
   .forBrowser("chrome")
   .setChromeOptions(options.addArguments("--headless=new"))
   .build();
+
+const TIMEOUT_DURATION_MS = 10 * 1000;
+
 driver
   .navigate()
   .to(`${appUrl}`)
+  .sleep(TIMEOUT_DURATION_MS)
   .then(() => {
     let value = driver.findElement({ id: "root" }).getText();
     return value;

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -24,8 +24,8 @@ const TIMEOUT_DURATION_MS = 10 * 1000;
 driver
   .navigate()
   .to(`${appUrl}`)
-  .sleep(TIMEOUT_DURATION_MS)
-  .then(() => {
+  .then(async () => {
+    driver.sleep(TIMEOUT_DURATION_MS);
     return driver.findElement({ id: "root" }).getText();
   })
   .then((value) => {

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -25,7 +25,7 @@ driver
   .navigate()
   .to(`${appUrl}`)
   .then(async () => {
-    driver.sleep(TIMEOUT_DURATION_MS);
+    await driver.sleep(TIMEOUT_DURATION_MS);
     return driver.findElement({ id: "root" }).getText();
   })
   .then((value) => {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves #7769 

## Changes Proposed

- Adds 10 second delay on the smoke test to give it plenty of time to load
- Fix possible parsing issue for the curl command call of pagerduty alert in `deployProd`

## Testing

- Tested the [workflow run here](https://github.com/CDCgov/prime-simplereport/actions/runs/9392099535)