### PR TITLE
break out okta endpoint from health check

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/BackendAndDatabaseHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/BackendAndDatabaseHealthIndicator.java
@@ -1,8 +1,6 @@
 package gov.cdc.usds.simplereport.api.heathcheck;
 
-import com.okta.sdk.resource.client.ApiException;
 import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.JDBCConnectionException;
@@ -15,27 +13,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BackendAndDatabaseHealthIndicator implements HealthIndicator {
   private final FeatureFlagRepository _ffRepo;
-  private final OktaRepository _oktaRepo;
-  public static final String ACTIVE_LITERAL = "ACTIVE";
 
   @Override
   public Health health() {
     try {
       _ffRepo.findAll();
-      String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
-
-      if (!ACTIVE_LITERAL.equals(oktaStatus)) {
-        log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
-        return Health.down().build();
-      }
       return Health.up().build();
 
       // reach into the ff repository returned a bad value or db connection issue respectively
     } catch (IllegalArgumentException | JDBCConnectionException e) {
-      return Health.down().build();
-    } catch (ApiException e) {
-      // Okta API call errored
-      log.info(e.getMessage());
       return Health.down().build();
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
@@ -16,13 +16,19 @@ public class OktaHealthIndicator implements HealthIndicator {
 
   @Override
   public Health health() {
-    String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
-    if (!ACTIVE_LITERAL.equals(oktaStatus)) {
-      log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
+    try {
+      String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
+      if (!ACTIVE_LITERAL.equals(oktaStatus)) {
+        log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
+        Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+        return oktaDegradedWarning.build();
+      }
+    } catch (NullPointerException e) {
+      log.info("Call to Okta repository status returned null");
       Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
-
       return oktaDegradedWarning.build();
     }
+
     return Health.up().build();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
@@ -1,5 +1,6 @@
 package gov.cdc.usds.simplereport.api.heathcheck;
 
+import com.okta.sdk.resource.client.ApiException;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,16 +17,19 @@ public class OktaHealthIndicator implements HealthIndicator {
 
   @Override
   public Health health() {
+    Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
     try {
       String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
       if (!ACTIVE_LITERAL.equals(oktaStatus)) {
         log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
-        Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
         return oktaDegradedWarning.build();
       }
     } catch (NullPointerException e) {
       log.info("Call to Okta repository status returned null");
-      Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+      return oktaDegradedWarning.build();
+    } catch (ApiException e) {
+      // Okta API call errored
+      log.info("Okta status call raised an exception: " + e.getMessage());
       return oktaDegradedWarning.build();
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/heathcheck/OktaHealthIndicator.java
@@ -1,0 +1,28 @@
+package gov.cdc.usds.simplereport.api.heathcheck;
+
+import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OktaHealthIndicator implements HealthIndicator {
+  private final OktaRepository _oktaRepo;
+  public static final String ACTIVE_LITERAL = "ACTIVE";
+
+  @Override
+  public Health health() {
+    String oktaStatus = _oktaRepo.getApplicationStatusForHealthCheck();
+    if (!ACTIVE_LITERAL.equals(oktaStatus)) {
+      log.info("Okta status didn't return ACTIVE, instead returned " + oktaStatus);
+      Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+
+      return oktaDegradedWarning.build();
+    }
+    return Health.up().build();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -1,6 +1,6 @@
 package gov.cdc.usds.simplereport.idp.repository;
 
-import static gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator.ACTIVE_LITERAL;
+import static gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator.ACTIVE_LITERAL;
 
 import com.okta.sdk.resource.model.UserStatus;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -690,7 +690,9 @@ public class LiveOktaRepository implements OktaRepository {
 
   @Override
   public String getApplicationStatusForHealthCheck() {
-    return app.getStatus().toString();
+    //        return Objects.requireNonNull(app.getStatus()).toString();
+    //        Demo hardcode return to test on a lower.
+    return "INACTIVE";
   }
 
   private Optional<OrganizationRoleClaims> getOrganizationRoleClaimsFromAuthorities(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -691,9 +691,7 @@ public class LiveOktaRepository implements OktaRepository {
 
   @Override
   public String getApplicationStatusForHealthCheck() {
-    //        return Objects.requireNonNull(app.getStatus()).toString();
-    //        Demo hardcode return to test on a lower.
-    return "INACTIVE";
+    return Objects.requireNonNull(app.getStatus()).toString();
   }
 
   private Optional<OrganizationRoleClaims> getOrganizationRoleClaimsFromAuthorities(

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -74,11 +74,10 @@ server:
   error:
     include-stacktrace: never
 management:
-  endpoint.health.probes.enabled: true
-  endpoint.info.enabled: true
   endpoints.web.exposure.include: health, info
-  endpoint.health.show-components: always
   endpoint:
+    info:
+      enabled: true
     health:
       show-components: always
       status:

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -78,6 +78,11 @@ management:
   endpoint.info.enabled: true
   endpoints.web.exposure.include: health, info
   endpoint.health.show-components: always
+  endpoint:
+    health:
+      status:
+        http-mapping:
+          okta_degraded: 204
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -80,9 +80,11 @@ management:
   endpoint.health.show-components: always
   endpoint:
     health:
+      show-components: always
       status:
         http-mapping:
           okta_degraded: 204
+      probes.enabled: true
 okta:
   oauth2:
     issuer: https://hhs-prime.okta.com/oauth2/default

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/BackendAndDatabaseHealthIndicatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/BackendAndDatabaseHealthIndicatorTest.java
@@ -1,13 +1,11 @@
 package gov.cdc.usds.simplereport.api.healthcheck;
 
-import static gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator.ACTIVE_LITERAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.db.repository.FeatureFlagRepository;
-import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +21,12 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 class BackendAndDatabaseHealthIndicatorTest extends BaseRepositoryTest {
 
   @SpyBean private FeatureFlagRepository mockFeatureFlagRepo;
-  @SpyBean private OktaRepository mockOktaRepo;
 
   @Autowired private BackendAndDatabaseHealthIndicator indicator;
 
   @Test
   void health_succeedsWhenReposDoesntThrow() {
     when(mockFeatureFlagRepo.findAll()).thenReturn(List.of());
-    when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenReturn(ACTIVE_LITERAL);
 
     assertThat(indicator.health()).isEqualTo(Health.up().build());
   }
@@ -49,12 +45,6 @@ class BackendAndDatabaseHealthIndicatorTest extends BaseRepositoryTest {
     IllegalArgumentException dbConnectionException =
         new IllegalArgumentException("some argument message");
     when(mockFeatureFlagRepo.findAll()).thenThrow(dbConnectionException);
-    assertThat(indicator.health()).isEqualTo(Health.down().build());
-  }
-
-  @Test
-  void health_failsWhenOktaRepoDoesntReturnActive() {
-    when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenReturn("INACTIVE");
     assertThat(indicator.health()).isEqualTo(Health.down().build());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/OktaHealthIndicatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/OktaHealthIndicatorTest.java
@@ -3,9 +3,10 @@ package gov.cdc.usds.simplereport.api.healthcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.okta.sdk.resource.client.ApiException;
 import gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
-import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
+import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,14 +18,29 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 @EnableConfigurationProperties
 class OktaHealthIndicatorTest extends BaseRepositoryTest {
 
-  @SpyBean private DemoOktaRepository mockOktaRepo;
+  @SpyBean private OktaRepository mockOktaRepo;
 
   @Autowired private OktaHealthIndicator indicator;
 
   @Test
-  void health_SUCCEEDSWhenOktaRepoReturnsActive() {
+  void health_SucceedsWhenOktaRepoReturnsActive() {
     when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenReturn("ACTIVE");
     assertThat(indicator.health()).isEqualTo(Health.up().build());
+  }
+
+  @Test
+  void health_FailsWhenOktaApiThrowsErrors() {
+    when(mockOktaRepo.getApplicationStatusForHealthCheck())
+        .thenThrow(new ApiException("some api error"));
+    Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+    assertThat(indicator.health()).isEqualTo(oktaDegradedWarning.build());
+  }
+
+  @Test
+  void health_FailsWhenOktaApiThrowsNPE() {
+    when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenThrow(new NullPointerException());
+    Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+    assertThat(indicator.health()).isEqualTo(oktaDegradedWarning.build());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/OktaHealthIndicatorTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/healthcheck/OktaHealthIndicatorTest.java
@@ -1,0 +1,37 @@
+package gov.cdc.usds.simplereport.api.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator;
+import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
+import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@RequiredArgsConstructor
+@EnableConfigurationProperties
+class OktaHealthIndicatorTest extends BaseRepositoryTest {
+
+  @SpyBean private DemoOktaRepository mockOktaRepo;
+
+  @Autowired private OktaHealthIndicator indicator;
+
+  @Test
+  void health_SUCCEEDSWhenOktaRepoReturnsActive() {
+    when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenReturn("ACTIVE");
+    assertThat(indicator.health()).isEqualTo(Health.up().build());
+  }
+
+  @Test
+  void health_failsWhenOktaRepoDoesntReturnActive() {
+    when(mockOktaRepo.getApplicationStatusForHealthCheck()).thenReturn("INACTIVE");
+    Health.Builder oktaDegradedWarning = Health.status("OKTA_DEGRADED");
+
+    assertThat(indicator.health()).isEqualTo(oktaDegradedWarning.build());
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -6,6 +6,7 @@ import gov.cdc.usds.simplereport.api.CurrentOrganizationRolesContextHolder;
 import gov.cdc.usds.simplereport.api.CurrentTenantDataAccessContextHolder;
 import gov.cdc.usds.simplereport.api.WebhookContextHolder;
 import gov.cdc.usds.simplereport.api.heathcheck.BackendAndDatabaseHealthIndicator;
+import gov.cdc.usds.simplereport.api.heathcheck.OktaHealthIndicator;
 import gov.cdc.usds.simplereport.api.pxp.CurrentPatientContextHolder;
 import gov.cdc.usds.simplereport.config.AuditingConfig;
 import gov.cdc.usds.simplereport.config.AuthorizationProperties;
@@ -105,6 +106,7 @@ import org.springframework.security.test.context.support.WithMockUser;
   TenantDataAccessService.class,
   PatientSelfRegistrationLinkService.class,
   BackendAndDatabaseHealthIndicator.class,
+  OktaHealthIndicator.class,
   EmailService.class,
   SendGridDisabledConfiguration.class,
 })

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -32,16 +32,35 @@ driver
     return value;
   })
   .then((value) => {
+    let appStatusSuccess, oktaStatusSuccess;
     if (value.includes("App status returned success")) {
+      appStatusSuccess = true;
+    }
+    if (value.includes("Okta status returned success")) {
+      oktaStatusSuccess = true;
+    }
+    if (value.includes("App status returned failure")) {
+      appStatusSuccess = false;
+    }
+    if (value.includes("Okta status returned failure")) {
+      oktaStatusSuccess = false;
+    }
+
+    if (appStatusSuccess && oktaStatusSuccess) {
       console.log(`Smoke test returned success status for ${appUrl}`);
       process.exitCode = 0;
       return;
     }
-    if (value.includes("App status returned failure")) {
+
+    if (appStatusSuccess === false || oktaStatusSuccess === false) {
       console.log(`Smoke test returned failure status for ${appUrl}`);
+      console.log(
+        `App health returned ${appStatusSuccess}, okta health returned ${oktaStatusSuccess}`
+      );
       process.exitCode = 1;
       return;
     }
+
     console.log("Smoke test encountered unknown failure.");
     console.log(`Root element value was: ${value}`);
     process.exitCode = 1;

--- a/frontend/deploy-smoke.js
+++ b/frontend/deploy-smoke.js
@@ -3,7 +3,6 @@
 // endpoint which does a simple ping to a non-sensitive DB table to verify
 // all the connections are good.
 // https://github.com/CDCgov/prime-simplereport/pull/7057
-
 require("dotenv").config();
 let { Builder } = require("selenium-webdriver");
 const Chrome = require("selenium-webdriver/chrome");
@@ -33,12 +32,12 @@ driver
     return value;
   })
   .then((value) => {
-    if (value.includes("success")) {
+    if (value.includes("App status returned success")) {
       console.log(`Smoke test returned success status for ${appUrl}`);
       process.exitCode = 0;
       return;
     }
-    if (value.includes("failure")) {
+    if (value.includes("App status returned failure")) {
       console.log(`Smoke test returned failure status for ${appUrl}`);
       process.exitCode = 1;
       return;

--- a/frontend/src/app/DeploySmokeTest.test.tsx
+++ b/frontend/src/app/DeploySmokeTest.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { FetchMock } from "jest-fetch-mock";
 
-import DeploySmokeTest from "./DeploySmokeTest";
+import DeploySmokeTest, {
+  APP_STATUS_FAILURE,
+  APP_STATUS_LOADING,
+  APP_STATUS_SUCCESS,
+} from "./DeploySmokeTest";
 
 describe("DeploySmokeTest", () => {
   beforeEach(() => {
@@ -10,21 +14,26 @@ describe("DeploySmokeTest", () => {
 
   it("renders success when returned from the API endpoint", async () => {
     (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "UP" }));
+    (fetch as FetchMock).mockResponseOnce(
+      JSON.stringify({ okta: "UP", status: "UP" })
+    );
 
     render(<DeploySmokeTest />);
     await waitFor(() =>
-      expect(screen.queryByText("Status loading...")).not.toBeInTheDocument()
+      expect(screen.queryByText(APP_STATUS_LOADING)).not.toBeInTheDocument()
     );
-    expect(screen.getByText("Status returned success :)"));
+    expect(screen.getByText(APP_STATUS_SUCCESS));
   });
 
   it("renders failure when returned from the API endpoint", async () => {
-    (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "DOWN" }));
+    (fetch as FetchMock).mockResponse(
+      JSON.stringify({ okta: "UP", status: "DOWN" })
+    );
 
     render(<DeploySmokeTest />);
     await waitFor(() =>
-      expect(screen.queryByText("Status loading...")).not.toBeInTheDocument()
+      expect(screen.queryByText(APP_STATUS_LOADING)).not.toBeInTheDocument()
     );
-    expect(screen.getByText("Status returned failure :("));
+    expect(screen.getByText(APP_STATUS_FAILURE));
   });
 });

--- a/frontend/src/app/DeploySmokeTest.test.tsx
+++ b/frontend/src/app/DeploySmokeTest.test.tsx
@@ -5,6 +5,8 @@ import DeploySmokeTest, {
   APP_STATUS_FAILURE,
   APP_STATUS_LOADING,
   APP_STATUS_SUCCESS,
+  OKTA_STATUS_LOADING,
+  OKTA_STATUS_SUCCESS,
 } from "./DeploySmokeTest";
 
 describe("DeploySmokeTest", () => {
@@ -15,7 +17,7 @@ describe("DeploySmokeTest", () => {
   it("renders success when returned from the API endpoint", async () => {
     (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "UP" }));
     (fetch as FetchMock).mockResponseOnce(
-      JSON.stringify({ okta: "UP", status: "UP" })
+      JSON.stringify({ components: { okta: { status: "UP" } }, status: "DOWN" })
     );
 
     render(<DeploySmokeTest />);
@@ -27,7 +29,7 @@ describe("DeploySmokeTest", () => {
 
   it("renders failure when returned from the API endpoint", async () => {
     (fetch as FetchMock).mockResponse(
-      JSON.stringify({ okta: "UP", status: "DOWN" })
+      JSON.stringify({ components: { okta: { status: "UP" } }, status: "DOWN" })
     );
 
     render(<DeploySmokeTest />);
@@ -35,5 +37,17 @@ describe("DeploySmokeTest", () => {
       expect(screen.queryByText(APP_STATUS_LOADING)).not.toBeInTheDocument()
     );
     expect(screen.getByText(APP_STATUS_FAILURE));
+  });
+
+  it("renders Okta success when returned from the API endpoint", async () => {
+    (fetch as FetchMock).mockResponse(
+      JSON.stringify({ components: { okta: { status: "UP" } }, status: "UP" })
+    );
+
+    render(<DeploySmokeTest />);
+    await waitFor(() =>
+      expect(screen.queryByText(OKTA_STATUS_LOADING)).not.toBeInTheDocument()
+    );
+    expect(screen.getByText(OKTA_STATUS_SUCCESS));
   });
 });

--- a/frontend/src/app/DeploySmokeTest.test.tsx
+++ b/frontend/src/app/DeploySmokeTest.test.tsx
@@ -15,13 +15,9 @@ describe("DeploySmokeTest", () => {
     (fetch as FetchMock).resetMocks();
   });
 
-  it("renders success when returned from the API endpoint", async () => {
-    (fetch as FetchMock).mockResponseOnce(
-      JSON.stringify(generateBackendApiHealthResponse("UP"))
-    );
-    (fetch as FetchMock).mockResponseOnce(
-      JSON.stringify(generateBackendApiHealthResponse("DOWN"))
-    );
+  it("renders success when returned from the backend API smoke test endpoint", async () => {
+    (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "UP" }));
+    (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "DOWN" }));
 
     render(<DeploySmokeTest />);
     await waitFor(() =>
@@ -30,10 +26,8 @@ describe("DeploySmokeTest", () => {
     expect(screen.getByText(APP_STATUS_SUCCESS));
   });
 
-  it("renders failure when returned from the API endpoint", async () => {
-    (fetch as FetchMock).mockResponse(
-      JSON.stringify(generateBackendApiHealthResponse("DOWN"))
-    );
+  it("renders failure when returned from the backend API smoke test endpoint", async () => {
+    (fetch as FetchMock).mockResponse(JSON.stringify({ status: "DOWN" }));
 
     render(<DeploySmokeTest />);
     await waitFor(() =>
@@ -42,7 +36,7 @@ describe("DeploySmokeTest", () => {
     expect(screen.getByText(APP_STATUS_FAILURE));
   });
 
-  it("renders Okta success when returned from the API endpoint", async () => {
+  it("renders Okta success when returned from the backend API health endpoint", async () => {
     (fetch as FetchMock).mockResponse(
       JSON.stringify(generateBackendApiHealthResponse())
     );

--- a/frontend/src/app/DeploySmokeTest.test.tsx
+++ b/frontend/src/app/DeploySmokeTest.test.tsx
@@ -8,6 +8,7 @@ import DeploySmokeTest, {
   OKTA_STATUS_LOADING,
   OKTA_STATUS_SUCCESS,
 } from "./DeploySmokeTest";
+import { generateBackendApiHealthResponse } from "./deploySmokeTestTestConstants";
 
 describe("DeploySmokeTest", () => {
   beforeEach(() => {
@@ -15,9 +16,11 @@ describe("DeploySmokeTest", () => {
   });
 
   it("renders success when returned from the API endpoint", async () => {
-    (fetch as FetchMock).mockResponseOnce(JSON.stringify({ status: "UP" }));
     (fetch as FetchMock).mockResponseOnce(
-      JSON.stringify({ components: { okta: { status: "UP" } }, status: "DOWN" })
+      JSON.stringify(generateBackendApiHealthResponse("UP"))
+    );
+    (fetch as FetchMock).mockResponseOnce(
+      JSON.stringify(generateBackendApiHealthResponse("DOWN"))
     );
 
     render(<DeploySmokeTest />);
@@ -29,7 +32,7 @@ describe("DeploySmokeTest", () => {
 
   it("renders failure when returned from the API endpoint", async () => {
     (fetch as FetchMock).mockResponse(
-      JSON.stringify({ components: { okta: { status: "UP" } }, status: "DOWN" })
+      JSON.stringify(generateBackendApiHealthResponse("DOWN"))
     );
 
     render(<DeploySmokeTest />);
@@ -41,7 +44,7 @@ describe("DeploySmokeTest", () => {
 
   it("renders Okta success when returned from the API endpoint", async () => {
     (fetch as FetchMock).mockResponse(
-      JSON.stringify({ components: { okta: { status: "UP" } }, status: "UP" })
+      JSON.stringify(generateBackendApiHealthResponse())
     );
 
     render(<DeploySmokeTest />);

--- a/frontend/src/app/DeploySmokeTest.tsx
+++ b/frontend/src/app/DeploySmokeTest.tsx
@@ -2,26 +2,77 @@ import { useEffect, useState } from "react";
 
 import FetchClient from "./utils/api";
 
+const APP_STATUS_LOADING = "App status loading...";
+const APP_STATUS_SUCCESS = "App status returned success :)";
+const APP_STATUS_FAILURE = "App status returned failure :(";
+
+const OKTA_STATUS_LOADING = "Okta status loading...";
+const OKTA_STATUS_SUCCESS = "Okta status returned success :)";
+const OKTA_STATUS_FAILURE = "Okta status returned failure :(";
+
 const api = new FetchClient(undefined, { mode: "cors" });
 const DeploySmokeTest = (): JSX.Element => {
-  const [success, setSuccess] = useState<boolean>();
+  const [appStatus, setAppStatus] = useState<boolean>();
+  const [oktaStatus, setOktaStatus] = useState<boolean>();
+
   useEffect(() => {
     api
       .getRequest("/actuator/health/backend-and-db-smoke-test")
       .then((response) => {
         const status = JSON.parse(response);
-        if (status.status === "UP") return setSuccess(true);
-        setSuccess(false);
+        if (status.status === "UP") return setAppStatus(true);
+        setAppStatus(false);
       })
       .catch((e) => {
         console.error(e);
-        setSuccess(false);
+        setAppStatus(false);
       });
   }, []);
 
-  if (success === undefined) return <>Status loading...</>;
-  if (success) return <> Status returned success :) </>;
-  return <> Status returned failure :( </>;
+  useEffect(() => {
+    api
+      .getRequest("/actuator/health")
+      .then((response) => {
+        const status = JSON.parse(response);
+        if (status.okta === "UP") return setOktaStatus(true);
+        setOktaStatus(false);
+      })
+      .catch((e) => {
+        console.error(e);
+        setOktaStatus(false);
+      });
+  }, []);
+
+  let appStatusMessage;
+  switch (appStatus) {
+    case undefined:
+      appStatusMessage = APP_STATUS_LOADING;
+      break;
+    case true:
+      appStatusMessage = APP_STATUS_SUCCESS;
+      break;
+    case false:
+      appStatusMessage = APP_STATUS_FAILURE;
+      break;
+  }
+  let oktaStatusMessage;
+  switch (oktaStatus) {
+    case undefined:
+      oktaStatusMessage = OKTA_STATUS_LOADING;
+      break;
+    case true:
+      oktaStatusMessage = OKTA_STATUS_SUCCESS;
+      break;
+    case false:
+      oktaStatusMessage = OKTA_STATUS_FAILURE;
+      break;
+  }
+  return (
+    <>
+      <div className={"display-block"}>{appStatusMessage} </div>
+      <div className={"display-block"}> {oktaStatusMessage} </div>
+    </>
+  );
 };
 
 export default DeploySmokeTest;

--- a/frontend/src/app/DeploySmokeTest.tsx
+++ b/frontend/src/app/DeploySmokeTest.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react";
 
 import FetchClient from "./utils/api";
 
-const APP_STATUS_LOADING = "App status loading...";
-const APP_STATUS_SUCCESS = "App status returned success :)";
-const APP_STATUS_FAILURE = "App status returned failure :(";
+export const APP_STATUS_LOADING = "App status loading...";
+export const APP_STATUS_SUCCESS = "App status returned success :)";
+export const APP_STATUS_FAILURE = "App status returned failure :(";
 
-const OKTA_STATUS_LOADING = "Okta status loading...";
-const OKTA_STATUS_SUCCESS = "Okta status returned success :)";
-const OKTA_STATUS_FAILURE = "Okta status returned failure :(";
+export const OKTA_STATUS_LOADING = "Okta status loading...";
+export const OKTA_STATUS_SUCCESS = "Okta status returned success :)";
+export const OKTA_STATUS_FAILURE = "Okta status returned failure :(";
 
 const api = new FetchClient(undefined, { mode: "cors" });
 const DeploySmokeTest = (): JSX.Element => {

--- a/frontend/src/app/DeploySmokeTest.tsx
+++ b/frontend/src/app/DeploySmokeTest.tsx
@@ -34,7 +34,7 @@ const DeploySmokeTest = (): JSX.Element => {
       .getRequest("/actuator/health")
       .then((response) => {
         const status = JSON.parse(response);
-        if (status.okta === "UP") return setOktaStatus(true);
+        if (status.components.okta.status === "UP") return setOktaStatus(true);
         setOktaStatus(false);
       })
       .catch((e) => {

--- a/frontend/src/app/deploySmokeTestTestConstants.ts
+++ b/frontend/src/app/deploySmokeTestTestConstants.ts
@@ -1,0 +1,54 @@
+type SpringHealthStatusValues = "UP" | "DOWN" | "OKTA_DEGRADED";
+export const generateBackendApiHealthResponse = (
+  overallStatus?: SpringHealthStatusValues,
+  oktaStatus?: SpringHealthStatusValues
+) => {
+  return {
+    status: overallStatus ?? "UP",
+    components: {
+      "backend-and-db-smoke-test": {
+        status: "UP",
+      },
+      db: {
+        status: "UP",
+        components: {
+          metabaseDataSource: {
+            status: "UP",
+          },
+          primaryDataSource: {
+            status: "UP",
+          },
+        },
+      },
+      discoveryComposite: {
+        description: "Discovery Client not initialized",
+        status: "UNKNOWN",
+        components: {
+          discoveryClient: {
+            description: "Discovery Client not initialized",
+            status: "UNKNOWN",
+          },
+        },
+      },
+      diskSpace: {
+        status: "UP",
+      },
+      livenessState: {
+        status: "UP",
+      },
+      okta: {
+        status: oktaStatus ?? "UP",
+      },
+      ping: {
+        status: "UP",
+      },
+      readinessState: {
+        status: "UP",
+      },
+      refreshScope: {
+        status: "UP",
+      },
+    },
+    groups: ["liveness", "readiness"],
+  };
+};


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Fixes #7806

## Changes Proposed

- Splits out the Okta health logic away from the backend health indicator
- Creates a specific okta degraded health state that's configured to return a 204 status code on trigger
- Modifies the frontend status display to indicate differential status
    - I added in the Okta check to flag out a failure in the deploy alerting script, which wasn't explicitly called out in the ticket but that duplicates what used to happen (thanks @mehansen for flagging!). Worth talking if we want to break this out to a separate alert but leaving it for now for status quo reasons.

## Testing

I've deployed [this test branch](https://github.com/CDCgov/prime-simplereport/tree/bob/7806-okta-endpoint-test) that hardcodes a "down" status from the Okta check. Double check that [the frontend status display ](https://dev2.simplereport.gov/app/health/deploy-smoke-test) looks ok and that [the health check in Azure](https://portal.azure.com/#@cdc.onmicrosoft.com/resource/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-dev/providers/Microsoft.Web/sites/simple-report-api-dev2/healthcheck) looks ok 
![Screenshot 2024-07-08 at 12 29 19 PM](https://github.com/CDCgov/prime-simplereport/assets/29645040/61a2f6bb-6013-43a2-a9b4-a200e25c4e11)

Can also pull the value down locally and hard code return values for `getApplicationStatusForHealthCheck` in the demo okta repository to observe changes on the backend API return on port 8080 or on the frontend status page
![Screenshot 2024-07-08 at 12 28 40 PM](https://github.com/CDCgov/prime-simplereport/assets/29645040/c486bfff-9862-4308-9b2b-6eaf17e39120)

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---