### PR TITLE
Bulk upload fhir mapping bugfix

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -487,12 +487,10 @@ public class Translators {
     return concept.code();
   }
 
-  public static SnomedConceptRecord convertConceptCodeToConceptName(String snomedCode) {
-    SnomedConceptRecord concept =
-        RESULTS_SNOMED_CONCEPTS.stream()
-            .filter(snomedConcept -> snomedCode.equals(snomedConcept.code()))
-            .findFirst()
-            .orElse(null);
-    return concept;
+  public static SnomedConceptRecord getSnomedConceptByCode(String snomedCode) {
+    return RESULTS_SNOMED_CONCEPTS.stream()
+        .filter(snomedConcept -> snomedCode.equals(snomedConcept.code()))
+        .findFirst()
+        .orElse(null);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -487,12 +487,12 @@ public class Translators {
     return concept.code();
   }
 
-  public static String convertConceptCodeToConceptName(String snomedCode) {
+  public static SnomedConceptRecord convertConceptCodeToConceptName(String snomedCode) {
     SnomedConceptRecord concept =
         RESULTS_SNOMED_CONCEPTS.stream()
             .filter(snomedConcept -> snomedCode.equals(snomedConcept.code()))
             .findFirst()
-            .orElse(INVALID_SNOMED_CONCEPT);
-    return concept.name();
+            .orElse(null);
+    return concept;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -92,6 +92,7 @@ import gov.cdc.usds.simplereport.db.model.TestOrder;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
+import gov.cdc.usds.simplereport.db.model.auxiliary.SnomedConceptRecord;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.db.model.auxiliary.TestCorrectionStatus;
 import gov.cdc.usds.simplereport.service.TestOrderService;
@@ -698,6 +699,9 @@ public class FhirConverter {
       Date resultDate) {
     if (result != null && result.getDisease() != null) {
 
+      SnomedConceptRecord resultConceptRecord =
+          Translators.convertConceptCodeToConceptName(result.getResultSNOMED());
+
       return convertToObservation(
           ConvertToObservationProps.builder()
               .testPerformedLoinc(deviceTypeDisease.getTestPerformedLoincCode())
@@ -706,8 +710,7 @@ public class FhirConverter {
               .correctionStatus(correctionStatus)
               .correctionReason(correctionReason)
               .id(result.getInternalId().toString())
-              .resultDescription(
-                  Translators.convertConceptCodeToConceptName(result.getResultSNOMED()))
+              .resultDescription(resultConceptRecord == null ? null : resultConceptRecord.name())
               .testkitNameId(testkitNameId)
               .deviceModel(deviceModel)
               .issued(resultDate)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -700,7 +700,7 @@ public class FhirConverter {
     if (result != null && result.getDisease() != null) {
 
       SnomedConceptRecord resultConceptRecord =
-          Translators.convertConceptCodeToConceptName(result.getResultSNOMED());
+          Translators.getSnomedConceptByCode(result.getResultSNOMED());
 
       return convertToObservation(
           ConvertToObservationProps.builder()

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -39,6 +39,7 @@ import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.model.auxiliary.FHIRBundleRecord;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PersonName;
 import gov.cdc.usds.simplereport.db.model.auxiliary.PhoneType;
+import gov.cdc.usds.simplereport.db.model.auxiliary.SnomedConceptRecord;
 import gov.cdc.usds.simplereport.db.model.auxiliary.StreetAddress;
 import gov.cdc.usds.simplereport.service.ResultsUploaderCachingService;
 import java.io.InputStream;
@@ -415,6 +416,9 @@ public class BulkUploadResultsToFhir {
                 .receivedTime(testingLabSpecimenReceivedDate)
                 .build());
 
+    SnomedConceptRecord resultConceptRecord =
+        Translators.convertConceptCodeToConceptName(row.getTestResult().getValue());
+
     var resultObservation =
         List.of(
             fhirConverter.convertToObservation(
@@ -427,8 +431,7 @@ public class BulkUploadResultsToFhir {
                     .correctionReason(null)
                     .id(uuidGenerator.randomUUID().toString())
                     .resultDescription(
-                        Translators.convertConceptCodeToConceptName(
-                            getTestResultSnomed(row.getTestResult().getValue())))
+                        resultConceptRecord == null ? null : resultConceptRecord.name())
                     .testkitNameId(testKitNameId)
                     .deviceModel(row.getEquipmentModelName().getValue())
                     .issued(Date.from(testResultDate.toInstant()))

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -416,8 +416,8 @@ public class BulkUploadResultsToFhir {
                 .receivedTime(testingLabSpecimenReceivedDate)
                 .build());
 
-    SnomedConceptRecord resultConceptRecord =
-        Translators.convertConceptCodeToConceptName(row.getTestResult().getValue());
+    String testResultSnomed = getTestResultSnomed(row.getTestResult().getValue());
+    SnomedConceptRecord resultConceptRecord = Translators.getSnomedConceptByCode(testResultSnomed);
 
     var resultObservation =
         List.of(
@@ -425,7 +425,7 @@ public class BulkUploadResultsToFhir {
                 ConvertToObservationProps.builder()
                     .testPerformedLoinc(row.getTestPerformedCode().getValue())
                     .diseaseName(diseaseName)
-                    .resultCode(getTestResultSnomed(row.getTestResult().getValue()))
+                    .resultCode(getTestResultSnomed(testResultSnomed))
                     .correctionStatus(
                         mapTestResultStatusToSRValue(row.getTestResultStatus().getValue()))
                     .correctionReason(null)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -425,7 +425,7 @@ public class BulkUploadResultsToFhir {
                 ConvertToObservationProps.builder()
                     .testPerformedLoinc(row.getTestPerformedCode().getValue())
                     .diseaseName(diseaseName)
-                    .resultCode(getTestResultSnomed(testResultSnomed))
+                    .resultCode(testResultSnomed)
                     .correctionStatus(
                         mapTestResultStatusToSRValue(row.getTestResultStatus().getValue()))
                     .correctionReason(null)


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #7804  

Our bulk upload result flow does not correctly add descriptions for SNOMEDs that are not within our (very limited) list of codes used by the frontend.  When a bulk upload is submitted with a valid code that isn't in this list we were incorrectly setting the description to "Invalid result". 

## Changes Proposed

- Stop defaulting the value to "invalid result", leave the description off of the fhir object if we can't correctly populate it.

## Additional Information

- 

## Testing

- Testing in an env for the specific changes we're making is difficult without grabbing the fhir message off of the queue in Azure.  Easier to just debug locally to verify mapping behavior.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
