### PR TITLE
Add covid only flag for resend mutation

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
@@ -27,7 +27,7 @@ public class TestResultMutationResolver {
   @MutationMapping
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public boolean resendToReportStream(
-      @Argument List<UUID> testEventIds, @Argument boolean fhirOnly) {
+      @Argument List<UUID> testEventIds, @Argument boolean fhirOnly, @Argument boolean covidOnly) {
     testEventRepository
         .findAllByInternalIdIn(testEventIds)
         .forEach(
@@ -35,7 +35,9 @@ public class TestResultMutationResolver {
               if (!fhirOnly) {
                 testEventReportingService.report(testEvent);
               }
-              fhirReportingService.report(testEvent);
+              if (!covidOnly) {
+                fhirReportingService.report(testEvent);
+              }
             });
 
     return true;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolver.java
@@ -32,10 +32,12 @@ public class TestResultMutationResolver {
         .findAllByInternalIdIn(testEventIds)
         .forEach(
             testEvent -> {
-              if (!fhirOnly) {
+              if (fhirOnly) {
+                fhirReportingService.report(testEvent);
+              } else if (covidOnly) {
                 testEventReportingService.report(testEvent);
-              }
-              if (!covidOnly) {
+              } else {
+                testEventReportingService.report(testEvent);
                 fhirReportingService.report(testEvent);
               }
             });

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -10,7 +10,7 @@ extend type Query {
   getOrgAdminUserIds(orgId: ID!): [ID]
 }
 extend type Mutation {
-  resendToReportStream(testEventIds: [ID!]!, fhirOnly: Boolean!, covidOnly: Boolean!): Boolean
+  resendToReportStream(testEventIds: [ID!]!, fhirOnly: Boolean = false, covidOnly: Boolean = false): Boolean
   createDeviceType(input: CreateDeviceType!): DeviceType
   updateDeviceType(input: UpdateDeviceType!): DeviceType
   createSpecimenType(input: CreateSpecimenType!): SpecimenType

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -10,7 +10,7 @@ extend type Query {
   getOrgAdminUserIds(orgId: ID!): [ID]
 }
 extend type Mutation {
-  resendToReportStream(testEventIds: [ID!]!, fhirOnly: Boolean!): Boolean
+  resendToReportStream(testEventIds: [ID!]!, fhirOnly: Boolean!, covidOnly: Boolean!): Boolean
   createDeviceType(input: CreateDeviceType!): DeviceType
   updateDeviceType(input: UpdateDeviceType!): DeviceType
   createSpecimenType(input: CreateSpecimenType!): SpecimenType

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/testresult/TestResultMutationResolverTest.java
@@ -30,7 +30,7 @@ class TestResultMutationResolverTest {
 
     var actual =
         testResultMutationResolver.resendToReportStream(
-            List.of(UUID.randomUUID(), UUID.randomUUID()), false);
+            List.of(UUID.randomUUID(), UUID.randomUUID()), false, false);
 
     verify(mockCsvReporter, times(2)).report(any());
     verify(mockFhirReporter, times(2)).report(any());
@@ -50,10 +50,30 @@ class TestResultMutationResolverTest {
 
     var actual =
         testResultMutationResolver.resendToReportStream(
-            List.of(UUID.randomUUID(), UUID.randomUUID()), true);
+            List.of(UUID.randomUUID(), UUID.randomUUID()), true, false);
 
     verify(mockCsvReporter, times(0)).report(any());
     verify(mockFhirReporter, times(2)).report(any());
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void resendToReportStream_covidOnly_success() {
+    var mockCsvReporter = mock(TestEventReportingService.class);
+    var mockFhirReporter = mock(TestEventReportingService.class);
+    var mockTestEventRepository = mock(TestEventRepository.class);
+
+    when(mockTestEventRepository.findAllByInternalIdIn(any()))
+        .thenReturn(List.of(createCovidTestEvent(), createMultiplexTestEvent()));
+    var testResultMutationResolver =
+        new TestResultMutationResolver(mockTestEventRepository, mockCsvReporter, mockFhirReporter);
+
+    var actual =
+        testResultMutationResolver.resendToReportStream(
+            List.of(UUID.randomUUID(), UUID.randomUUID()), false, true);
+
+    verify(mockCsvReporter, times(2)).report(any());
+    verify(mockFhirReporter, times(0)).report(any());
     assertThat(actual).isTrue();
   }
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -398,6 +398,7 @@ export type MutationResendActivationEmailArgs = {
 };
 
 export type MutationResendToReportStreamArgs = {
+  covidOnly: Scalars["Boolean"]["input"];
   fhirOnly: Scalars["Boolean"]["input"];
   testEventIds: Array<Scalars["ID"]["input"]>;
 };

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -398,8 +398,8 @@ export type MutationResendActivationEmailArgs = {
 };
 
 export type MutationResendToReportStreamArgs = {
-  covidOnly: Scalars["Boolean"]["input"];
-  fhirOnly: Scalars["Boolean"]["input"];
+  covidOnly?: InputMaybe<Scalars["Boolean"]["input"]>;
+  fhirOnly?: InputMaybe<Scalars["Boolean"]["input"]>;
   testEventIds: Array<Scalars["ID"]["input"]>;
 };
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Used for #7766 

## Changes Proposed

- Adds boolean flag to `resentToReportStream` mutation for only resending results to the covid pipeline

## Testing

- Added unit test for this case and will confirm with ReportStream once resending is complete