### PR TITLE
Persist role updates and add audit columns to ApiUserRole and ApiUserFacility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -28,7 +28,7 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
   @Setter
   private String loginEmail;
 
-  @Getter @Setter @Embedded private PersonName nameInfo;
+  @Setter @Embedded private PersonName nameInfo;
 
   @Column(nullable = true)
   @Getter
@@ -47,6 +47,11 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
     loginEmail = email;
     nameInfo = name;
     lastSeen = null;
+  }
+
+  @Override
+  public PersonName getNameInfo() {
+    return nameInfo;
   }
 
   public void updateLastSeen() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -12,6 +12,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.NaturalId;
 
@@ -22,11 +24,14 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
 
   @Column(nullable = false, updatable = true, unique = true)
   @NaturalId(mutable = true)
+  @Getter
+  @Setter
   private String loginEmail;
 
-  @Embedded private PersonName nameInfo;
+  @Getter @Setter @Embedded private PersonName nameInfo;
 
   @Column(nullable = true)
+  @Getter
   private Date lastSeen;
 
   @OneToMany(cascade = ALL, mappedBy = "apiUser", orphanRemoval = true)
@@ -44,28 +49,8 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
     lastSeen = null;
   }
 
-  public String getLoginEmail() {
-    return loginEmail;
-  }
-
-  public void setLoginEmail(String newEmail) {
-    loginEmail = newEmail;
-  }
-
-  public Date getLastSeen() {
-    return lastSeen;
-  }
-
   public void updateLastSeen() {
     lastSeen = new Date();
-  }
-
-  public PersonName getNameInfo() {
-    return nameInfo;
-  }
-
-  public void setNameInfo(PersonName name) {
-    nameInfo = name;
   }
 
   public Set<Facility> getFacilities() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -33,7 +33,7 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
   private Set<ApiUserFacility> facilityAssignments = new HashSet<>();
 
   @OneToMany(cascade = ALL, mappedBy = "apiUser", orphanRemoval = true)
-  private Set<ApiUserRole> apiUserRoles = new HashSet<>();
+  private Set<ApiUserRole> roleAssignments = new HashSet<>();
 
   protected ApiUser() {
     /* for hibernate */ }
