### PR TITLE
Limit high urgency prod page to only when staging was successful

### DIFF
--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -103,7 +103,7 @@ jobs:
 
   failed_deploy_pagerduty_alert:
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.deploy.result != 'success' }}
+    if: ${{ always() && needs.deploy.result != 'success' && github.event.workflow_run.conclusion == 'success' }}
     needs: [ deploy ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- We've been getting a lot of high urgency pages when Deploy Stg fails which is happening more often than originally expected

## Changes Proposed

- Changes the requirement for a high urgency failed prod deploy PagerDuty alert to require Deploy Stg to have completed successfully
- This adds the same check that is being done in the first jobs of Deploy Prod, in `build_docker` and `build_frontend` which also both require Deploy Stg to have concluded successfully
- When Deploy Stg fails, we do already have it set up to get a [Slack alert with the high visibility siren gif](https://skylight-hq.slack.com/archives/C01FPLGB0VD/p1717782420094389) so we will still be notified of whatever the issue may be, but now without an additional high urgency page

# Additional Info
- Perhaps we could consider adding another Slack alert or low urgency page making it more visible that Deploy Stg failed and therefore Deploy Prod was skipped