### PR TITLE
Add syphilis history field to bulk uploader

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -15,9 +15,8 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEma
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEthnicity;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateGendersOfSexualPartners;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
-import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveHIVRequiredAOEFields;
-import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveSyphilisRequiredAOEFields;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRace;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRequiredFieldsForPositiveResult;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateResidence;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateState;
@@ -31,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
 import gov.cdc.usds.simplereport.db.model.auxiliary.ResultUploadErrorSource;
 import gov.cdc.usds.simplereport.db.model.auxiliary.ResultUploadErrorType;
+import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.ResultsUploaderCachingService;
 import gov.cdc.usds.simplereport.service.ResultsUploaderDeviceService;
 import gov.cdc.usds.simplereport.service.model.reportstream.FeedbackMessage;
@@ -614,17 +614,16 @@ public class TestResultRow implements FileRow {
 
     if (isHivResult()) {
       errors.addAll(
-          validatePositiveHIVRequiredAOEFields(testResult, gendersOfSexualPartners, pregnant));
+          validateRequiredFieldsForPositiveResult(
+              testResult, DiseaseService.HIV_NAME, List.of(gendersOfSexualPartners, pregnant)));
     }
 
     if (isSyphilisResult()) {
       errors.addAll(
-          validatePositiveSyphilisRequiredAOEFields(
+          validateRequiredFieldsForPositiveResult(
               testResult,
-              gendersOfSexualPartners,
-              pregnant,
-              syphilisHistory,
-              symptomaticForDisease));
+              DiseaseService.SYPHILIS_NAME,
+              List.of(gendersOfSexualPartners, pregnant, syphilisHistory, symptomaticForDisease)));
     }
 
     return errors;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -16,6 +16,7 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateEth
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateGendersOfSexualPartners;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveHIVRequiredAOEFields;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveSyphilisRequiredAOEFields;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRace;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateResidence;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
@@ -105,6 +106,7 @@ public class TestResultRow implements FileRow {
   final ValueOrError testResultStatus;
   final ValueOrError testOrderedCode;
   final ValueOrError gendersOfSexualPartners;
+  final ValueOrError syphilisHistory;
 
   static final String PATIENT_LAST_NAME = "patient_last_name";
   static final String PATIENT_FIRST_NAME = "patient_first_name";
@@ -149,6 +151,7 @@ public class TestResultRow implements FileRow {
   public static final String ORDERING_FACILITY_ZIP_CODE = "ordering_facility_zip_code";
   public static final String ORDERING_FACILITY_PHONE_NUMBER = "ordering_facility_phone_number";
   public static final String GENDERS_OF_SEXUAL_PARTNERS = "genders_of_sexual_partners";
+  public static final String SYPHILIS_HISTORY = "syphilis_history";
 
   public static final ImmutableMap<String, String> diseaseSpecificLoincMap =
       new ImmutableMap.Builder<String, String>()
@@ -452,6 +455,7 @@ public class TestResultRow implements FileRow {
     testOrderedCode = getValue(rawRow, "test_ordered_code", isRequired("test_ordered_code"));
     gendersOfSexualPartners =
         getValue(rawRow, GENDERS_OF_SEXUAL_PARTNERS, isRequired(GENDERS_OF_SEXUAL_PARTNERS));
+    syphilisHistory = getValue(rawRow, SYPHILIS_HISTORY, isRequired(SYPHILIS_HISTORY));
   }
 
   private List<FeedbackMessage> validateDeviceModelAndTestPerformedCode(
@@ -482,6 +486,17 @@ public class TestResultRow implements FileRow {
     }
     return resultsUploaderCachingService
         .getHivEquipmentModelAndTestPerformedCodeSet()
+        .contains(
+            ResultsUploaderCachingService.getKey(
+                equipmentModelName.getValue(), testPerformedCode.getValue()));
+  }
+
+  private boolean isSyphilisResult() {
+    if (equipmentModelName.getValue() == null || testPerformedCode.getValue() == null) {
+      return false;
+    }
+    return resultsUploaderCachingService
+        .getSyphilisEquipmentModelAndTestPerformedCodeSet()
         .contains(
             ResultsUploaderCachingService.getKey(
                 equipmentModelName.getValue(), testPerformedCode.getValue()));
@@ -600,6 +615,16 @@ public class TestResultRow implements FileRow {
     if (isHivResult()) {
       errors.addAll(
           validatePositiveHIVRequiredAOEFields(testResult, gendersOfSexualPartners, pregnant));
+    }
+
+    if (isSyphilisResult()) {
+      errors.addAll(
+          validatePositiveSyphilisRequiredAOEFields(
+              testResult,
+              gendersOfSexualPartners,
+              pregnant,
+              syphilisHistory,
+              symptomaticForDisease));
     }
 
     return errors;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -14,6 +14,8 @@ public class CachingConfig {
       "covidEquipmentModelAndTestPerformedCodeSet";
   public static final String HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "hivEquipmentModelAndTestPerformedCodeSet";
+  public static final String SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
+      "syphilisEquipmentModelAndTestPerformedCodeSet";
   public static final String DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP =
       "deviceModelAndTestPerformedCodeMap";
   public static final String SPECIMEN_NAME_TO_SNOMED_MAP = "specimenTypeNameSNOMEDMap";
@@ -26,6 +28,7 @@ public class CachingConfig {
     return new ConcurrentMapCacheManager(
         COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+        SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP,
         SPECIMEN_NAME_TO_SNOMED_MAP,
         SNOMED_TO_SPECIMEN_NAME_MAP,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -23,6 +23,7 @@ public class DiseaseService {
   public static final String FLU_RNA_NAME = "Flu RNA";
   public static final String RSV_NAME = "RSV";
   public static final String HIV_NAME = "HIV";
+  public static final String SYPHILIS_NAME = "Syphilis";
 
   private final DiseaseCacheService diseaseCacheService;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -6,6 +6,7 @@ import static gov.cdc.usds.simplereport.config.CachingConfig.DEVICE_MODEL_AND_TE
 import static gov.cdc.usds.simplereport.config.CachingConfig.HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SNOMED_TO_SPECIMEN_NAME_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SPECIMEN_NAME_TO_SNOMED_MAP;
+import static gov.cdc.usds.simplereport.config.CachingConfig.SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
@@ -148,6 +149,12 @@ public class ResultsUploaderCachingService {
   public Set<String> getHivEquipmentModelAndTestPerformedCodeSet() {
     log.info("generating hivEquipmentModelAndTestPerformedCodeSet cache");
     return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.HIV_NAME);
+  }
+
+  @Cacheable(SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getSyphilisEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating syphilisEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.SYPHILIS_NAME);
   }
 
   @Cacheable(COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -9,6 +9,7 @@ import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.ORDERING
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.ORDERING_FACILITY_STREET;
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.ORDERING_FACILITY_STREET2;
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.ORDERING_FACILITY_ZIP_CODE;
+import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.SYPHILIS_HISTORY;
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.TESTING_LAB_CITY;
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.TESTING_LAB_NAME;
 import static gov.cdc.usds.simplereport.api.model.filerow.TestResultRow.TESTING_LAB_PHONE_NUMBER;
@@ -305,6 +306,7 @@ public class TestResultUploadService {
     row.put(DATE_RESULT_RELEASED_COLUMN_NAME, dateResultReleased.toOffsetDateTime().toString());
 
     row.remove(GENDERS_OF_SEXUAL_PARTNERS);
+    row.remove(SYPHILIS_HISTORY);
 
     return row;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -260,6 +260,12 @@ public class CsvValidatorUtils {
         + " column. This is required because the row contains a positive HIV test result.";
   }
 
+  private static String getRequiredSyphilisAoeValuesErrorMessage(String columnName) {
+    return "File is missing data in the "
+        + columnName
+        + " column. This is required because the row contains a positive Syphilis test result.";
+  }
+
   public static List<FeedbackMessage> validateTestResult(ValueOrError input) {
     return validateSpecificValueOrSNOMED(input, TEST_RESULT_VALUES);
   }
@@ -670,6 +676,51 @@ public class CsvValidatorUtils {
               .fieldRequired(pregnant.isRequired())
               .build());
     }
+    return errors;
+  }
+
+  private static FeedbackMessage buildSyphilisMissingDataFeedbackMessage(ValueOrError field) {
+    return FeedbackMessage.builder()
+        .scope(ITEM_SCOPE)
+        .fieldHeader(field.getHeader())
+        .source(ResultUploadErrorSource.SIMPLE_REPORT)
+        .message(getRequiredSyphilisAoeValuesErrorMessage(field.getHeader()))
+        .errorType(ResultUploadErrorType.MISSING_DATA)
+        .fieldRequired(field.isRequired())
+        .build();
+  }
+
+  public static List<FeedbackMessage> validatePositiveSyphilisRequiredAOEFields(
+      ValueOrError testResult,
+      ValueOrError gendersOfSexualPartners,
+      ValueOrError pregnant,
+      ValueOrError previousSyphilisDiagnosis,
+      ValueOrError symptomaticForDisease) {
+    List<FeedbackMessage> errors = new ArrayList<>();
+    // includes SNOMED values for positive and detected
+    Set<String> positiveTestResultValues = Set.of("positive", "detected", "260373001", "10828004");
+    if (!positiveTestResultValues.contains(testResult.getValue().toLowerCase())) {
+      return errors;
+    }
+
+    if (gendersOfSexualPartners.getValue() == null
+        || gendersOfSexualPartners.getValue().isBlank()) {
+      errors.add(buildSyphilisMissingDataFeedbackMessage(gendersOfSexualPartners));
+    }
+
+    if (pregnant.getValue() == null || pregnant.getValue().isBlank()) {
+      errors.add(buildSyphilisMissingDataFeedbackMessage(pregnant));
+    }
+
+    if (previousSyphilisDiagnosis.getValue() == null
+        || previousSyphilisDiagnosis.getValue().isBlank()) {
+      errors.add(buildSyphilisMissingDataFeedbackMessage(previousSyphilisDiagnosis));
+    }
+
+    if (symptomaticForDisease.getValue() == null || symptomaticForDisease.getValue().isBlank()) {
+      errors.add(buildSyphilisMissingDataFeedbackMessage(symptomaticForDisease));
+    }
+
     return errors;
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -11,7 +11,7 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateFle
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateGendersOfSexualPartners;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePartialUnkAddress;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
-import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePositiveHIVRequiredAOEFields;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRequiredFieldsForPositiveResult;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateZipCode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.io.ContentReference;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
+import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.model.reportstream.FeedbackMessage;
 import gov.cdc.usds.simplereport.utils.UnknownAddressUtils;
 import java.io.IOException;
@@ -293,7 +294,10 @@ class CsvValidatorUtilsTest {
     ValueOrError testResult = new ValueOrError("negative", "test_result");
     ValueOrError genders = new ValueOrError("", "genders_of_sexual_partners");
     ValueOrError pregnant = new ValueOrError("", "pregnant");
-    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).isEmpty();
+    assertThat(
+            validateRequiredFieldsForPositiveResult(
+                testResult, DiseaseService.HIV_NAME, List.of(genders, pregnant)))
+        .isEmpty();
   }
 
   @Test
@@ -301,7 +305,10 @@ class CsvValidatorUtilsTest {
     ValueOrError testResult = new ValueOrError("positive", "test_result");
     ValueOrError genders = new ValueOrError("m, f, tm, tw", "genders_of_sexual_partners");
     ValueOrError pregnant = new ValueOrError("n", "pregnant");
-    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).isEmpty();
+    assertThat(
+            validateRequiredFieldsForPositiveResult(
+                testResult, DiseaseService.HIV_NAME, List.of(genders, pregnant)))
+        .isEmpty();
   }
 
   @Test
@@ -309,6 +316,9 @@ class CsvValidatorUtilsTest {
     ValueOrError testResult = new ValueOrError("positive", "test_result");
     ValueOrError genders = new ValueOrError("", "genders_of_sexual_partners");
     ValueOrError pregnant = new ValueOrError("", "pregnant");
-    assertThat(validatePositiveHIVRequiredAOEFields(testResult, genders, pregnant)).hasSize(2);
+    assertThat(
+            validateRequiredFieldsForPositiveResult(
+                testResult, DiseaseService.HIV_NAME, List.of(genders, pregnant)))
+        .hasSize(2);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
@@ -461,6 +461,40 @@ class TestResultRowTest {
                 .contains("This is required because the row contains a positive HIV test result."));
   }
 
+  @Test
+  void validatePositiveSyphilisRequiredAoeFields() {
+    var missingSyphilisRequiredAoeFields = validRowMap;
+    missingSyphilisRequiredAoeFields.put("equipment_model_name", "Syphilis model");
+    missingSyphilisRequiredAoeFields.put("test_performed_code", "80387-4");
+    missingSyphilisRequiredAoeFields.put("specimen_type", "123456789");
+    missingSyphilisRequiredAoeFields.put("test_result", "Detected");
+    missingSyphilisRequiredAoeFields.put("pregnant", "");
+    missingSyphilisRequiredAoeFields.put("genders_of_sexual_partners", "");
+    missingSyphilisRequiredAoeFields.put("previous_syphilis_diagnosis", "");
+    missingSyphilisRequiredAoeFields.put("symptomatic_for_disease", "");
+
+    var resultsUploaderCachingService = mock(ResultsUploaderCachingService.class);
+    when(resultsUploaderCachingService.getModelAndTestPerformedCodeToDeviceMap())
+        .thenReturn(Map.of("syphilis model|80387-4", TestDataBuilder.createDeviceType()));
+    when(resultsUploaderCachingService.getSyphilisEquipmentModelAndTestPerformedCodeSet())
+        .thenReturn(Set.of("syphilis model|80387-4"));
+
+    var testResultRow =
+        new TestResultRow(
+            missingSyphilisRequiredAoeFields,
+            resultsUploaderCachingService,
+            mock(FeatureFlagsConfig.class));
+
+    var actual = testResultRow.validateIndividualValues();
+
+    assertThat(actual).hasSize(4);
+    actual.forEach(
+        message ->
+            assertThat(message.getMessage())
+                .contains(
+                    "This is required because the row contains a positive Syphilis test result."));
+  }
+
   private ResultsUploaderCachingService mockResultsUploaderCachingService() {
     var resultsUploaderCachingService = mock(ResultsUploaderCachingService.class);
     when(resultsUploaderCachingService.getModelAndTestPerformedCodeToDeviceMap())


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7452 

## Changes Proposed

- Adds support for the `syphilis_history` column to the bulk results uploader

## Additional Information

- We decided to maintain the current design of only asking for whether the patient is symptomatic for the disease rather than asking for individual symptoms
- A [separate ticket](https://github.com/CDCgov/prime-simplereport/issues/7469) exists to create the syphilis FHIR bundle for both single entry and bulk upload

## Testing

- Deployed to dev5
- Attempt to submit a bulk results upload file that contains a positive syphilis result but blank values for genders of sexual partners, pregnant, previous syphilis diagnosis, and/or symptomatic for disease
- You should get a missing data error message in the bulk uploader screen
- A syphilis device is configured on dev5 with syphilis as a test performed code of `76272004` and a model name of `syphilis device model`


![image](https://github.com/CDCgov/prime-simplereport/assets/23287037/03909b83-5d81-4e89-acdc-36a998da7179)
