### PR TITLE
Update roles and facilities on read

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -25,7 +25,7 @@ public class UserResolver {
 
   @QueryMapping
   public User whoami() {
-    return new User(_userService.getCurrentUserInfo());
+    return new User(_userService.getCurrentUserInfoForWhoAmI());
   }
 
   @QueryMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -222,6 +222,11 @@ public class ApiUserService {
     IdentityAttributes userIdentity = new IdentityAttributes(username, name);
     Optional<OrganizationRoleClaims> roleClaims = _oktaRepo.updateUser(userIdentity);
     Optional<OrganizationRoles> orgRoles = roleClaims.map(_orgService::getOrganizationRoles);
+
+    if (!_featureFlagsConfig.isOktaMigrationEnabled() && orgRoles.isPresent()) {
+      setRolesAndFacilities(orgRoles.get(), apiUser);
+    }
+
     UserInfo user = new UserInfo(apiUser, orgRoles, false);
 
     createUserUpdatedAuditLog(
@@ -274,6 +279,10 @@ public class ApiUserService {
 
     Optional<OrganizationRoleClaims> roleClaims = _oktaRepo.updateUserEmail(userIdentity, email);
     Optional<OrganizationRoles> orgRoles = roleClaims.map(_orgService::getOrganizationRoles);
+
+    if (!_featureFlagsConfig.isOktaMigrationEnabled() && orgRoles.isPresent()) {
+      setRolesAndFacilities(orgRoles.get(), apiUser);
+    }
 
     createUserUpdatedAuditLog(
         apiUser.getInternalId(), getCurrentApiUser().getInternalId().toString());

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator;
 import gov.cdc.usds.simplereport.api.pxp.CurrentPatientContextHolder;
 import gov.cdc.usds.simplereport.config.AuditingConfig;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
 import gov.cdc.usds.simplereport.config.InitialSetupProperties;
 import gov.cdc.usds.simplereport.config.SendGridDisabledConfiguration;
 import gov.cdc.usds.simplereport.config.authorization.DemoAuthenticationConfiguration;
@@ -109,6 +110,7 @@ import org.springframework.security.test.context.support.WithMockUser;
   OktaHealthIndicator.class,
   EmailService.class,
   SendGridDisabledConfiguration.class,
+  FeatureFlagsConfig.class
 })
 @EnableConfigurationProperties({InitialSetupProperties.class, AuthorizationProperties.class})
 public class SliceTestConfiguration {

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -131,6 +131,8 @@ simple-report:
         authorization:
           organization-external-id: DAT_ORG
           granted-roles: NO_ACCESS, USER
+          facilities:
+            - Uptown Clinic
       - identity: # OUTSIDE_ORG_ADMIN
           username: captain@pirate.com
           first-name: Jack


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part 1 for #7598

## Changes Proposed
- Saves role and facility information when the `oktaMigrationEnabled` feature flag is set to `false` and for the following actions:
  - any `whoami` calls
  - search for a user in the Support Admin page
  - loading the user in the "Manage users" page
  - resetting user password and mfa, reactivating the user, resending the activation email

## Additional Information
- Follow up PR will add functionality when the `oktaMigrationEnabled` feature flag is set to `true`

## Testing
- Deployed on dev3

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
