### PR TITLE
Add timer started at column to test order

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestOrder.java
@@ -55,6 +55,11 @@ public class TestOrder extends BaseTestInfo {
   @Setter
   private Set<Result> results = new HashSet<>();
 
+  @Column(name = "timer_started_at")
+  @Getter
+  @Setter
+  private String timerStartedAt;
+
   protected TestOrder() {
     /* for hibernate */
   }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5626,3 +5626,20 @@ databaseChangeLog:
                     references: role
         - sql: |
             GRANT SELECT ON ${database.defaultSchemaName}.api_user_role TO ${noPhiUsername};
+
+  - changeSet:
+      id: add-timer-started-at-to-test_order-table
+      author: ggs2@cdc.gov
+      changes:
+        - addColumn:
+            tableName: test_order
+            columns:
+              - column:
+                  name: timer_started_at
+                  type: text
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: test_order
+            columnName: timer_started_at


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Needed for #7054

## Changes Proposed

- Adds a `timer_started_at` column to TestOrder

## Additional Information

- Follow up PR will include the actual changes for keeping a test card timer in sync

## Testing

- Deployed on dev5
- Make sure conduct test flow still behaves normally as expected

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->