### PR TITLE
upgrade metabase to v.0.50.10

### DIFF
--- a/ops/services/metabase/service/main.tf
+++ b/ops/services/metabase/service/main.tf
@@ -49,7 +49,7 @@ resource "azurerm_linux_web_app" "metabase" {
 
     application_stack {
       docker_image     = "metabase/metabase"
-      docker_image_tag = "v0.44.7.1"
+      docker_image_tag = "v0.50.10"
     }
   }
 


### PR DESCRIPTION
upgrading metabase (which we haven't touched since [this PR back in 2023](https://github.com/CDCgov/prime-simplereport/pull/6191)) to v.0.50.10 to get access to some analysis features needed for some new dashboards.

@shanice-skylight and @alismx: it looks like an action item from that old PR is to work this into our automatic upgrade routine. Don't think this was ever picked up, so made a ticket for it [here](https://github.com/CDCgov/prime-simplereport/issues/7894).

[Deployed on dev2](https://dev2.simplereport.gov/metabase) and everything looks ok to me, but would love to have someone else double check things look ok to them if they have access to dev2 metabase