### PR TITLE
Bob/7806 okta endpoint test

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/BackendAndDatabaseHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/BackendAndDatabaseHealthIndicator.java
@@ -1,8 +1,6 @@
 package gov.cdc.usds.simplereport.api.heathcheck;
 
-import com.okta.sdk.resource.client.ApiException;
 import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.JDBCConnectionException;
@@ -15,27 +13,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BackendAndDatabaseHealthIndicator implements HealthIndicator {
   private final FeatureFlagRepository _ffRepo;
-  private final OktaRepository _oktaRepo;
-  public static final String ACTIVE_LITERAL = "ACTIVE";
 
   @Override
   public Health health() {
     try {
       _ffRepo.findAll();
-      String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
-
-      if (!ACTIVE_LITERAL.equals(oktaStatus)) {
-        log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
-        return Health.down().build();
-      }
       return Health.up().build();
 
       // reach into the ff repository returned a bad value or db connection issue respectively
     } catch (IllegalArgumentException | JDBCConnectionException e) {
-      return Health.down().build();
-    } catch (ApiException e) {
-      // Okta API call errored
-      log.info(e.getMessage());
       return Health.down().build();
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
@@ -1,0 +1,28 @@
+package gov.cdc.usds.simplereport.api.heathcheck;
+
+import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OktaHealthIndicator implements HealthIndicator {
+  private final OktaRepository _oktaRepo;
+  public static final String ACTIVE_LITERAL = "ACTIVE";
+
+  @Override
+  public Health health() {
+    String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
+    if (!ACTIVE_LITERAL.equals(oktaStatus)) {
+      log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
+      Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+
+      return oktaDegradedWarning.build();
+    }
+    return Health.up().build();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -1,6 +1,6 @@
 package gov.cdc.usds.simplereport.idp.repository;
 
-import static gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator.ACTIVE_LITERAL;
+import static gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator.ACTIVE_LITERAL;
 
 import com.okta.sdk.resource.model.UserStatus;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -690,7 +690,9 @@ public class LiveOktaRepository implements OktaRepository {
 
   @Override
   public String getApplicationStatusForHealthCheck() {
-    return app.getStatus().toString();
+    //        return Objects.requireNonNull(app.getStatus()).toString();
+    //        Demo hardcode return to test on a lower.
+    return "INACTIVE";
   }
 
   private Optional<OrganizationRoleClaims> getOrganizationRoleClaimsFromAuthorities(

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -78,6 +78,11 @@ management:
   endpoint.info.enabled: true
   endpoints.web.exposure.include: health, info
   endpoint.health.show-components: always
+  endpoint:
+    health:
+      status:
+        http-mapping:
+          okta_degraded: 204
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/BackendAndDatabaseHealthIndicatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/BackendAndDatabaseHealthIndicatorTest.java
@@ -1,6 +1,6 @@
 package gov.cdc.usds.simplereport.api.healthcheck;
 
-import static gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator.ACTIVE_LITERAL;
+import static gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator.ACTIVE_LITERAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -3,7 +3,6 @@
 // endpoint which does a simple ping to a non-sensitive DB table to verify
 // all the connections are good.
 // https://github.com/CDCgov/prime-simplereport/pull/7057
-
 require("dotenv").config();
 let { Builder } = require("selenium-webdriver");
 const Chrome = require("selenium-webdriver/chrome");
@@ -33,12 +32,12 @@ driver
     return value;
   })
   .then((value) => {
-    if (value.includes("success")) {
+    if (value.includes("App status returned success")) {
       console.log(`Smoke test returned success status for ${appUrl}`);
       process.exitCode = 0;
       return;
     }
-    if (value.includes("failure")) {
+    if (value.includes("App status returned failure")) {
       console.log(`Smoke test returned failure status for ${appUrl}`);
       process.exitCode = 1;
       return;

--- a/frontend/src/app/DeploySmokeTest.tsx
+++ b/frontend/src/app/DeploySmokeTest.tsx
@@ -2,26 +2,77 @@ import { useEffect, useState } from "react";
 
 import FetchClient from "./utils/api";
 
+const APP_STATUS_LOADING = "App status loading...";
+const APP_STATUS_SUCCESS = "App status returned success :)";
+const APP_STATUS_FAILURE = "App status returned failure :(";
+
+const OKTA_STATUS_LOADING = "Okta status loading...";
+const OKTA_STATUS_SUCCESS = "Okta status returned success :)";
+const OKTA_STATUS_FAILURE = "Okta status returned failure :(";
+
 const api = new FetchClient(undefined, { mode: "cors" });
 const DeploySmokeTest = (): JSX.Element => {
-  const [success, setSuccess] = useState<boolean>();
+  const [appStatus, setAppStatus] = useState<boolean>();
+  const [oktaStatus, setOktaStatus] = useState<boolean>();
+
   useEffect(() => {
     api
       .getRequest("/actuator/health/backend-and-db-smoke-test")
       .then((response) => {
         const status = JSON.parse(response);
-        if (status.status === "UP") return setSuccess(true);
-        setSuccess(false);
+        if (status.status === "UP") return setAppStatus(true);
+        setAppStatus(false);
       })
       .catch((e) => {
         console.error(e);
-        setSuccess(false);
+        setAppStatus(false);
       });
   }, []);
 
-  if (success === undefined) return <>Status loading...</>;
-  if (success) return <> Status returned success :) </>;
-  return <> Status returned failure :( </>;
+  useEffect(() => {
+    api
+      .getRequest("/actuator/health")
+      .then((response) => {
+        const status = JSON.parse(response);
+        if (status.okta === "UP") return setOktaStatus(true);
+        setOktaStatus(false);
+      })
+      .catch((e) => {
+        console.error(e);
+        setOktaStatus(false);
+      });
+  }, []);
+
+  let appStatusMessage;
+  switch (appStatus) {
+    case undefined:
+      appStatusMessage = APP_STATUS_LOADING;
+      break;
+    case true:
+      appStatusMessage = APP_STATUS_SUCCESS;
+      break;
+    case false:
+      appStatusMessage = APP_STATUS_FAILURE;
+      break;
+  }
+  let oktaStatusMessage;
+  switch (oktaStatus) {
+    case undefined:
+      oktaStatusMessage = OKTA_STATUS_LOADING;
+      break;
+    case true:
+      oktaStatusMessage = OKTA_STATUS_SUCCESS;
+      break;
+    case false:
+      oktaStatusMessage = OKTA_STATUS_FAILURE;
+      break;
+  }
+  return (
+    <>
+      <div className={"display-block"}>{appStatusMessage} </div>
+      <div className={"display-block"}> {oktaStatusMessage} </div>
+    </>
+  );
 };
 
 export default DeploySmokeTest;


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fixes #7806

## Changes Proposed

- Splits out the Okta health logic away from the backend health indicator
- Modifies the frontend status display to indicate differential status
    - Haven't changed the overall logic of the frontend script just yet since the ticket in question didn't make a firm decision on whether to alert on Okta being down through the deploy step. Can change this if needed in the future.

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

# FRONTEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