@@ -76,28 +76,23 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
 
   public void setFacilities(Set<Facility> facilities) {
     this.facilityAssignments.clear();
-    for (Facility f : facilities) {
-      ApiUserFacility auf = new ApiUserFacility();
-      auf.setApiUser(this);
-      auf.setFacility(f);
-      this.facilityAssignments.add(auf);
+    for (Facility facility : facilities) {
+      this.facilityAssignments.add(new ApiUserFacility(this, facility));
     }
   }
 
   public void setRoles(Set<OrganizationRole> newOrgRoles, Organization org) {
-    this.apiUserRoles.clear();
-    for (OrganizationRole o : newOrgRoles) {
-      if (o.equals(OrganizationRole.NO_ACCESS)) {
-        // the NO_ACCESS role is only relevant for the Okta implementation of auth and we don't want
-        // to persist it. once we migrate off of Okta for role management, we should be able to
-        // deprecate the enum value completely
+    this.roleAssignments.clear();
+    for (OrganizationRole orgRole : newOrgRoles) {
+      if (orgRole.equals(OrganizationRole.NO_ACCESS)) {
+        // the NO_ACCESS role is only relevant for the Okta implementation of authorization, and we
+        // don't need
+        // to persist it in our tables. once we migrate off of Okta for role management, we should
+        // be able to
+        // deprecate the NO_ACCESS enum value completely
         continue;
       }
-      ApiUserRole aur = new ApiUserRole();
-      aur.setApiUser(this);
-      aur.setOrganization(org);
-      aur.setRole(o);
-      this.apiUserRoles.add(aur);
+      this.roleAssignments.add(new ApiUserRole(this, org, orgRole));
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -85,11 +85,8 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
     this.roleAssignments.clear();
     for (OrganizationRole orgRole : newOrgRoles) {
       if (orgRole.equals(OrganizationRole.NO_ACCESS)) {
-        // the NO_ACCESS role is only relevant for the Okta implementation of authorization, and we
-        // don't need
-        // to persist it in our tables. once we migrate off of Okta for role management, we should
-        // be able to
-        // deprecate the NO_ACCESS enum value completely
+        // the NO_ACCESS role is only relevant for the Okta implementation of authorization, and it
+        // doesn't need to be persisted in our tables
         continue;
       }
       this.roleAssignments.add(new ApiUserRole(this, org, orgRole));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserFacility.java
@@ -4,19 +4,25 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
-import lombok.Setter;
 
 @Entity(name = "api_user_facility")
 public class ApiUserFacility extends AuditedEntity {
 
   @ManyToOne
   @JoinColumn(name = "api_user_id", nullable = false)
-  @Setter
   private ApiUser apiUser;
 
   @ManyToOne
   @JoinColumn(name = "facility_id", nullable = false)
-  @Setter
   @Getter
   private Facility facility;
+
+  protected ApiUserFacility() {
+    /* for hibernate */
+  }
+
+  public ApiUserFacility(ApiUser user, Facility facility) {
+    this.apiUser = user;
+    this.facility = facility;
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserFacility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserFacility.java
@@ -1,0 +1,22 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity(name = "api_user_facility")
+public class ApiUserFacility extends AuditedEntity {
+
+  @ManyToOne
+  @JoinColumn(name = "api_user_id", nullable = false)
+  @Setter
+  private ApiUser apiUser;
+
+  @ManyToOne
+  @JoinColumn(name = "facility_id", nullable = false)
+  @Setter
+  @Getter
+  private Facility facility;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
@@ -1,0 +1,32 @@
+package gov.cdc.usds.simplereport.db.model;
+
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity(name = "api_user_role")
+public class ApiUserRole extends AuditedEntity {
+
+  @ManyToOne
+  @JoinColumn(name = "api_user_id", nullable = false)
+  @Setter
+  private ApiUser apiUser;
+
+  @ManyToOne
+  @JoinColumn(name = "organization_id", nullable = false)
+  @Setter
+  private Organization organization;
+
+  @Column(nullable = false, columnDefinition = "organization_role")
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+  @Enumerated(EnumType.STRING)
+  @Setter
+  private OrganizationRole role;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
@@ -7,7 +7,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -16,17 +15,28 @@ public class ApiUserRole extends AuditedEntity {
 
   @ManyToOne
   @JoinColumn(name = "api_user_id", nullable = false)
-  @Setter
   private ApiUser apiUser;
 
   @ManyToOne
   @JoinColumn(name = "organization_id", nullable = false)
-  @Setter
   private Organization organization;
 
   @Column(nullable = false, columnDefinition = "organization_role")
   @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Enumerated(EnumType.STRING)
-  @Setter
   private OrganizationRole role;
+
+  protected ApiUserRole() {
+    /* for hibernate */
+  }
+
+  public ApiUserRole(ApiUser user, Organization org, OrganizationRole role) {
+    if (role.equals(OrganizationRole.NO_ACCESS)) {
+      throw new IllegalArgumentException(
+          "Invalid role NO_ACCESS when creating new user role assignment");
+    }
+    this.apiUser = user;
+    this.organization = org;
+    this.role = role;
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -161,6 +161,7 @@ public class ApiUserService {
     apiUser.setNameInfo(name);
     apiUser.setIsDeleted(false);
     apiUser.setFacilities(facilitiesFound);
+    apiUser.setRoles(roles, org);
 
     Optional<OrganizationRoles> orgRoles = roleClaims.map(c -> _orgService.getOrganizationRoles(c));
     UserInfo user = new UserInfo(apiUser, orgRoles, false);
@@ -188,6 +189,7 @@ public class ApiUserService {
     Set<OrganizationRole> roles = getOrganizationRoles(role, accessAllFacilities);
     Set<Facility> facilitiesFound = getFacilitiesToGiveAccess(org, roles, facilities);
     apiUser.setFacilities(facilitiesFound);
+    apiUser.setRoles(roles, org);
 
     Optional<OrganizationRoleClaims> roleClaims =
         _oktaRepo.createUser(userIdentity, org, facilitiesFound, roles, active);
@@ -245,6 +247,7 @@ public class ApiUserService {
     UserInfo user = new UserInfo(apiUser, orgRoles, false);
 
     apiUser.setFacilities(facilitiesFound);
+    apiUser.setRoles(roles, org);
 
     createUserUpdatedAuditLog(apiUser.getInternalId(), getCurrentApiUser().getInternalId());
 
@@ -713,6 +716,7 @@ public class ApiUserService {
     Set<Facility> facilitiesToGiveAccessTo =
         getFacilitiesToGiveAccess(newOrg, roles, new HashSet<>(facilities));
     apiUser.setFacilities(facilitiesToGiveAccessTo);
+    apiUser.setRoles(roles, newOrg);
 
     _oktaRepo.updateUserPrivilegesAndGroupAccess(
         username, newOrg, facilitiesToGiveAccessTo, role.toOrganizationRole(), allFacilitiesAccess);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationInitializingService.java
@@ -317,6 +317,7 @@ public class OrganizationInitializingService {
             _orgRepo
                 .findByExternalId(authorization.getOrganizationExternalId())
                 .orElseThrow(MisconfiguredUserException::new);
+        apiUser.setRoles(roles, org);
         log.info(
             "User={} will have roles={} in organization={}",
             identity.getUsername(),

--- a/backend/src/main/resources/application-create-sample-data.yaml
+++ b/backend/src/main/resources/application-create-sample-data.yaml
@@ -235,7 +235,7 @@ simple-report:
           organization-external-id: DIS_ORG
           facilities:
             - Testing Site
-          granted-roles: []
+          granted-roles: ENTRY_ONLY
       - identity:
           username: jamar@example.com
           first-name: Jamar

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5417,3 +5417,212 @@ databaseChangeLog:
               constraints:
                 primaryKey: true
                 nullable: false
+  - changeSet:
+      id: add-audit-cols-to-facility-table
+      author: tnd8@cdc.gov
+      changes:
+        - dropTable:
+            tableName: api_user_facility
+        - createTable:
+            tableName: api_user_facility
+            remarks: creates a new table to store the relationship between api_user and facility
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                      primaryKey: true
+                      nullable: false
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__api_user
+                    references: api_user
+              - column:
+                  name: facility_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__facility
+                    references: facility
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  remarks: The creation timestamp for this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  remarks: The timestamp for the most recent update of this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: uuid
+                  remarks: The user who created this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__created_by
+              - column:
+                  name: updated_by
+                  type: uuid
+                  remarks: The user who most recently updated this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__updated_by
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.api_user_facility TO ${noPhiUsername};
+      rollback:
+        - dropTable:
+            tableName: api_user_facility
+        - createTable:
+            tableName: api_user_facility
+            remarks: creates a new table to store the relationship between api_user and facility
+            columns:
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__api_user
+                    references: api_user
+              - column:
+                  name: facility_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__facility
+                    references: facility
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.api_user_facility TO ${noPhiUsername};
+  - changeSet:
+      id: add-audit-cols-and-enum-role-to-api_user_role-table
+      author: tnd8@cdc.gov
+      changes:
+        - dropTable:
+            tableName: api_user_role
+        - dropTable:
+            tableName: role
+        - createTable:
+            tableName: api_user_role
+            remarks: creates a new table to store the relationship between api_user and role
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_facility__api_user
+                    references: api_user
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__organization
+                    references: organization
+              - column:
+                  name: role
+                  type: ${database.defaultSchemaName}.ORGANIZATION_ROLE
+                  remarks: The name of the role that is an enumerated value.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+                  remarks: The creation timestamp for this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME
+                  remarks: The timestamp for the most recent update of this entity.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: uuid
+                  remarks: The user who created this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__created_by
+              - column:
+                  name: updated_by
+                  type: uuid
+                  remarks: The user who most recently updated this entity.
+                  constraints:
+                    nullable: false
+                    references: api_user
+                    foreignKeyName: fk__anyentity__updated_by
+        - sql:
+            sql: GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};
+      rollback:
+        - dropTable:
+            tableName: api_user_role
+        - createTable:
+            tableName: role
+            remarks: named references to a OrganizationRole enum
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: ${database.defaultSchemaName}.ORGANIZATION_ROLE
+                  remarks: The name of the role that is an enumerated value.
+                  constraints:
+                    nullable: false
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.role TO ${noPhiUsername};
+        - createTable:
+            tableName: api_user_role
+            remarks: creates a new table to store the relationship between api_user and role
+            columns:
+              - column:
+                  name: internal_id
+                  type: uuid
+                  remarks: The internal database identifier for this entity.
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: api_user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__api_user
+                    references: api_user
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__organization
+                    references: organization
+              - column:
+                  name: role_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__api_user_role__role
+                    references: role
+        - sql: |
+            GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -400,7 +400,7 @@ class DemoOktaRepositoryTest {
   }
 
   @Test
-  void deleteOrgAndFacilities() {
+  void deleteOrg() {
     _repo.createUser(AMOS, ABC, Set.of(ABC_1), Set.of(OrganizationRole.USER), true);
     _repo.createUser(
         BRAD,
@@ -414,6 +414,9 @@ class DemoOktaRepositoryTest {
 
     _repo.deleteOrganization(ABC);
 
+    assertThrows(
+        IllegalGraphqlArgumentException.class,
+        () -> _repo.createFacility(getFacility(UUID.randomUUID(), ABC)));
     assertThrows(
         IllegalGraphqlArgumentException.class, () -> _repo.getAllUsersForOrganization(ABC));
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -414,9 +414,8 @@ class DemoOktaRepositoryTest {
 
     _repo.deleteOrganization(ABC);
 
-    assertThrows(
-        IllegalGraphqlArgumentException.class,
-        () -> _repo.createFacility(getFacility(UUID.randomUUID(), ABC)));
+    Facility fakeFacility = getFacility(UUID.randomUUID(), ABC);
+    assertThrows(IllegalGraphqlArgumentException.class, () -> _repo.createFacility(fakeFacility));
     assertThrows(
         IllegalGraphqlArgumentException.class, () -> _repo.getAllUsersForOrganization(ABC));
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

resolves #7597 

## Changes Proposed

- update api_user_role table to use the org role enum directly and drop the role table
- add audited entity columns to both the ApiUserRole and ApiUserFacility classes/tables. note that created by/at and updated by/at are always going to be the same because we update these connections by creating new entries in the tables
- anywhere we update a user's permissions, we now update the api_user_role table!
- updated a test per a [note from Elisa on my last PR](https://github.com/CDCgov/prime-simplereport/pull/7703#discussion_r1613681341)

## Additional Information

if there's a cleaner way to do this in JPA, really interested to pair on it! it seems like you have to explicitly instantiate the ApiUserRole and ApiUserFacility instances in order to populate the additional audit columns

I decided to use the OrganizationRole enum for the role on ApiUserRole, even though it's not a perfect match with the DB constraints on that column (DB enum doesn't include NO_ACCESS). I'm hopeful they will be a match in the future when we finish the migration because we can delete the concept of NO_ACCESS as a role once we move off of Okta

## Testing

deployed to `dev4`
options for testing:
- create a user with certain roles and facility access
- update a user with certain roles and facility access using the org admin view and the super admin view
