### PR TITLE
updateTimeOfTest --> AoeQuestions pt 1

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -101,7 +101,34 @@ public class QueueMutationResolver {
 
     Map<String, Boolean> symptomsMap = parseSymptoms(symptoms);
 
-    testOrderService.updateTimeOfTestQuestions(
+    testOrderService.updateAoeQuestions(
+        patientId,
+        pregnancy,
+        syphilisHistory,
+        symptomsMap,
+        symptomOnset,
+        noSymptoms,
+        genderOfSexualPartners);
+
+    if (testResultDelivery != null) {
+      personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
+    }
+  }
+
+  @MutationMapping
+  public void updateAoeQuestions(
+      @Argument UUID patientId,
+      @Argument String pregnancy,
+      @Argument String syphilisHistory,
+      @Argument String symptoms,
+      @Argument LocalDate symptomOnset,
+      @Argument Boolean noSymptoms,
+      @Argument List<String> genderOfSexualPartners,
+      @Argument TestResultDeliveryPreference testResultDelivery) {
+
+    Map<String, Boolean> symptomsMap = parseSymptoms(symptoms);
+
+    testOrderService.updateAoeQuestions(
         patientId,
         pregnancy,
         syphilisHistory,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -455,7 +455,7 @@ public class TestOrderService {
   }
 
   @AuthorizationConfiguration.RequirePermissionUpdateTestForPatient
-  public void updateTimeOfTestQuestions(
+  public void updateAoeQuestions(
       UUID patientId,
       String pregnancy,
       String syphilisHistory,

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -694,6 +694,16 @@ type Mutation {
     genderOfSexualPartners: [String]
     testResultDelivery: TestResultDeliveryPreference
   ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
+  updateAoeQuestions(
+    patientId: ID!
+    pregnancy: String
+    syphilisHistory: String
+    symptoms: String @Size(min: 0, max: 1024)
+    symptomOnset: LocalDate
+    noSymptoms: Boolean
+    genderOfSexualPartners: [String]
+    testResultDelivery: TestResultDeliveryPreference
+  ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkSms(internalId: ID!): Boolean
     @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkSmsByTestEventId(testEventId: ID!): Boolean

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -351,7 +351,7 @@ class QueueManagementTest extends BaseGraphqlTest {
     updateSelfPrivileges(Role.USER, true, Set.of());
     performQueueUpdateMutation(updateVariables, Optional.empty());
 
-    updateSelfPrivileges(Role.USER, false, Set.of());
+    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
     // updateAoeQuestions uses the exact same security restrictions
     Map<String, Object> removeVariables = Map.of("patientId", personId.toString());
     performRemoveFromQueueMutation(removeVariables, Optional.of(ACCESS_ERROR));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -350,9 +350,9 @@ class QueueManagementTest extends BaseGraphqlTest {
     performQueueUpdateMutation(updateVariables, Optional.empty());
     updateSelfPrivileges(Role.USER, true, Set.of());
     performQueueUpdateMutation(updateVariables, Optional.empty());
-
-    updateSelfPrivileges(Role.USER, false, Set.of(_secondSite.getInternalId()));
-    // updateTimeOfTestQuestions uses the exact same security restrictions
+    
+    updateSelfPrivileges(Role.USER, false, Set.of());
+    // updateAoeQuestions uses the exact same security restrictions
     Map<String, Object> removeVariables = Map.of("patientId", personId.toString());
     performRemoveFromQueueMutation(removeVariables, Optional.of(ACCESS_ERROR));
     updateSelfPrivileges(Role.USER, false, Set.of(_site.getInternalId()));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/graphql/QueueManagementTest.java
@@ -350,7 +350,7 @@ class QueueManagementTest extends BaseGraphqlTest {
     performQueueUpdateMutation(updateVariables, Optional.empty());
     updateSelfPrivileges(Role.USER, true, Set.of());
     performQueueUpdateMutation(updateVariables, Optional.empty());
-    
+
     updateSelfPrivileges(Role.USER, false, Set.of());
     // updateAoeQuestions uses the exact same security restrictions
     Map<String, Object> removeVariables = Map.of("patientId", personId.toString());

--- a/backend/src/test/resources/graphql-test/update-aoe-questions.graphql
+++ b/backend/src/test/resources/graphql-test/update-aoe-questions.graphql
@@ -6,6 +6,7 @@ mutation UpdateAOE(
   $syphilisHistory: String
   $noSymptoms: Boolean
   $genderOfSexualPartners: [String]
+  $testResultDelivery: TestResultDeliveryPreference
 ) {
   updateAoeQuestions(
     patientId: $patientId
@@ -15,5 +16,6 @@ mutation UpdateAOE(
     noSymptoms: $noSymptoms
     symptomOnset: $symptomOnset
     genderOfSexualPartners: $genderOfSexualPartners
+    testResultDelivery: $testResultDelivery
   )
 }

--- a/backend/src/test/resources/graphql-test/update-aoe-questions.graphql
+++ b/backend/src/test/resources/graphql-test/update-aoe-questions.graphql
@@ -1,0 +1,19 @@
+mutation UpdateAOE(
+  $patientId: ID!
+  $symptoms: String
+  $symptomOnset: LocalDate
+  $pregnancy: String
+  $syphilisHistory: String
+  $noSymptoms: Boolean
+  $genderOfSexualPartners: [String]
+) {
+  updateAoeQuestions(
+    patientId: $patientId
+    pregnancy: $pregnancy
+    syphilisHistory: $syphilisHistory
+    symptoms: $symptoms
+    noSymptoms: $noSymptoms
+    symptomOnset: $symptomOnset
+    genderOfSexualPartners: $genderOfSexualPartners
+  )
+}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -228,6 +228,7 @@ export type Mutation = {
   setRegistrationLinkIsDeleted?: Maybe<Scalars["String"]["output"]>;
   setUserIsDeleted?: Maybe<User>;
   submitQueueItem?: Maybe<AddTestResultResponse>;
+  updateAoeQuestions?: Maybe<Scalars["String"]["output"]>;
   updateDeviceType?: Maybe<DeviceType>;
   updateFacility?: Maybe<Facility>;
   updateFeatureFlag?: Maybe<FeatureFlag>;
@@ -464,6 +465,19 @@ export type MutationSubmitQueueItemArgs = {
   patientId: Scalars["ID"]["input"];
   results: Array<InputMaybe<MultiplexResultInput>>;
   specimenTypeId: Scalars["ID"]["input"];
+};
+
+export type MutationUpdateAoeQuestionsArgs = {
+  genderOfSexualPartners?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>>
+  >;
+  noSymptoms?: InputMaybe<Scalars["Boolean"]["input"]>;
+  patientId: Scalars["ID"]["input"];
+  pregnancy?: InputMaybe<Scalars["String"]["input"]>;
+  symptomOnset?: InputMaybe<Scalars["LocalDate"]["input"]>;
+  symptoms?: InputMaybe<Scalars["String"]["input"]>;
+  syphilisHistory?: InputMaybe<Scalars["String"]["input"]>;
+  testResultDelivery?: InputMaybe<TestResultDeliveryPreference>;
 };
 
 export type MutationUpdateDeviceTypeArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part one of a followup effort [after this comment](https://github.com/CDCgov/prime-simplereport/pull/7589#discussion_r1574895730) to rename instances of legacy `timeOfTestQuestions` to `aoeQuestions` as we use them now. 

## Changes Proposed
- Since we're changing a mutation endpoint, adding in the newly named endpoint before a followup PR that will deprecate the old mutation endpoints. See writeup [here](https://github.com/CDCgov/prime-simplereport/wiki/GraphQL-Flow#how-do-i-edit-a-query-or-mutation) about backwards compatibility if needed.

## Testing
deployed on dev3
- Make sure there aren't any regressions in the AOE flow

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---