### PR TITLE
remove california-specific language from bulk uploader

### DIFF
--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -13,15 +13,23 @@ const DiseaseSpecificUploadContainer = () => {
     <div className="usa-alert usa-alert--info margin-left-105em margin-right-105em maxw-tablet-lg">
       <div className="usa-alert__body">
         <h2 className="usa-alert__heading">
-          New: Report flu and RSV results to California
+          New: Report flu and RSV results in select jurisdictions
         </h2>
         <div className="usa-alert__text">
           <p>
-            Organizations sending results to the California Department of Public
-            Health (CDPH) can now use the bulk results upload feature to report
-            positive flu and RSV tests. Report{" "}
+            SimpleReport allows organizations to report{" "}
             {BULK_UPLOAD_SUPPORTED_DISEASES_COPY_TEXT} results all from a single
-            spreadsheet.{" "}
+            spreadsheet to a growing number of jurisdictions. To check if your
+            jurisdiction is currently supported, please refer to the "Test for
+            Other Diseases" section in the{" "}
+            <a
+              href={
+                "https://www.simplereport.gov/using-simplereport/test-for-other-diseases/influenza/"
+              }
+            >
+              SimpleReport online user guide
+            </a>
+            .{" "}
             <a
               href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
               onClick={() => {
@@ -30,7 +38,7 @@ const DiseaseSpecificUploadContainer = () => {
                 });
               }}
             >
-              See more information and guidance about flu and RSV reporting
+              See more information and guidance about reporting these diseases
             </a>
             .
           </p>

--- a/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
@@ -28,21 +28,28 @@ exports[`Disease specific upload container test passes axe tests 1`] = `
             <h2
               class="usa-alert__heading"
             >
-              New: Report flu and RSV results to California
+              New: Report flu and RSV results in select jurisdictions
             </h2>
             <div
               class="usa-alert__text"
             >
               <p>
-                Organizations sending results to the California Department of Public Health (CDPH) can now use the bulk results upload feature to report positive flu and RSV tests. Report
+                SimpleReport allows organizations to report
                  
                 COVID-19, Flu A and B, and RSV
-                 results all from a single spreadsheet.
+                 results all from a single spreadsheet to a growing number of jurisdictions. To check if your jurisdiction is currently supported, please refer to the "Test for Other Diseases" section in the
+                 
+                <a
+                  href="https://www.simplereport.gov/using-simplereport/test-for-other-diseases/influenza/"
+                >
+                  SimpleReport online user guide
+                </a>
+                .
                  
                 <a
                   href="https://www.simplereport.gov/assets/resources/bulk_results_upload_guide-flu_pilot.pdf"
                 >
-                  See more information and guidance about flu and RSV reporting
+                  See more information and guidance about reporting these diseases
                 </a>
                 .
               </p>


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Fixs #7848 by genericizing the bulk uploader alternate diseases copy
- Updated the pdf guide on the static site in [this PR](https://github.com/CDCgov/prime-simplereport-site/pull/703)

## Screenshots / Demos
![Screenshot 2024-06-27 at 9 14 24 AM](https://github.com/CDCgov/prime-simplereport/assets/29645040/cabe5844-c783-4a7a-a48b-b7ff65a8d66e)

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
