### PR TITLE
elisa/7146-collection-location

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -151,6 +151,9 @@ public class OrganizationInitializingService {
         log.info("Creating specimen type {}", s.getName());
         specimenType = _specimenTypeRepo.save(s);
         specimenTypesByCode.put(specimenType.getTypeCode(), _specimenTypeRepo.save(s));
+      } else {
+        specimenType.setCollectionLocationCode(s.getCollectionLocationCode());
+        specimenType.setCollectionLocationName(s.getCollectionLocationName());
       }
     }
 

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -73,8 +73,12 @@ simple-report-initialization:
       collection-location-code: "71836000"
     - name: Venous blood specimen
       type-code: "122555007"
+      collection-location-name: Blood specimen (specimen)
+      collection-location-code: "119297000"
     - name: Oral fluid specimen
       type-code: "441620008"
+      collection-location-name: Mouth region structure (body structure)
+      collection-location-code: "123851003"
   device-types:
     - name: Abbott Alinity M
       manufacturer: Abbott


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #7146

## Changes Proposed

- Adds the `collection_location_name` and `collection_location_code` for `Venous blood specimen` and `Oral fluid specimen` `SpecimenType`s to the `create-sample-data` Spring profile

## Additional Information

The original ticket asked for the following

> Populate collection location for the specimen types confirmed in our spike: rows 10, 11, 12, 14, 15, 18, 23, and 26 in the [mapping spreadsheet](https://docs.google.com/spreadsheets/d/1_qEClruZUhYboRrEY7sEVtg9vVL76XuWYKcACu4i-bE/edit#gid=0).
Do this for all envs.

However, for demo and training, we only have `SpecimenType` `12` and `23` from this spreadsheet so I decided to only update the collection location name and code for the `SpecimenType`s we do have

## Testing
- Ensure when running this locally, the `Venous blood specimen` and `Oral fluid specimen` `SpecimenType`s get updated with the `collection_location_name` and `collection_location_code`

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->