### PR TITLE
Investigate failed Sonarqube builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Sonar analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
-        run: ./gradlew sonarqube -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
+        run: ./gradlew sonar -Dsonar.projectBaseDir=${{ env.PROJECT_ROOT }} --info
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -213,7 +213,8 @@ sonar {
         property "sonar.coverage.exclusions", "frontend/src/setupTests.js,frontend/src/index.tsx"
         property "sonar.cpd.exclusions", "frontend/src/lang/*.ts"
         property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info,ops/services/app_functions/report_stream_batched_publisher/functions/coverage/lcov.info"
-        property "sonar.gradle.skipCompile", "false"
+        property "sonar.gradle.skipCompile", "false",
+        property "sonar.java.binaries", "backend/build/classes/java/main"
     }
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -213,7 +213,7 @@ sonar {
         property "sonar.coverage.exclusions", "frontend/src/setupTests.js,frontend/src/index.tsx"
         property "sonar.cpd.exclusions", "frontend/src/lang/*.ts"
         property "sonar.javascript.lcov.reportPaths", "frontend/coverage/lcov.info,ops/services/app_functions/report_stream_batched_publisher/functions/coverage/lcov.info"
-        property "sonar.gradle.skipCompile", "false",
+        property "sonar.gradle.skipCompile", "false"
         property "sonar.java.binaries", "backend/build/classes/java/main"
     }
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- See Issue for this PR [here](https://github.com/orgs/CDCgov/projects/15/views/1?pane=issue&itemId=67055453)
- Sonarcube seems to be intermittently failing to build in CI jobs. See examples [here](https://github.com/CDCgov/prime-simplereport/actions/runs/9473846278/job/26102743160?pr=7787) and [here](https://github.com/CDCgov/prime-simplereport/actions/runs/9451499926/job/26085385093)

## Changes Proposed

- Added the `sonar.java.binaries` property and provided the value `backend/build/classes/java/main` which is the full path to the java classes
- modified the .`/gradlew sonarqube `command to `./gradlew sonar` due to `sonarqube` command being deprecated 


## Testing

- See successful [Github Action](https://github.com/CDCgov/prime-simplereport/actions/runs/9698227175/job/26764902047?pr=7853) for sonar step to verify no longer failing 
- A smoke test of basic functionality should be accomplished before merging.
- This PR has been verified on `dev2`

