### PR TITLE
Adjust abnormal flag mapping

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -441,12 +441,64 @@ public class Translators {
           Map.entry(OTHER, "Other"));
   private static final Set<String> ORGANIZATION_TYPE_KEYS = ORGANIZATION_TYPES.keySet();
 
+  private static final String DETECTED_SNOMED = "260373001";
+  private static final String NOT_DETECTED_SNOMED = "260415000";
+  private static final String INVALID_SNOMED = "455371000124106";
+  public static final Map<String, SnomedConceptRecord> ABNORMAL_SNOMEDS =
+      Map.ofEntries(
+          Map.entry(
+              DETECTED_SNOMED,
+              new SnomedConceptRecord("Detected", DETECTED_SNOMED, TestResult.POSITIVE)),
+          Map.entry(
+              "720735008",
+              new SnomedConceptRecord("Presumptive positive", "720735008", TestResult.POSITIVE)),
+          Map.entry(
+              "10828004", new SnomedConceptRecord("Positive", "10828004", TestResult.POSITIVE)),
+          Map.entry(
+              "11214006", new SnomedConceptRecord("Reactive", "11214006", TestResult.POSITIVE)));
+
+  public static final Map<String, SnomedConceptRecord> NORMAL_SNOMEDS =
+      Map.ofEntries(
+          Map.entry(
+              NOT_DETECTED_SNOMED,
+              new SnomedConceptRecord("Not detected", NOT_DETECTED_SNOMED, TestResult.NEGATIVE)),
+          Map.entry(
+              "260385009", new SnomedConceptRecord("Negative", "260385009", TestResult.NEGATIVE)),
+          Map.entry(
+              "895231008",
+              new SnomedConceptRecord(
+                  "Not detected in pooled specimen", "895231008", TestResult.NEGATIVE)),
+          Map.entry(
+              "131194007",
+              new SnomedConceptRecord("Non-Reactive", "131194007", TestResult.NEGATIVE)),
+          // certain UNDETERMINED codes are also flagged as normal
+          // https://github.com/CDCgov/prime-reportstream/blob/1ffae4ca0b04cd0aa9f169e26813ecd86df71bb5/prime-router/src/main/kotlin/metadata/Mappers.kt#L768
+          Map.entry(
+              "419984006",
+              new SnomedConceptRecord("Inconclusive", "419984006", TestResult.UNDETERMINED)),
+          Map.entry(
+              "42425007",
+              new SnomedConceptRecord("Equivocal", "42425007", TestResult.UNDETERMINED)),
+          Map.entry(
+              "82334004",
+              new SnomedConceptRecord("Indeterminate", "82334004", TestResult.UNDETERMINED)),
+          Map.entry(
+              "373121007",
+              new SnomedConceptRecord("Test not done", "373121007", TestResult.UNDETERMINED)),
+          Map.entry(
+              INVALID_SNOMED,
+              new SnomedConceptRecord("Invalid result", INVALID_SNOMED, TestResult.UNDETERMINED)),
+          Map.entry(
+              "125154007",
+              new SnomedConceptRecord(
+                  "Specimen unsatisfactory for evaluation", "125154007", TestResult.UNDETERMINED)));
+
   public static final SnomedConceptRecord DETECTED_SNOMED_CONCEPT =
-      new SnomedConceptRecord("Detected", "260373001", TestResult.POSITIVE);
+      ABNORMAL_SNOMEDS.get(DETECTED_SNOMED);
   private static final SnomedConceptRecord NOT_DETECTED_SNOMED_CONCEPT =
-      new SnomedConceptRecord("Not detected", "260415000", TestResult.NEGATIVE);
+      NORMAL_SNOMEDS.get(NOT_DETECTED_SNOMED);
   private static final SnomedConceptRecord INVALID_SNOMED_CONCEPT =
-      new SnomedConceptRecord("Invalid result", "455371000124106", TestResult.UNDETERMINED);
+      NORMAL_SNOMEDS.get(INVALID_SNOMED);
   private static final List<SnomedConceptRecord> RESULTS_SNOMED_CONCEPTS =
       List.of(DETECTED_SNOMED_CONCEPT, NOT_DETECTED_SNOMED_CONCEPT, INVALID_SNOMED_CONCEPT);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1,10 +1,11 @@
 package gov.cdc.usds.simplereport.api.converter;
 
-import static gov.cdc.usds.simplereport.api.Translators.DETECTED_SNOMED_CONCEPT;
+import static gov.cdc.usds.simplereport.api.Translators.ABNORMAL_SNOMEDS;
 import static gov.cdc.usds.simplereport.api.Translators.FEMALE;
 import static gov.cdc.usds.simplereport.api.Translators.GENDER_IDENTITIES;
 import static gov.cdc.usds.simplereport.api.Translators.MALE;
 import static gov.cdc.usds.simplereport.api.Translators.NON_BINARY;
+import static gov.cdc.usds.simplereport.api.Translators.NORMAL_SNOMEDS;
 import static gov.cdc.usds.simplereport.api.Translators.OTHER;
 import static gov.cdc.usds.simplereport.api.Translators.REFUSED;
 import static gov.cdc.usds.simplereport.api.Translators.TRANS_MAN;
@@ -159,6 +160,7 @@ import org.hl7.fhir.r4.model.ServiceRequest.ServiceRequestStatus;
 import org.hl7.fhir.r4.model.Specimen;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
