### PR TITLE
Synchronize test timers for all users

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/ApiTestOrder.java
@@ -30,4 +30,8 @@ public class ApiTestOrder extends WrappedEntity<TestOrder> {
   public String getReasonForCorrection() {
     return wrapped.getReasonForCorrection();
   }
+
+  public String getTimerStartedAt() {
+    return wrapped.getTimerStartedAt();
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolver.java
@@ -114,4 +114,10 @@ public class QueueMutationResolver {
       personService.updateTestResultDeliveryPreference(patientId, testResultDelivery);
     }
   }
+
+  @MutationMapping
+  public void updateTestOrderTimerStartedAt(
+      @Argument UUID testOrderId, @Argument String startedAt) {
+    testOrderService.updateTimerStartedAt(testOrderId, startedAt);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -484,6 +484,16 @@ public class TestOrderService {
     _testOrderRepo.save(order);
   }
 
+  @AuthorizationConfiguration.RequirePermissionUpdateTestForPatient
+  public void updateTimerStartedAt(UUID id, String startedAt) {
+    Optional<TestOrder> optionalTestOrder = _testOrderRepo.findById(id);
+    if (optionalTestOrder.isPresent()) {
+      TestOrder order = optionalTestOrder.get();
+      order.setTimerStartedAt(startedAt);
+      _testOrderRepo.save(order);
+    }
+  }
+
   private TestOrder retrieveTestOrder(UUID patientId) {
     Organization org = _organizationService.getCurrentOrganization();
     Person patient = _personService.getPatientNoPermissionsCheck(patientId, org);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -491,6 +491,8 @@ public class TestOrderService {
       TestOrder order = optionalTestOrder.get();
       order.setTimerStartedAt(startedAt);
       _testOrderRepo.save(order);
+    } else {
+      throw new IllegalGraphqlArgumentException("Cannot find TestOrder");
     }
   }
 

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -279,6 +279,7 @@ type TestOrder {
   dateTested: DateTime
   correctionStatus: String
   reasonForCorrection: String
+  timerStartedAt: String
 }
 
 type TestResult {
@@ -693,6 +694,10 @@ type Mutation {
     noSymptoms: Boolean
     genderOfSexualPartners: [String]
     testResultDelivery: TestResultDeliveryPreference
+  ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
+  updateTestOrderTimerStartedAt(
+    testOrderId: ID!
+    startedAt: String
   ): String @requiredPermissions(allOf: ["UPDATE_TEST"])
   sendPatientLinkSms(internalId: ID!): Boolean
     @requiredPermissions(allOf: ["UPDATE_TEST"])

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/queue/QueueMutationResolverTest.java
@@ -1,0 +1,33 @@
+package gov.cdc.usds.simplereport.api.queue;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import gov.cdc.usds.simplereport.service.PersonService;
+import gov.cdc.usds.simplereport.service.TestOrderService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
+
+@Component
+class QueueMutationResolverTest {
+  @Test
+  void updateTestTimer() {
+    // GIVEN
+    TestOrderService testOrderService = mock(TestOrderService.class);
+    PersonService personService = mock(PersonService.class);
+
+    long currentTime = System.currentTimeMillis();
+    String currentTimeString = Long.toString(currentTime);
+
+    var sut = new QueueMutationResolver(testOrderService, personService);
+
+    // WHEN
+    sut.updateTestOrderTimerStartedAt(UUID.randomUUID(), currentTimeString);
+
+    // THEN
+    verify(testOrderService).updateTimerStartedAt(any(UUID.class), eq(currentTimeString));
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2343,6 +2343,21 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertNull(modifiedNoTimerOrder.getTimerStartedAt());
   }
 
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void updateTimer_testOrderNotFound_throwsException() {
+    long currentTime = System.currentTimeMillis();
+    String currentTimeString = Long.toString(currentTime);
+
+    IllegalGraphqlArgumentException caught =
+        assertThrows(
+            IllegalGraphqlArgumentException.class,
+            () -> {
+              _service.updateTimerStartedAt(UUID.randomUUID(), currentTimeString);
+            });
+    assertEquals("Cannot find TestOrder", caught.getMessage());
+  }
+
   private List<TestEvent> makeAdminData() {
     var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
     _organizationService.setIdentityVerified("da-org-airport", true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2325,6 +2325,28 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     verify(testEventReportingService, times(2)).report(any());
   }
 
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void updateTimer_savesCorrectly() {
+    // GIVEN
+    TestOrder timerOrder = addTestToQueue();
+    TestOrder noTimerOrder = addTestToQueue();
+
+    long currentTime = System.currentTimeMillis();
+    String currentTimeString = Long.toString(currentTime);
+
+    // WHEN
+    _service.updateTimerStartedAt(timerOrder.getInternalId(), currentTimeString);
+    _service.updateTimerStartedAt(noTimerOrder.getInternalId(), null);
+
+    // THEN
+    TestOrder modifiedTimerOrder = _service.getTestOrder(timerOrder.getInternalId());
+    assertEquals(modifiedTimerOrder.getTimerStartedAt(), currentTimeString);
+
+    TestOrder modifiedNoTimerOrder = _service.getTestOrder(noTimerOrder.getInternalId());
+    assertNull(modifiedNoTimerOrder.getTimerStartedAt());
+  }
+
   private List<TestEvent> makeAdminData() {
     var org = _organizationService.createOrganization("Da Org", "airport", "da-org-airport");
     _organizationService.setIdentityVerified("da-org-airport", true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2328,22 +2328,18 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @Test
   @WithSimpleReportOrgAdminUser
   void updateTimer_savesCorrectly() {
-    // GIVEN
     TestOrder timerOrder = addTestToQueue();
-    TestOrder noTimerOrder = addTestToQueue();
-
     long currentTime = System.currentTimeMillis();
     String currentTimeString = Long.toString(currentTime);
 
-    // WHEN
+    // saves a time value
     _service.updateTimerStartedAt(timerOrder.getInternalId(), currentTimeString);
-    _service.updateTimerStartedAt(noTimerOrder.getInternalId(), null);
-
-    // THEN
     TestOrder modifiedTimerOrder = _service.getTestOrder(timerOrder.getInternalId());
     assertEquals(modifiedTimerOrder.getTimerStartedAt(), currentTimeString);
 
-    TestOrder modifiedNoTimerOrder = _service.getTestOrder(noTimerOrder.getInternalId());
+    // saves a null time value
+    _service.updateTimerStartedAt(timerOrder.getInternalId(), null);
+    TestOrder modifiedNoTimerOrder = _service.getTestOrder(timerOrder.getInternalId());
     assertNull(modifiedNoTimerOrder.getTimerStartedAt());
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -2348,12 +2348,13 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void updateTimer_testOrderNotFound_throwsException() {
     long currentTime = System.currentTimeMillis();
     String currentTimeString = Long.toString(currentTime);
+    UUID testOrderId = UUID.randomUUID();
 
     IllegalGraphqlArgumentException caught =
         assertThrows(
             IllegalGraphqlArgumentException.class,
             () -> {
-              _service.updateTimerStartedAt(UUID.randomUUID(), currentTimeString);
+              _service.updateTimerStartedAt(testOrderId, currentTimeString);
             });
     assertEquals("Cannot find TestOrder", caught.getMessage());
   }

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -70,6 +70,7 @@ import mockSupportedDiseaseMultiplex, {
 } from "../mocks/mockSupportedDiseaseMultiplex";
 import mockSupportedDiseaseTestPerformedHIV from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHIV";
 import mockSupportedDiseaseTestPerformedSyphilis from "../../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedSyphilis";
+import { UpdateTestOrderTimerStartedAtDocument } from "../../../generated/graphql";
 
 import { TestCard, TestCardProps } from "./TestCard";
 
@@ -412,6 +413,30 @@ describe("TestCard", () => {
     await user.type(screen.getByTestId("device-type-dropdown"), "lumira");
 
     expect(await screen.findByTestId("timer")).toHaveTextContent("Start timer");
+  });
+
+  it("updates the test order timer started at value when the timer is clicked", async () => {
+    const currentTime = Date.now();
+    const props = { ...testProps };
+    props.testOrder.timerStartedAt = currentTime.toString();
+    const { user } = await renderQueueItem({
+      props: props,
+      mocks: [
+        {
+          request: {
+            query: UpdateTestOrderTimerStartedAtDocument,
+            variables: { testOrderId: props.testOrder.internalId },
+          },
+          result: { data: { updateTestOrderTimerStartedAt: null } },
+        },
+      ],
+    });
+
+    const timerButton = await screen.findByTestId("timer");
+    expect(timerButton).toHaveTextContent("15:00");
+
+    await user.click(timerButton);
+    expect(timerButton).toHaveTextContent("Start timer");
   });
 
   it("renders dropdown of device types", async () => {

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -439,6 +439,45 @@ describe("TestCard", () => {
     expect(timerButton).toHaveTextContent("Start timer");
   });
 
+  it("handles a null timer started at value", async () => {
+    const currentTime = Date.now();
+    global.Date.now = jest.fn(() => new Date(currentTime).getTime());
+    const props = { ...testProps };
+    props.testOrder.timerStartedAt = null;
+    const { user } = await renderQueueItem({
+      props: props,
+      mocks: [
+        {
+          request: {
+            query: UpdateTestOrderTimerStartedAtDocument,
+            variables: {
+              testOrderId: props.testOrder.internalId,
+              startedAt: currentTime.toString(),
+            },
+          },
+          result: { data: { updateTestOrderTimerStartedAt: null } },
+        },
+        {
+          request: {
+            query: UpdateTestOrderTimerStartedAtDocument,
+            variables: { testOrderId: props.testOrder.internalId },
+          },
+          result: { data: { updateTestOrderTimerStartedAt: null } },
+        },
+      ],
+    });
+
+    const timerButton = await screen.findByTestId("timer");
+    expect(timerButton).toHaveTextContent("Start timer");
+
+    await user.click(timerButton);
+    expect(timerButton).toHaveTextContent("15:00");
+
+    await user.click(timerButton);
+    expect(timerButton).toHaveTextContent("Start timer");
+    global.Date.now = Date.now;
+  });
+
   it("renders dropdown of device types", async () => {
     const { user } = await renderQueueItem({
       mocks: [blankUpdateAoeEventMock],

--- a/frontend/src/app/testQueue/TestCard/TestCard.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.tsx
@@ -71,18 +71,6 @@ export const TestCard = ({
     }
   };
 
-  // when the test order has a new timer started at value, check if we need to clear the timer
-  // this happens when another user stops a timer, so to keep it in sync
-  // we need to stop it for any other users viewing the same queue
-  useEffect(() => {
-    if (
-      testOrder.timerStartedAt === null ||
-      testOrder.timerStartedAt === undefined
-    ) {
-      timer.reset(trackTimerReset);
-    }
-  }, [testOrder.timerStartedAt]);
-
   useEffect(() => {
     if (startTestPatientId === testOrder.patient.internalId) {
       testCardElement.current.scrollIntoView({ behavior: "smooth" });
@@ -114,6 +102,8 @@ export const TestCard = ({
     if (startedAt === undefined) {
       timer.reset(trackTimerReset);
       testOrder.timerStartedAt = "0";
+    } else {
+      testOrder.timerStartedAt = startedAt?.toString();
     }
   };
 

--- a/frontend/src/app/testQueue/TestCard/TestCard.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.tsx
@@ -71,6 +71,9 @@ export const TestCard = ({
     }
   };
 
+  // when the test order has a new timer started at value, check if we need to clear the timer
+  // this happens when another user stops a timer, so to keep it in sync
+  // we need to stop it for any other users viewing the same queue
   useEffect(() => {
     if (
       testOrder.timerStartedAt === null ||

--- a/frontend/src/app/testQueue/TestCard/TestCard.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.tsx
@@ -42,7 +42,9 @@ export const TestCard = ({
   const timer = useTestTimer(
     testOrder.internalId,
     testOrder.deviceType.testLength,
-    Number(testOrder.timerStartedAt)
+    testOrder.timerStartedAt === null
+      ? undefined
+      : Number(testOrder.timerStartedAt)
   );
   const organization = useSelector<RootState, Organization>(
     (state: any) => state.organization as Organization

--- a/frontend/src/app/testQueue/TestCard/TestCard.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.tsx
@@ -56,6 +56,14 @@ export const TestCard = ({
 
   const testCardElement = useRef() as React.MutableRefObject<HTMLDivElement>;
 
+  useEffect(() => {
+    if (startTestPatientId === testOrder.patient.internalId) {
+      testCardElement.current.scrollIntoView({ behavior: "smooth" });
+    }
+    // only run on first render to prevent disruptive repeated scrolls
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const appInsights = getAppInsights();
 
   const timerContext = {
@@ -70,14 +78,6 @@ export const TestCard = ({
       appInsights.trackEvent({ name: "Test timer reset" }, timerContext);
     }
   };
-
-  useEffect(() => {
-    if (startTestPatientId === testOrder.patient.internalId) {
-      testCardElement.current.scrollIntoView({ behavior: "smooth" });
-    }
-    // only run on first render to prevent disruptive repeated scrolls
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const { patientFullName, patientDateOfBirth } =
     useTestOrderPatient(testOrder);

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -211,6 +211,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
       testOrderQueue &&
       testOrderQueue.map((testOrder) => {
         if (!testOrder) return <></>;
+
         return (
           <CSSTransition
             key={testOrder.internalId}

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -211,7 +211,6 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
       testOrderQueue &&
       testOrderQueue.map((testOrder) => {
         if (!testOrder) return <></>;
-
         return (
           <CSSTransition
             key={testOrder.internalId}

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -178,8 +178,15 @@ export const useTestTimer = (
   startedAt: number = 0
 ) => {
   const [, setCount] = useState(0);
+  const existingTimer = findTimer(id);
+  if (existingTimer && startedAt == 0) {
+    // if timer already exists and startedAt is 0,
+    // then reset the timer
+    existingTimer.reset();
+    saveTimers();
+  }
   const timer: Timer = findTimer(id) || addTimer(id, testLength);
-  if (startedAt !== null && startedAt !== undefined && startedAt !== 0) {
+  if (!!startedAt) {
     timer.setStartedAt(startedAt);
   }
   useEffect(() => {

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -175,11 +175,11 @@ export const removeTimer = (id: string) => {
 export const useTestTimer = (
   id: string,
   testLength: number,
-  startedAt: number = 0
+  startedAt?: number
 ) => {
   const [, setCount] = useState(0);
   const existingTimer = findTimer(id);
-  if (existingTimer && startedAt === 0) {
+  if (existingTimer && (startedAt === null || startedAt === undefined)) {
     // if timer already exists and startedAt is 0,
     // then reset the timer
     existingTimer.reset();

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -186,7 +186,7 @@ export const useTestTimer = (
     saveTimers();
   }
   const timer: Timer = findTimer(id) || addTimer(id, testLength);
-  if (!!startedAt) {
+  if (startedAt) {
     timer.setStartedAt(startedAt);
   }
   useEffect(() => {

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -306,7 +306,10 @@ export const TestTimerWidget = ({
     <div>
       <button
         className="timer-button timer-ready"
-        onClick={() => reset(trackTimerReset)}
+        onClick={() => {
+          reset(trackTimerReset);
+          saveStartedAtCallback(undefined);
+        }}
         data-testid="timer"
         aria-label="Reset timer"
       >

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -180,7 +180,7 @@ export const useTestTimer = (
   const [, setCount] = useState(0);
   const existingTimer = findTimer(id);
   if (existingTimer && (startedAt === null || startedAt === undefined)) {
-    // if timer already exists and startedAt is 0,
+    // if timer already exists and startedAt is null or undefined,
     // then reset the timer
     existingTimer.reset();
     saveTimers();

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -33,9 +33,9 @@ export class Timer {
   alarmed: boolean;
   notify?: (value: number) => any;
 
-  constructor(id: string, testLength: number) {
+  constructor(id: string, testLength: number, startedAt: number = 0) {
     this.id = id;
-    this.startedAt = 0;
+    this.startedAt = startedAt;
     this.alarmAt = 0;
     this.testLength = testLength;
     this.countdown = toMillis(testLength);
@@ -57,6 +57,12 @@ export class Timer {
   start(now: number) {
     this.startedAt = now;
     this.alarmAt = this.startedAt + toMillis(this.testLength);
+  }
+
+  setStartedAt(startedAt: number) {
+    this.startedAt = startedAt;
+    this.alarmAt = this.startedAt + toMillis(this.testLength);
+    this.elapsed = Date.now() - this.startedAt;
   }
 
   reset() {
@@ -166,9 +172,16 @@ export const removeTimer = (id: string) => {
   }
 };
 
-export const useTestTimer = (id: string, testLength: number) => {
+export const useTestTimer = (
+  id: string,
+  testLength: number,
+  startedAt: number = 0
+) => {
   const [, setCount] = useState(0);
   const timer: Timer = findTimer(id) || addTimer(id, testLength);
+  if (startedAt !== 0) {
+    timer.setStartedAt(startedAt);
+  }
   useEffect(() => {
     timer.notify = setCount;
     return () => {
@@ -181,6 +194,7 @@ export const useTestTimer = (id: string, testLength: number) => {
       (timer.startedAt ? timer.countdown : toMillis(timer.testLength)) / 1000
     ),
     elapsed: Math.round(timer.elapsed / 1000),
+    startedAt: timer.startedAt,
     start: (trackClickEvent: Function) => {
       const timerToStart: Timer = findTimer(id) || addTimer(id, testLength);
       timerToStart.start(Date.now());
@@ -210,9 +224,14 @@ export const mmss = (t: number) => {
 type Props = {
   timer: ReturnType<typeof useTestTimer>;
   context: TimerTrackEventMetadata;
+  saveStartedAtCallback: (startedAt: number | undefined) => void;
 };
 
-export const TestTimerWidget = ({ timer, context }: Props) => {
+export const TestTimerWidget = ({
+  timer,
+  context,
+  saveStartedAtCallback,
+}: Props) => {
   const { running, countdown, elapsed, start, reset } = timer;
   const [timerFinished, setTimerFinished] = useState(false);
 
@@ -238,7 +257,11 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
     return (
       <button
         className="timer-button timer-reset"
-        onClick={() => start(trackTimerStart)}
+        onClick={() => {
+          start(trackTimerStart);
+          const timerToReset = findTimer(context.testOrderId);
+          saveStartedAtCallback(timerToReset?.startedAt);
+        }}
         data-testid="timer"
         aria-label="Start timer"
       >
@@ -253,7 +276,10 @@ export const TestTimerWidget = ({ timer, context }: Props) => {
     return (
       <button
         className="timer-button timer-running"
-        onClick={() => reset(trackTimerReset)}
+        onClick={() => {
+          reset(trackTimerReset);
+          saveStartedAtCallback(undefined);
+        }}
         data-testid="timer"
         aria-label="Reset timer"
       >

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -179,7 +179,7 @@ export const useTestTimer = (
 ) => {
   const [, setCount] = useState(0);
   const timer: Timer = findTimer(id) || addTimer(id, testLength);
-  if (startedAt !== 0) {
+  if (startedAt !== null && startedAt !== undefined && startedAt !== 0) {
     timer.setStartedAt(startedAt);
   }
   useEffect(() => {

--- a/frontend/src/app/testQueue/TestTimer.tsx
+++ b/frontend/src/app/testQueue/TestTimer.tsx
@@ -179,7 +179,7 @@ export const useTestTimer = (
 ) => {
   const [, setCount] = useState(0);
   const existingTimer = findTimer(id);
-  if (existingTimer && startedAt == 0) {
+  if (existingTimer && startedAt === 0) {
     // if timer already exists and startedAt is 0,
     // then reset the timer
     existingTimer.reset();

--- a/frontend/src/app/testQueue/operations.graphql
+++ b/frontend/src/app/testQueue/operations.graphql
@@ -99,6 +99,7 @@ query GetFacilityQueue($facilityId: ID!) {
         dateTested
         correctionStatus
         reasonForCorrection
+        timerStartedAt
     }
     facility(id: $facilityId) {
         name
@@ -123,4 +124,14 @@ query GetFacilityQueue($facilityId: ID!) {
             }
         }
     }
+}
+
+mutation UpdateTestOrderTimerStartedAt(
+    $testOrderId: ID!
+    $startedAt: String
+) {
+    updateTestOrderTimerStartedAt(
+        testOrderId: $testOrderId
+        startedAt: $startedAt
+    )
 }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -539,6 +539,11 @@ export type MutationUpdateSpecimenTypeArgs = {
   input: UpdateSpecimenType;
 };
 
+export type MutationUpdateTestOrderTimerStartedAtArgs = {
+  startedAt?: InputMaybe<Scalars["String"]["input"]>;
+  testOrderId: Scalars["ID"]["input"];
+};
+
 export type MutationUpdateUserArgs = {
   firstName?: InputMaybe<Scalars["String"]["input"]>;
   id: Scalars["ID"]["input"];

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -236,6 +236,7 @@ export type Mutation = {
   updatePatient?: Maybe<Patient>;
   updateRegistrationLink?: Maybe<Scalars["String"]["output"]>;
   updateSpecimenType?: Maybe<SpecimenType>;
+  updateTestOrderTimerStartedAt?: Maybe<Scalars["String"]["output"]>;
   updateUser?: Maybe<User>;
   updateUserEmail?: Maybe<User>;
   updateUserPrivileges?: Maybe<User>;
@@ -998,6 +999,7 @@ export type TestOrder = {
   symptomOnset?: Maybe<Scalars["LocalDate"]["output"]>;
   symptoms?: Maybe<Scalars["String"]["output"]>;
   syphilisHistory?: Maybe<Scalars["String"]["output"]>;
+  timerStartedAt?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type TestResult = {
@@ -2276,6 +2278,7 @@ export type GetFacilityQueueQuery = {
     dateTested?: any | null;
     correctionStatus?: string | null;
     reasonForCorrection?: string | null;
+    timerStartedAt?: string | null;
     deviceType: {
       __typename?: "DeviceType";
       internalId: string;
@@ -2342,6 +2345,16 @@ export type GetFacilityQueueQuery = {
       }>;
     }>;
   } | null;
+};
+
+export type UpdateTestOrderTimerStartedAtMutationVariables = Exact<{
+  testOrderId: Scalars["ID"]["input"];
+  startedAt?: InputMaybe<Scalars["String"]["input"]>;
+}>;
+
+export type UpdateTestOrderTimerStartedAtMutation = {
+  __typename?: "Mutation";
+  updateTestOrderTimerStartedAt?: string | null;
 };
 
 export type GetTestResultForResendingEmailsQueryVariables = Exact<{
@@ -7462,6 +7475,7 @@ export const GetFacilityQueueDocument = gql`
       dateTested
       correctionStatus
       reasonForCorrection
+      timerStartedAt
     }
     facility(id: $facilityId) {
       name
@@ -7558,6 +7572,62 @@ export type GetFacilityQueueQueryResult = Apollo.QueryResult<
   GetFacilityQueueQuery,
   GetFacilityQueueQueryVariables
 >;
+export const UpdateTestOrderTimerStartedAtDocument = gql`
+  mutation UpdateTestOrderTimerStartedAt(
+    $testOrderId: ID!
+    $startedAt: String
+  ) {
+    updateTestOrderTimerStartedAt(
+      testOrderId: $testOrderId
+      startedAt: $startedAt
+    )
+  }
+`;
+export type UpdateTestOrderTimerStartedAtMutationFn = Apollo.MutationFunction<
+  UpdateTestOrderTimerStartedAtMutation,
+  UpdateTestOrderTimerStartedAtMutationVariables
+>;
+
+/**
+ * __useUpdateTestOrderTimerStartedAtMutation__
+ *
+ * To run a mutation, you first call `useUpdateTestOrderTimerStartedAtMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateTestOrderTimerStartedAtMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateTestOrderTimerStartedAtMutation, { data, loading, error }] = useUpdateTestOrderTimerStartedAtMutation({
+ *   variables: {
+ *      testOrderId: // value for 'testOrderId'
+ *      startedAt: // value for 'startedAt'
+ *   },
+ * });
+ */
+export function useUpdateTestOrderTimerStartedAtMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateTestOrderTimerStartedAtMutation,
+    UpdateTestOrderTimerStartedAtMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateTestOrderTimerStartedAtMutation,
+    UpdateTestOrderTimerStartedAtMutationVariables
+  >(UpdateTestOrderTimerStartedAtDocument, options);
+}
+export type UpdateTestOrderTimerStartedAtMutationHookResult = ReturnType<
+  typeof useUpdateTestOrderTimerStartedAtMutation
+>;
+export type UpdateTestOrderTimerStartedAtMutationResult =
+  Apollo.MutationResult<UpdateTestOrderTimerStartedAtMutation>;
+export type UpdateTestOrderTimerStartedAtMutationOptions =
+  Apollo.BaseMutationOptions<
+    UpdateTestOrderTimerStartedAtMutation,
+    UpdateTestOrderTimerStartedAtMutationVariables
+  >;
 export const GetTestResultForResendingEmailsDocument = gql`
   query getTestResultForResendingEmails($id: ID!) {
     testResult(id: $id) {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7054

## Changes Proposed

- Persist the test card timer start time value in the database
- Display this timer start time for other app users viewing the same queue

## Testing

- Deployed on dev5
- Open two browser sessions of the same facility queue (recommend having one of the browser sessions be incognito or private so that you can be sure each timer session data is isolated within different local storages)