### PR TITLE
Add LOINC description fields on add/edit device page

### DIFF
--- a/frontend/src/app/Settings/Users/UserInfoTab.scss
+++ b/frontend/src/app/Settings/Users/UserInfoTab.scss
@@ -25,9 +25,3 @@
   color: #1b1b1b;
   margin-top: 0;
 }
-
-.userinfo-divider {
-  border-bottom: 1px solid #dcdee0;
-  margin-right: -18px;
-  margin-left: -32px;
-}

--- a/frontend/src/app/Settings/Users/UserInfoTab.tsx
+++ b/frontend/src/app/Settings/Users/UserInfoTab.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 
 import Button from "../../commonComponents/Button/Button";
 import { User } from "../../../generated/graphql";
+import SeparatorLine from "../../supportAdmin/Components/SeparatorLine";
 
 import { SettingsUser } from "./ManageUsersContainer";
 import DeleteUserModal from "./DeleteUserModal";
@@ -95,7 +96,7 @@ const UserInfoTab: React.FC<UserInfoTabProps> = ({
             disabled={isUpdating || !isUserActive}
           />
         </div>
-        <div className="userinfo-divider"></div>
+        <SeparatorLine classNames={"margin-left-neg-4 margin-right-neg-2"} />
         <h3 className="user-controls-header">User controls</h3>
         <div
           className={classnames(

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
               </button>
             </div>
             <div
-              class="userinfo-divider"
+              class="sr-separator-line margin-left-neg-4 margin-right-neg-2"
             />
             <h3
               class="user-controls-header"

--- a/frontend/src/app/supportAdmin/Components/SeparatorLine.scss
+++ b/frontend/src/app/supportAdmin/Components/SeparatorLine.scss
@@ -1,0 +1,3 @@
+.sr-separator-line {
+  border-bottom: 1px solid #dcdee0;
+}

--- a/frontend/src/app/supportAdmin/Components/SeparatorLine.tsx
+++ b/frontend/src/app/supportAdmin/Components/SeparatorLine.tsx
@@ -1,0 +1,12 @@
+import "./SeparatorLine.scss";
+import React from "react";
+import classnames from "classnames";
+
+interface Props {
+  classNames?: string;
+}
+const SeparatorLine: React.FC<Props> = ({ classNames }) => {
+  return <div className={classnames("sr-separator-line", classNames)} />;
+};
+
+export default SeparatorLine;

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -226,7 +226,7 @@ describe("update existing devices", () => {
   beforeEach(() => {
     saveDeviceType = jest.fn();
   });
-  ///start here
+
   it("renders the Device Form", () => {
     const { container } = renderWithUser();
     expect(container).toMatchSnapshot();

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.test.tsx
@@ -65,6 +65,8 @@ describe("create new device", () => {
     await user.selectOptions(screen.getByLabelText("Disease *"), "COVID-19");
     await addValue(user, "Test performed *", "1920-12");
     await addValue(user, "Test ordered *", "2102-91");
+    await addValue(user, "Test Ordered Loinc Long Name", "Test Value");
+    await addValue(user, "Test Performed Loinc Long Name", "Test Value II");
     await waitFor(() =>
       expect(
         screen.queryByText("This is a required field")
@@ -91,8 +93,15 @@ describe("create new device", () => {
         screen.getByLabelText("Equipment Uid"),
         "equipmentUid321"
       );
-
       await user.type(screen.getByLabelText("Uid Type"), "equipmentUidType123");
+      await user.type(
+        screen.getByLabelText("Test Performed Loinc Long Name"),
+        "longest loinc"
+      );
+      await user.type(
+        screen.getByLabelText("Test Ordered Loinc Long Name"),
+        "longest loinc"
+      );
     };
 
     it("enables the save button", async () => {
@@ -122,6 +131,8 @@ describe("create new device", () => {
               equipmentUid: "equipmentUid321",
               equipmentUidType: "equipmentUidType123",
               testOrderedLoincCode: "2102-91",
+              testOrderedLoincLongName: "longest loinc",
+              testPerformedLoincLongName: "longest loinc",
             },
           ],
         })
@@ -215,7 +226,7 @@ describe("update existing devices", () => {
   beforeEach(() => {
     saveDeviceType = jest.fn();
   });
-
+  ///start here
   it("renders the Device Form", () => {
     const { container } = renderWithUser();
     expect(container).toMatchSnapshot();
@@ -447,6 +458,16 @@ describe("update existing devices", () => {
           "equipmentUidType123"
         );
 
+        await user.type(
+          screen.getAllByLabelText("Test Ordered Loinc Long Name")[1],
+          "longLoinc123"
+        );
+
+        await user.type(
+          screen.getAllByLabelText("Test Performed Loinc Long Name")[1],
+          "longLoinc123"
+        );
+
         await user.click(screen.getByText("Save changes"));
 
         await waitFor(() =>
@@ -473,6 +494,8 @@ describe("update existing devices", () => {
                 equipmentUid: "equipmentUid321",
                 equipmentUidType: "equipmentUidType123",
                 testkitNameId: "testkitNameId123",
+                testOrderedLoincLongName: "longLoinc123",
+                testPerformedLoincLongName: "longLoinc123",
               },
             ],
           })

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -17,7 +17,6 @@ export type SupportedDiseasesFormData = {
   equipmentUidType?: string;
   supportedDisease: string;
   testPerformedLoincCode: string;
-  ///testOrdered is marked as required on UI input
   testOrderedLoincCode?: string;
   testkitNameId?: string;
   testOrderedLoincLongName?: string;

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -126,6 +126,7 @@ const DeviceForm = (props: Props) => {
     UpdateDeviceType | undefined
   >();
 
+  //wtf is this logic? 😭
   const loadingDeviceData = !!props.deviceOptions && !selectedDevice;
 
   useEffect(() => {

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -108,6 +108,16 @@ const DeviceForm = (props: Props) => {
             convertedSupportedDisease["testOrderedLoincCode"] =
               supportedDisease.testOrderedLoincCode;
           }
+          if (supportedDisease.testOrderedLoincLongName) {
+            // @ts-ignore
+            convertedSupportedDisease["testOrderedLoincLongName"] =
+              supportedDisease.testOrderedLoincLongName;
+          }
+          if (supportedDisease.testPreformedLoincLongName) {
+            // @ts-ignore
+            convertedSupportedDisease["testPreformedLoincLongName"] =
+              supportedDisease.testPreformedLoincLongName;
+          }
           return convertedSupportedDisease;
         }
       ),

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -83,37 +83,31 @@ const DeviceForm = (props: Props) => {
       name: deviceData.name,
       supportedDiseaseTestPerformed: deviceData.supportedDiseases.map(
         (supportedDisease: SupportedDiseasesFormData) => {
-          const convertedSupportedDisease = {
+          const convertedSupportedDisease: SupportedDiseasesFormData = {
             supportedDisease: supportedDisease.supportedDisease,
             testPerformedLoincCode: supportedDisease.testPerformedLoincCode,
           };
           if (supportedDisease.equipmentUid) {
-            // @ts-ignore
             convertedSupportedDisease["equipmentUid"] =
               supportedDisease.equipmentUid;
           }
           if (supportedDisease.equipmentUidType) {
-            // @ts-ignore
             convertedSupportedDisease["equipmentUidType"] =
               supportedDisease.equipmentUidType;
           }
           if (supportedDisease.testkitNameId) {
-            // @ts-ignore
             convertedSupportedDisease["testkitNameId"] =
               supportedDisease.testkitNameId;
           }
           if (supportedDisease.testOrderedLoincCode) {
-            // @ts-ignore
             convertedSupportedDisease["testOrderedLoincCode"] =
               supportedDisease.testOrderedLoincCode;
           }
           if (supportedDisease.testOrderedLoincLongName) {
-            // @ts-ignore
             convertedSupportedDisease["testOrderedLoincLongName"] =
               supportedDisease.testOrderedLoincLongName;
           }
           if (supportedDisease.testPerformedLoincLongName) {
-            // @ts-ignore
             convertedSupportedDisease["testPerformedLoincLongName"] =
               supportedDisease.testPerformedLoincLongName;
           }

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -21,7 +21,7 @@ export type SupportedDiseasesFormData = {
   testOrderedLoincCode?: string;
   testkitNameId?: string;
   testOrderedLoincLongName?: string;
-  testPreformedLoincLongName?: string;
+  testPerformedLoincLongName?: string;
 };
 
 export type DeviceFormData = {
@@ -113,10 +113,10 @@ const DeviceForm = (props: Props) => {
             convertedSupportedDisease["testOrderedLoincLongName"] =
               supportedDisease.testOrderedLoincLongName;
           }
-          if (supportedDisease.testPreformedLoincLongName) {
+          if (supportedDisease.testPerformedLoincLongName) {
             // @ts-ignore
-            convertedSupportedDisease["testPreformedLoincLongName"] =
-              supportedDisease.testPreformedLoincLongName;
+            convertedSupportedDisease["testPerformedLoincLongName"] =
+              supportedDisease.testPerformedLoincLongName;
           }
           return convertedSupportedDisease;
         }
@@ -136,7 +136,6 @@ const DeviceForm = (props: Props) => {
     UpdateDeviceType | undefined
   >();
 
-  //wtf is this logic? 😭
   const loadingDeviceData = !!props.deviceOptions && !selectedDevice;
 
   useEffect(() => {
@@ -184,6 +183,10 @@ const DeviceForm = (props: Props) => {
                 equipmentUid: diseaseTestPerformed.equipmentUid,
                 equipmentUidType: diseaseTestPerformed.equipmentUidType,
                 testOrderedLoincCode: diseaseTestPerformed.testOrderedLoincCode,
+                testPerformedLoincLongName:
+                  diseaseTestPerformed.testPerformedLoincLongName,
+                testOrderedLoincLongName:
+                  diseaseTestPerformed.testOrderedLoincLongName,
               })
             ),
         }

--- a/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DeviceForm.tsx
@@ -17,8 +17,11 @@ export type SupportedDiseasesFormData = {
   equipmentUidType?: string;
   supportedDisease: string;
   testPerformedLoincCode: string;
+  ///testOrdered is marked as required on UI input
   testOrderedLoincCode?: string;
   testkitNameId?: string;
+  testOrderedLoincLongName?: string;
+  testPreformedLoincLongName?: string;
 };
 
 export type DeviceFormData = {

--- a/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
@@ -148,6 +148,30 @@ const DiseaseInformation = ({
             )}
           />
         </div>
+        <div className="tablet:grid-col">
+          <TextInput
+            name={`supportedDiseases.${index}.testPerformedLoincLongName`}
+            label="Test perfromed loinc long name"
+            disabled={disabled}
+            className={"margin-top-1"}
+            value={values?.[index]?.testPreformedLoincLongName}
+            registrationProps={register(
+              `supportedDiseases.${index}.testPerformedLoincLongName` as const
+            )}
+          />
+        </div>
+        <div className="tablet:grid-col">
+          <TextInput
+            name={`supportedDiseases.${index}.testOrderedLoincLongName`}
+            label="Test ordered loinc long name"
+            disabled={disabled}
+            className={"margin-top-1"}
+            value={values?.[index]?.testOrderedLoincLongName}
+            registrationProps={register(
+              `supportedDiseases.${index}.testOrderedLoincLongName` as const
+            )}
+          />
+        </div>
         <div className="flex-align-self-end">
           {index > 0 ? (
             <button
@@ -187,6 +211,8 @@ const DiseaseInformation = ({
                 equipmentUid: "",
                 testkitNameId: "",
                 testOrderedLoincCode: "",
+                testOrderedLoincLongName: "",
+                testPreformedLoincLongName: "",
               });
             }}
             variant="unstyled"

--- a/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
@@ -151,7 +151,7 @@ const DiseaseInformation = ({
         <div className="tablet:grid-col">
           <TextInput
             name={`supportedDiseases.${index}.testOrderedLoincLongName`}
-            label="Test ordered loinc long name"
+            label="Test Ordered Loinc Long Name"
             disabled={disabled}
             className={"margin-top-1"}
             value={values?.[index]?.testOrderedLoincLongName}
@@ -164,7 +164,7 @@ const DiseaseInformation = ({
         <div className="tablet:grid-col">
           <TextInput
             name={`supportedDiseases.${index}.testPerformedLoincLongName`}
-            label="Test perfromed loinc long name"
+            label="Test Performed Loinc Long Name"
             disabled={disabled}
             className={"margin-top-1"}
             value={values?.[index]?.testPerformedLoincLongName}

--- a/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Control,
   FieldErrors,
@@ -9,6 +8,7 @@ import {
 
 import Button from "../../commonComponents/Button/Button";
 import Select from "../../commonComponents/Select";
+import SeparatorLine from "../Components/SeparatorLine";
 import TextInput from "../../commonComponents/TextInput";
 
 import { DeviceFormData, SupportedDiseasesFormData } from "./DeviceForm";
@@ -43,151 +43,154 @@ const DiseaseInformation = ({
    */
   const createSupportedDiseaseRow = (field: any, index: number) => {
     return (
-      <div className="grid-row grid-gap" key={index}>
-        <div className="tablet:grid-col">
-          <Select
-            label={"Disease"}
-            options={supportedDiseaseOptions}
-            disabled={disabled}
-            required
-            value={values?.[index]?.supportedDisease}
-            defaultOption={""}
-            defaultSelect={true}
-            className={"margin-top-1"}
-            validationStatus={
-              errors?.supportedDiseases?.[index]?.supportedDisease?.type
-                ? "error"
-                : undefined
-            }
-            errorMessage="This is a required field"
-            registrationProps={register(
-              `supportedDiseases.${index}.supportedDisease` as const,
-              {
-                required: true,
+      <div key={index}>
+        <div className="grid-row grid-gap">
+          <div className="tablet:grid-col">
+            <Select
+              label={"Disease"}
+              options={supportedDiseaseOptions}
+              disabled={disabled}
+              required
+              value={values?.[index]?.supportedDisease}
+              defaultOption={""}
+              defaultSelect={true}
+              className={"margin-top-1"}
+              validationStatus={
+                errors?.supportedDiseases?.[index]?.supportedDisease?.type
+                  ? "error"
+                  : undefined
               }
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.testPerformedLoincCode`}
-            label="Test performed"
-            disabled={disabled}
-            required
-            className={"margin-top-1"}
-            value={values?.[index]?.testPerformedLoincCode}
-            validationStatus={
-              errors?.supportedDiseases?.[index]?.testPerformedLoincCode?.type
-                ? "error"
-                : undefined
-            }
-            errorMessage="This is a required field"
-            registrationProps={register(
-              `supportedDiseases.${index}.testPerformedLoincCode` as const,
-              {
-                required: true,
+              errorMessage="This is a required field"
+              registrationProps={register(
+                `supportedDiseases.${index}.supportedDisease` as const,
+                {
+                  required: true,
+                }
+              )}
+            />
+          </div>
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.testPerformedLoincCode`}
+              label="Test performed"
+              disabled={disabled}
+              required
+              className={"margin-top-1"}
+              value={values?.[index]?.testPerformedLoincCode}
+              validationStatus={
+                errors?.supportedDiseases?.[index]?.testPerformedLoincCode?.type
+                  ? "error"
+                  : undefined
               }
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.testOrderedLoincCode`}
-            label="Test ordered"
-            disabled={disabled}
-            required
-            className={"margin-top-1"}
-            value={values?.[index]?.testOrderedLoincCode}
-            validationStatus={
-              errors?.supportedDiseases?.[index]?.testOrderedLoincCode?.type
-                ? "error"
-                : undefined
-            }
-            errorMessage="This is a required field"
-            registrationProps={register(
-              `supportedDiseases.${index}.testOrderedLoincCode` as const,
-              {
-                required: true,
+              errorMessage="This is a required field"
+              registrationProps={register(
+                `supportedDiseases.${index}.testPerformedLoincCode` as const,
+                {
+                  required: true,
+                }
+              )}
+            />
+          </div>
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.testOrderedLoincCode`}
+              label="Test ordered"
+              disabled={disabled}
+              required
+              className={"margin-top-1"}
+              value={values?.[index]?.testOrderedLoincCode}
+              validationStatus={
+                errors?.supportedDiseases?.[index]?.testOrderedLoincCode?.type
+                  ? "error"
+                  : undefined
               }
-            )}
-          />
+              errorMessage="This is a required field"
+              registrationProps={register(
+                `supportedDiseases.${index}.testOrderedLoincCode` as const,
+                {
+                  required: true,
+                }
+              )}
+            />
+          </div>
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.testkitNameId`}
+              label="Testkit Name Id"
+              disabled={disabled}
+              className={"margin-top-1"}
+              value={values?.[index]?.testkitNameId}
+              registrationProps={register(
+                `supportedDiseases.${index}.testkitNameId` as const
+              )}
+            />
+          </div>
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.equipmentUid`}
+              label="Equipment Uid"
+              disabled={disabled}
+              className={"margin-top-1"}
+              value={values?.[index]?.equipmentUid}
+              registrationProps={register(
+                `supportedDiseases.${index}.equipmentUid` as const
+              )}
+            />
+          </div>
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.equipmentUidType`}
+              label="Uid Type"
+              disabled={disabled}
+              className={"margin-top-1"}
+              value={values?.[index]?.equipmentUidType}
+              registrationProps={register(
+                `supportedDiseases.${index}.equipmentUidType` as const
+              )}
+            />
+          </div>
         </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.testkitNameId`}
-            label="Testkit Name Id"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.testkitNameId}
-            registrationProps={register(
-              `supportedDiseases.${index}.testkitNameId` as const
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.equipmentUid`}
-            label="Equipment Uid"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.equipmentUid}
-            registrationProps={register(
-              `supportedDiseases.${index}.equipmentUid` as const
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.equipmentUidType`}
-            label="Uid Type"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.equipmentUidType}
-            registrationProps={register(
-              `supportedDiseases.${index}.equipmentUidType` as const
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.testOrderedLoincLongName`}
-            label="Test Ordered Loinc Long Name"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.testOrderedLoincLongName}
-            registrationProps={register(
-              `supportedDiseases.${index}.testOrderedLoincLongName` as const
-            )}
-          />
-        </div>
+        <div className="grid-row grid-gap">
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.testOrderedLoincLongName`}
+              label="Test Ordered Loinc Long Name"
+              disabled={disabled}
+              className={"margin-top-1"}
+              value={values?.[index]?.testOrderedLoincLongName}
+              registrationProps={register(
+                `supportedDiseases.${index}.testOrderedLoincLongName` as const
+              )}
+            />
+          </div>
 
-        <div className="tablet:grid-col">
-          <TextInput
-            name={`supportedDiseases.${index}.testPerformedLoincLongName`}
-            label="Test Performed Loinc Long Name"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.testPerformedLoincLongName}
-            registrationProps={register(
-              `supportedDiseases.${index}.testPerformedLoincLongName` as const
-            )}
-          />
+          <div className="tablet:grid-col">
+            <TextInput
+              name={`supportedDiseases.${index}.testPerformedLoincLongName`}
+              label="Test Performed Loinc Long Name"
+              disabled={disabled}
+              className={"margin-top-1"}
+              value={values?.[index]?.testPerformedLoincLongName}
+              registrationProps={register(
+                `supportedDiseases.${index}.testPerformedLoincLongName` as const
+              )}
+            />
+          </div>
         </div>
-        <div className="flex-align-self-end">
-          {index > 0 ? (
-            <button
-              className="usa-button--unstyled padding-105 height-5 cursor-pointer"
+        <div className="grid-row">
+          {index > 0 && (
+            <Button
+              label={"Delete disease"}
+              ariaLabel={`Delete disease`}
+              className={"margin-top-1"}
+              variant={"secondary"}
               onClick={() => {
                 remove(index);
               }}
-              aria-label={`Delete disease`}
-            >
-              <FontAwesomeIcon icon={"trash"} className={"text-error"} />
-            </button>
-          ) : (
-            <div className={"padding-205 height-5"}></div>
+            />
           )}
         </div>
+        <SeparatorLine classNames={"margin-top-2 margin-bottom-2"} />
       </div>
     );
   };

--- a/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
@@ -167,7 +167,7 @@ const DiseaseInformation = ({
             label="Test perfromed loinc long name"
             disabled={disabled}
             className={"margin-top-1"}
-            value={values?.[index]?.testPreformedLoincLongName}
+            value={values?.[index]?.testPerformedLoincLongName}
             registrationProps={register(
               `supportedDiseases.${index}.testPerformedLoincLongName` as const
             )}
@@ -213,7 +213,7 @@ const DiseaseInformation = ({
                 testkitNameId: "",
                 testOrderedLoincCode: "",
                 testOrderedLoincLongName: "",
-                testPreformedLoincLongName: "",
+                testPerformedLoincLongName: "",
               });
             }}
             variant="unstyled"

--- a/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
+++ b/frontend/src/app/supportAdmin/DeviceType/DiseaseInformation.tsx
@@ -150,18 +150,6 @@ const DiseaseInformation = ({
         </div>
         <div className="tablet:grid-col">
           <TextInput
-            name={`supportedDiseases.${index}.testPerformedLoincLongName`}
-            label="Test perfromed loinc long name"
-            disabled={disabled}
-            className={"margin-top-1"}
-            value={values?.[index]?.testPreformedLoincLongName}
-            registrationProps={register(
-              `supportedDiseases.${index}.testPerformedLoincLongName` as const
-            )}
-          />
-        </div>
-        <div className="tablet:grid-col">
-          <TextInput
             name={`supportedDiseases.${index}.testOrderedLoincLongName`}
             label="Test ordered loinc long name"
             disabled={disabled}
@@ -169,6 +157,19 @@ const DiseaseInformation = ({
             value={values?.[index]?.testOrderedLoincLongName}
             registrationProps={register(
               `supportedDiseases.${index}.testOrderedLoincLongName` as const
+            )}
+          />
+        </div>
+
+        <div className="tablet:grid-col">
+          <TextInput
+            name={`supportedDiseases.${index}.testPerformedLoincLongName`}
+            label="Test perfromed loinc long name"
+            disabled={disabled}
+            className={"margin-top-1"}
+            value={values?.[index]?.testPreformedLoincLongName}
+            registrationProps={register(
+              `supportedDiseases.${index}.testPerformedLoincLongName` as const
             )}
           />
         </div>

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -555,248 +555,253 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <legend>
                     Disease Information
                   </legend>
-                  <div
-                    class="grid-row grid-gap"
-                  >
+                  <div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group prime-dropdown  margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="58"
+                        <div
+                          class="usa-form-group prime-dropdown  margin-top-1"
                         >
-                          Disease
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="58"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <select
-                          aria-required="true"
-                          class="usa-select"
-                          disabled=""
-                          id="58"
-                          name="supportedDiseases.0.supportedDisease"
+                            Disease
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <select
+                            aria-required="true"
+                            class="usa-select"
+                            disabled=""
+                            id="58"
+                            name="supportedDiseases.0.supportedDisease"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              aria-selected="false"
+                              value="177cfdfa-1ce5-404f-bd39-5492f87868f4"
+                            >
+                              COVID-19
+                            </option>
+                            <option
+                              aria-selected="false"
+                              value="e286f2a8-38e2-445b-80a5-c16507a96b66"
+                            >
+                              Flu A
+                            </option>
+                            <option
+                              aria-selected="false"
+                              value="14924488-268f-47db-bea6-aa706971a098"
+                            >
+                              Flu B
+                            </option>
+                          </select>
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          <option
+                          <label
+                            class="usa-label"
+                            for="59"
+                          >
+                            Test performed
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="true"
+                            class="usa-input"
+                            disabled=""
+                            id="59"
+                            name="supportedDiseases.0.testPerformedLoincCode"
+                            type="text"
                             value=""
                           />
-                          <option
-                            aria-selected="false"
-                            value="177cfdfa-1ce5-404f-bd39-5492f87868f4"
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="60"
                           >
-                            COVID-19
-                          </option>
-                          <option
-                            aria-selected="false"
-                            value="e286f2a8-38e2-445b-80a5-c16507a96b66"
+                            Test ordered
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="true"
+                            class="usa-input"
+                            disabled=""
+                            id="60"
+                            name="supportedDiseases.0.testOrderedLoincCode"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="61"
                           >
-                            Flu A
-                          </option>
-                          <option
-                            aria-selected="false"
-                            value="14924488-268f-47db-bea6-aa706971a098"
+                            Testkit Name Id
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="61"
+                            name="supportedDiseases.0.testkitNameId"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="62"
                           >
-                            Flu B
-                          </option>
-                        </select>
+                            Equipment Uid
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="62"
+                            name="supportedDiseases.0.equipmentUid"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="59"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test performed
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="63"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="true"
-                          class="usa-input"
-                          disabled=""
-                          id="59"
-                          name="supportedDiseases.0.testPerformedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Uid Type
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="63"
+                            name="supportedDiseases.0.equipmentUidType"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="60"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test ordered
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="64"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="true"
-                          class="usa-input"
-                          disabled=""
-                          id="60"
-                          name="supportedDiseases.0.testOrderedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Test Ordered Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="64"
+                            name="supportedDiseases.0.testOrderedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="61"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Testkit Name Id
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="61"
-                          name="supportedDiseases.0.testkitNameId"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="65"
+                          >
+                            Test Performed Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="65"
+                            name="supportedDiseases.0.testPerformedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="62"
-                        >
-                          Equipment Uid
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="62"
-                          name="supportedDiseases.0.equipmentUid"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                      class="grid-row"
+                    />
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="63"
-                        >
-                          Uid Type
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="63"
-                          name="supportedDiseases.0.equipmentUidType"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="64"
-                        >
-                          Test Ordered Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="64"
-                          name="supportedDiseases.0.testOrderedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="65"
-                        >
-                          Test Performed Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="65"
-                          name="supportedDiseases.0.testPerformedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="flex-align-self-end"
-                    >
-                      <div
-                        class="padding-205 height-5"
-                      />
-                    </div>
+                      class="sr-separator-line margin-top-2 margin-bottom-2"
+                    />
                   </div>
                 </fieldset>
                 <div

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceForm.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                 >
                   <label
                     class="usa-label"
-                    for="45"
+                    for="53"
                   >
                     Device Name
                     <abbr
@@ -308,7 +308,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                     aria-required="true"
                     class="usa-input"
                     disabled=""
-                    id="45"
+                    id="53"
                     name="name"
                     type="text"
                     value=""
@@ -327,7 +327,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                 >
                   <label
                     class="usa-label"
-                    for="46"
+                    for="54"
                   >
                     Model
                     <abbr
@@ -343,7 +343,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                     aria-required="true"
                     class="usa-input"
                     disabled=""
-                    id="46"
+                    id="54"
                     name="model"
                     type="text"
                     value=""
@@ -362,7 +362,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                 >
                   <label
                     class="usa-label"
-                    for="47"
+                    for="55"
                   >
                     Manufacturer
                     <abbr
@@ -378,7 +378,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                     aria-required="true"
                     class="usa-input"
                     disabled=""
-                    id="47"
+                    id="55"
                     name="manufacturer"
                     type="text"
                     value=""
@@ -397,7 +397,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                 >
                   <label
                     class="usa-label"
-                    for="48"
+                    for="56"
                   >
                     Test length (minutes)
                     <abbr
@@ -413,7 +413,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                     aria-required="true"
                     class="usa-input"
                     disabled=""
-                    id="48"
+                    id="56"
                     name="testLength"
                     type="number"
                     value=""
@@ -432,8 +432,8 @@ exports[`update existing devices renders the Device Form 1`] = `
                 >
                   <label
                     class="usa-label"
-                    for="49"
-                    id="label-for-49"
+                    for="57"
+                    id="label-for-57"
                   >
                     SNOMED code for swab type(s)
                     <abbr
@@ -447,13 +447,13 @@ exports[`update existing devices renders the Device Form 1`] = `
                   <div
                     class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                     data-testid="multi-select"
-                    id="49"
+                    id="57"
                   >
                     <input
                       aria-controls="multi-select-swabTypes-list"
                       aria-expanded="false"
                       aria-invalid="false"
-                      aria-labelledby="label-for-49"
+                      aria-labelledby="label-for-57"
                       aria-owns="multi-select-swabTypes-list"
                       aria-required="true"
                       autocapitalize="off"
@@ -566,7 +566,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="50"
+                          for="58"
                         >
                           Disease
                           <abbr
@@ -581,7 +581,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="true"
                           class="usa-select"
                           disabled=""
-                          id="50"
+                          id="58"
                           name="supportedDiseases.0.supportedDisease"
                         >
                           <option
@@ -616,7 +616,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="51"
+                          for="59"
                         >
                           Test performed
                           <abbr
@@ -632,7 +632,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="true"
                           class="usa-input"
                           disabled=""
-                          id="51"
+                          id="59"
                           name="supportedDiseases.0.testPerformedLoincCode"
                           type="text"
                           value=""
@@ -647,7 +647,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="52"
+                          for="60"
                         >
                           Test ordered
                           <abbr
@@ -663,7 +663,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="true"
                           class="usa-input"
                           disabled=""
-                          id="52"
+                          id="60"
                           name="supportedDiseases.0.testOrderedLoincCode"
                           type="text"
                           value=""
@@ -678,7 +678,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="53"
+                          for="61"
                         >
                           Testkit Name Id
                         </label>
@@ -687,7 +687,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="false"
                           class="usa-input"
                           disabled=""
-                          id="53"
+                          id="61"
                           name="supportedDiseases.0.testkitNameId"
                           type="text"
                           value=""
@@ -702,7 +702,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="54"
+                          for="62"
                         >
                           Equipment Uid
                         </label>
@@ -711,7 +711,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="false"
                           class="usa-input"
                           disabled=""
-                          id="54"
+                          id="62"
                           name="supportedDiseases.0.equipmentUid"
                           type="text"
                           value=""
@@ -726,7 +726,7 @@ exports[`update existing devices renders the Device Form 1`] = `
                       >
                         <label
                           class="usa-label"
-                          for="55"
+                          for="63"
                         >
                           Uid Type
                         </label>
@@ -735,8 +735,56 @@ exports[`update existing devices renders the Device Form 1`] = `
                           aria-required="false"
                           class="usa-input"
                           disabled=""
-                          id="55"
+                          id="63"
                           name="supportedDiseases.0.equipmentUidType"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="64"
+                        >
+                          Test Ordered Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="true"
+                          aria-required="false"
+                          class="usa-input"
+                          disabled=""
+                          id="64"
+                          name="supportedDiseases.0.testOrderedLoincLongName"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="65"
+                        >
+                          Test Performed Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="true"
+                          aria-required="false"
+                          class="usa-input"
+                          disabled=""
+                          id="65"
+                          name="supportedDiseases.0.testPerformedLoincLongName"
                           type="text"
                           value=""
                         />

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -492,6 +492,52 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                       </div>
                     </div>
                     <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="12"
+                        >
+                          Test Ordered Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="false"
+                          aria-required="false"
+                          class="usa-input"
+                          id="12"
+                          name="supportedDiseases.0.testOrderedLoincLongName"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="13"
+                        >
+                          Test Performed Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="false"
+                          aria-required="false"
+                          class="usa-input"
+                          id="13"
+                          name="supportedDiseases.0.testPerformedLoincLongName"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
                       class="flex-align-self-end"
                     >
                       <div

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/DeviceTypeFormContainer.test.tsx.snap
@@ -322,228 +322,233 @@ exports[`DeviceTypeFormContainer should render the device type form 1`] = `
                   <legend>
                     Disease Information
                   </legend>
-                  <div
-                    class="grid-row grid-gap"
-                  >
+                  <div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group prime-dropdown  margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="6"
+                        <div
+                          class="usa-form-group prime-dropdown  margin-top-1"
                         >
-                          Disease
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="6"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <select
-                          aria-required="true"
-                          class="usa-select"
-                          id="6"
-                          name="supportedDiseases.0.supportedDisease"
+                            Disease
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <select
+                            aria-required="true"
+                            class="usa-select"
+                            id="6"
+                            name="supportedDiseases.0.supportedDisease"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              aria-selected="false"
+                              value="294729"
+                            >
+                              COVID-19
+                            </option>
+                          </select>
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          <option
+                          <label
+                            class="usa-label"
+                            for="7"
+                          >
+                            Test performed
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="true"
+                            class="usa-input"
+                            id="7"
+                            name="supportedDiseases.0.testPerformedLoincCode"
+                            type="text"
                             value=""
                           />
-                          <option
-                            aria-selected="false"
-                            value="294729"
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="8"
                           >
-                            COVID-19
-                          </option>
-                        </select>
+                            Test ordered
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="true"
+                            class="usa-input"
+                            id="8"
+                            name="supportedDiseases.0.testOrderedLoincCode"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="7"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test performed
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="9"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="true"
-                          class="usa-input"
-                          id="7"
-                          name="supportedDiseases.0.testPerformedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Testkit Name Id
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="false"
+                            class="usa-input"
+                            id="9"
+                            name="supportedDiseases.0.testkitNameId"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="8"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test ordered
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="10"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="true"
-                          class="usa-input"
-                          id="8"
-                          name="supportedDiseases.0.testOrderedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Equipment Uid
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="false"
+                            class="usa-input"
+                            id="10"
+                            name="supportedDiseases.0.equipmentUid"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="9"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Testkit Name Id
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="false"
-                          class="usa-input"
-                          id="9"
-                          name="supportedDiseases.0.testkitNameId"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="11"
+                          >
+                            Uid Type
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="false"
+                            class="usa-input"
+                            id="11"
+                            name="supportedDiseases.0.equipmentUidType"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="10"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Equipment Uid
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="false"
-                          class="usa-input"
-                          id="10"
-                          name="supportedDiseases.0.equipmentUid"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="12"
+                          >
+                            Test Ordered Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="false"
+                            class="usa-input"
+                            id="12"
+                            name="supportedDiseases.0.testOrderedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="11"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Uid Type
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="false"
-                          class="usa-input"
-                          id="11"
-                          name="supportedDiseases.0.equipmentUidType"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="13"
+                          >
+                            Test Performed Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="false"
+                            aria-required="false"
+                            class="usa-input"
+                            id="13"
+                            name="supportedDiseases.0.testPerformedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="12"
-                        >
-                          Test Ordered Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="false"
-                          class="usa-input"
-                          id="12"
-                          name="supportedDiseases.0.testOrderedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                      class="grid-row"
+                    />
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="13"
-                        >
-                          Test Performed Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="false"
-                          aria-required="false"
-                          class="usa-input"
-                          id="13"
-                          name="supportedDiseases.0.testPerformedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="flex-align-self-end"
-                    >
-                      <div
-                        class="padding-205 height-5"
-                      />
-                    </div>
+                      class="sr-separator-line margin-top-2 margin-bottom-2"
+                    />
                   </div>
                 </fieldset>
                 <div

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -699,6 +699,54 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                       </div>
                     </div>
                     <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="12"
+                        >
+                          Test Ordered Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="true"
+                          aria-required="false"
+                          class="usa-input"
+                          disabled=""
+                          id="12"
+                          name="supportedDiseases.0.testOrderedLoincLongName"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="tablet:grid-col"
+                    >
+                      <div
+                        class="usa-form-group margin-top-1"
+                      >
+                        <label
+                          class="usa-label"
+                          for="13"
+                        >
+                          Test Performed Loinc Long Name
+                        </label>
+                        <input
+                          aria-disabled="true"
+                          aria-required="false"
+                          class="usa-input"
+                          disabled=""
+                          id="13"
+                          name="supportedDiseases.0.testPerformedLoincLongName"
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
                       class="flex-align-self-end"
                     >
                       <div

--- a/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/DeviceType/__snapshots__/ManageDeviceTypeFormContainer.test.tsx.snap
@@ -517,242 +517,247 @@ exports[`ManageDeviceTypeFormContainer renders the Manage Device Type Form Conta
                   <legend>
                     Disease Information
                   </legend>
-                  <div
-                    class="grid-row grid-gap"
-                  >
+                  <div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group prime-dropdown  margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="6"
+                        <div
+                          class="usa-form-group prime-dropdown  margin-top-1"
                         >
-                          Disease
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="6"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <select
-                          aria-required="true"
-                          class="usa-select"
-                          disabled=""
-                          id="6"
-                          name="supportedDiseases.0.supportedDisease"
+                            Disease
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <select
+                            aria-required="true"
+                            class="usa-select"
+                            disabled=""
+                            id="6"
+                            name="supportedDiseases.0.supportedDisease"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              aria-selected="false"
+                              value="294729"
+                            >
+                              COVID-19
+                            </option>
+                            <option
+                              aria-selected="false"
+                              value="123-456"
+                            >
+                              Flu A
+                            </option>
+                          </select>
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          <option
+                          <label
+                            class="usa-label"
+                            for="7"
+                          >
+                            Test performed
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="true"
+                            class="usa-input"
+                            disabled=""
+                            id="7"
+                            name="supportedDiseases.0.testPerformedLoincCode"
+                            type="text"
                             value=""
                           />
-                          <option
-                            aria-selected="false"
-                            value="294729"
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="8"
                           >
-                            COVID-19
-                          </option>
-                          <option
-                            aria-selected="false"
-                            value="123-456"
+                            Test ordered
+                            <abbr
+                              class="usa-hint usa-hint--required"
+                              title="required"
+                            >
+                               
+                              *
+                            </abbr>
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="true"
+                            class="usa-input"
+                            disabled=""
+                            id="8"
+                            name="supportedDiseases.0.testOrderedLoincCode"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="tablet:grid-col"
+                      >
+                        <div
+                          class="usa-form-group margin-top-1"
+                        >
+                          <label
+                            class="usa-label"
+                            for="9"
                           >
-                            Flu A
-                          </option>
-                        </select>
+                            Testkit Name Id
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="9"
+                            name="supportedDiseases.0.testkitNameId"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="7"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test performed
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="10"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="true"
-                          class="usa-input"
-                          disabled=""
-                          id="7"
-                          name="supportedDiseases.0.testPerformedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Equipment Uid
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="10"
+                            name="supportedDiseases.0.equipmentUid"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="8"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Test ordered
-                          <abbr
-                            class="usa-hint usa-hint--required"
-                            title="required"
+                          <label
+                            class="usa-label"
+                            for="11"
                           >
-                             
-                            *
-                          </abbr>
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="true"
-                          class="usa-input"
-                          disabled=""
-                          id="8"
-                          name="supportedDiseases.0.testOrderedLoincCode"
-                          type="text"
-                          value=""
-                        />
+                            Uid Type
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="11"
+                            name="supportedDiseases.0.equipmentUidType"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
+                      class="grid-row grid-gap"
                     >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="9"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Testkit Name Id
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="9"
-                          name="supportedDiseases.0.testkitNameId"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="12"
+                          >
+                            Test Ordered Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="12"
+                            name="supportedDiseases.0.testOrderedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
                       <div
-                        class="usa-form-group margin-top-1"
+                        class="tablet:grid-col"
                       >
-                        <label
-                          class="usa-label"
-                          for="10"
+                        <div
+                          class="usa-form-group margin-top-1"
                         >
-                          Equipment Uid
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="10"
-                          name="supportedDiseases.0.equipmentUid"
-                          type="text"
-                          value=""
-                        />
+                          <label
+                            class="usa-label"
+                            for="13"
+                          >
+                            Test Performed Loinc Long Name
+                          </label>
+                          <input
+                            aria-disabled="true"
+                            aria-required="false"
+                            class="usa-input"
+                            disabled=""
+                            id="13"
+                            name="supportedDiseases.0.testPerformedLoincLongName"
+                            type="text"
+                            value=""
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="11"
-                        >
-                          Uid Type
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="11"
-                          name="supportedDiseases.0.equipmentUidType"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                      class="grid-row"
+                    />
                     <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="12"
-                        >
-                          Test Ordered Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="12"
-                          name="supportedDiseases.0.testOrderedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="tablet:grid-col"
-                    >
-                      <div
-                        class="usa-form-group margin-top-1"
-                      >
-                        <label
-                          class="usa-label"
-                          for="13"
-                        >
-                          Test Performed Loinc Long Name
-                        </label>
-                        <input
-                          aria-disabled="true"
-                          aria-required="false"
-                          class="usa-input"
-                          disabled=""
-                          id="13"
-                          name="supportedDiseases.0.testPerformedLoincLongName"
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="flex-align-self-end"
-                    >
-                      <div
-                        class="padding-205 height-5"
-                      />
-                    </div>
+                      class="sr-separator-line margin-top-2 margin-bottom-2"
+                    />
                   </div>
                 </fieldset>
                 <div

--- a/frontend/src/app/supportAdmin/DeviceType/operations.graphql
+++ b/frontend/src/app/supportAdmin/DeviceType/operations.graphql
@@ -65,6 +65,8 @@ query getDeviceTypeList{
       equipmentUid
       equipmentUidType
       testOrderedLoincCode
+      testOrderedLoincLongName
+      testPerformedLoincLongName
     }
     testLength
   }

--- a/frontend/src/app/supportAdmin/ManageUsers/__snapshots__/AdminManageUser.test.tsx.snap
+++ b/frontend/src/app/supportAdmin/ManageUsers/__snapshots__/AdminManageUser.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Admin manage users Undelete user 1`] = `
                     </button>
                   </div>
                   <div
-                    class="userinfo-divider"
+                    class="sr-separator-line margin-left-neg-4 margin-right-neg-2"
                   />
                   <h3
                     class="user-controls-header"
@@ -685,7 +685,7 @@ exports[`Admin manage users Undelete user 2`] = `
                     </button>
                   </div>
                   <div
-                    class="userinfo-divider"
+                    class="sr-separator-line margin-left-neg-4 margin-right-neg-2"
                   />
                   <h3
                     class="user-controls-header"
@@ -1570,7 +1570,7 @@ exports[`Admin manage users search results matches snapshot 1`] = `
                     </button>
                   </div>
                   <div
-                    class="userinfo-divider"
+                    class="sr-separator-line margin-left-neg-4 margin-right-neg-2"
                   />
                   <h3
                     class="user-controls-header"

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1797,6 +1797,8 @@ export type GetDeviceTypeListQuery = {
       equipmentUid?: string | null;
       equipmentUidType?: string | null;
       testOrderedLoincCode?: string | null;
+      testOrderedLoincLongName?: string | null;
+      testPerformedLoincLongName?: string | null;
       supportedDisease: {
         __typename?: "SupportedDisease";
         internalId: string;
@@ -5317,6 +5319,8 @@ export const GetDeviceTypeListDocument = gql`
         equipmentUid
         equipmentUidType
         testOrderedLoincCode
+        testOrderedLoincLongName
+        testPerformedLoincLongName
       }
       testLength
     }


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Solves #7179 

## Changes Proposed

- Update `diseaseForm` and `diseaseInformation` components so that they both read from and write to the `testPerformedLoincLongName` and `testOrderedLoincLongName` attributes as defined in our Device Type Disease Table.
- Update the `getDeviceTypeList` qraphGL querry to return `testPerformedLoincLongName` and `testOrderedLoincLongName`.
- Add input options to the edit device page for the user to update the loinc long names with.

## Testing

- This code is live on dev2. To test, go to the add/edit device page and verify that the fields for both of the long names are there. Update the values with new values and verify that they persist on refresh and/or in metabase. 


## Screenshots
Worked with @kenieh and settled on a red "Delete disease" button rather than the red trash can in its own row by itself
<img width="1308" alt="Screenshot 2024-06-24 at 17 18 48" src="https://github.com/CDCgov/prime-simplereport/assets/20211771/48bf2078-b058-4dd8-9d36-7ce80cc4e3a8">