+import org.owasp.encoder.Encode;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
@@ -753,19 +755,21 @@ public class FhirConverter {
     return observation;
   }
 
-  private Coding convertToAbnormalFlagInterpretation(String resultCode) {
+  public Coding convertToAbnormalFlagInterpretation(String resultCode) {
     Coding abnormalFlag = new Coding();
 
     abnormalFlag.setSystem(ABNORMAL_FLAGS_CODE_SYSTEM);
 
-    if (resultCode.equals(DETECTED_SNOMED_CONCEPT.code())) {
+    if (ABNORMAL_SNOMEDS.keySet().contains(resultCode)) {
       abnormalFlag.setCode(ABNORMAL_FLAG_ABNORMAL.code());
       abnormalFlag.setDisplay(ABNORMAL_FLAG_ABNORMAL.displayName());
-    } else {
+    } else if (NORMAL_SNOMEDS.keySet().contains(resultCode)) {
       abnormalFlag.setCode(ABNORMAL_FLAG_NORMAL.code());
       abnormalFlag.setDisplay(ABNORMAL_FLAG_NORMAL.displayName());
+    } else {
+      log.info("Unsupported SNOMED result code: {}", Encode.forJava(resultCode));
+      return null;
     }
-
     return abnormalFlag;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -745,9 +745,10 @@ public class FhirConverter {
         props.getCorrectionReason(),
         observation);
 
-    observation
-        .addInterpretation()
-        .addCoding(convertToAbnormalFlagInterpretation(props.getResultCode()));
+    Coding abnormalFlagCode = convertToAbnormalFlagInterpretation(props.getResultCode());
+    if (abnormalFlagCode != null) {
+      observation.addInterpretation().addCoding(abnormalFlagCode);
+    }
 
     observation.setIssued(props.getIssued());
     observation.getIssuedElement().setTimeZoneZulu(true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -62,6 +62,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointUse;
@@ -2044,5 +2045,28 @@ class FhirConverterTest {
     assertThat(specimen.getCollection().getBodySite().getCodingFirstRep().getCode())
         .isEqualTo(DEFAULT_LOCATION_CODE);
     assertThat(specimen.getCollection().getBodySite().getText()).isEqualTo(DEFAULT_LOCATION_NAME);
+  }
+
+  @Test
+  void convertToAbnormalFlagInterpretation_withUnsupportedSnomed_returnsNull() {
+    String snomed = "1111";
+    Coding actual = fhirConverter.convertToAbnormalFlagInterpretation(snomed);
+    assertThat(actual).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("snomedArgs")
+  void convertToAbnormalFlagInterpretation_matches(
+      String snomed, String expectedCode, String expectedCodeName) {
+    Coding actual = fhirConverter.convertToAbnormalFlagInterpretation(snomed);
+    assertThat(actual.getCode()).isEqualTo(expectedCode);
+    assertThat(actual.getDisplay()).isEqualTo(expectedCodeName);
+  }
+
+  private static Stream<Arguments> snomedArgs() {
+    return Stream.of(
+        arguments("10828004", "A", "Abnormal"),
+        arguments("131194007", "N", "Normal"),
+        arguments("455371000124106", "N", "Normal"));
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part 1 for #7897 
- This should at least fix the issue CA was experiencing.

## Changes Proposed

- Set the `Abnormal` and `Normal` coding only when they match a defined list of SNOMED codes that we support
- If the SNOMED code that is provided does not match, we will log it and return `null` instead of setting the code to `Normal`

## Additional Information
- Will create an alert in a separate PR when we log an unsupported SNOMED code
- ⚠️ As part of #7898 we should make sure that any results being sent to the CSV pipeline should also map to values here: https://github.com/CDCgov/prime-reportstream/blob/1ffae4ca0b04cd0aa9f169e26813ecd86df71bb5/prime-router/src/main/kotlin/metadata/Mappers.kt#L768 otherwise you get the following error from ReportStream that is not obvious to users uploading their results:
**RS CSV API Error 400 Response:**
```
{
  "id" : null,
  "submissionId" : 4261955,
  "overallStatus" : "Error",
  "timestamp" : "2024-07-11T20:43:28.954Z",
  "plannedCompletionAt" : null,
  "actualCompletionAt" : null,
  "sender" : "",
  "reportItemCount" : null,
  "errorCount" : 1,
  "warningCount" : 0,
  "httpStatus" : 400,
  "destinations" : [ ],
  "actionName" : "receive",
  "externalName" : "",
  "reportId" : null,
  "topic" : null,
  "bodyFormat" : "",
  "errors" : [ {
    "scope" : "item",
    "indices" : [ 1 ],
    "trackingIds" : [ "42daf9c8-9deb-4636-a040-380bde2b44cd+1+20240711" ],
    "field" : "test_result (test_result)",
    "message" : "The code '' for field test_result (test_result) is invalid. Reformat to HL7 specification.",
    "errorCode" : "INVALID_MSG_PARSE_CODE"
  } ],
  "warnings" : [ ],
  "destinationCount" : 0,
  "fileName" : ""
}
```

## Testing
- deployed to dev3
- upload a bulk result with various SNOMED combinations
- example with new SNOMEDs
[DEV3_EX.csv](https://github.com/user-attachments/files/16183512/DEV3_EX.csv)


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
