### PR TITLE
Fix test event survey data after AOE correction

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/TestEvent.java
@@ -116,7 +116,7 @@ public class TestEvent extends BaseTestInfo {
     this.patientData = event.getPatientData();
     this.providerData = event.getProviderData();
     this.order = order;
-    this.surveyData = event.getSurveyData();
+    this.surveyData = order.getAskOnEntrySurvey().getSurvey();
     setDateTestedBackdate(order.getDateTestedBackdate());
     this.priorCorrectedTestEventId = event.getInternalId();
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7877 

## Changes Proposed

- After making an AOE change on a correction test card, submitting the test event survey data will now correctly store the updated AOE survey data from the test order as opposed to the old survey data from the original test event.

## Additional Information

- When the conduct test queue and test card were refactored last year, it wasn't immediately clear that we technically introduced a new feature: being able to make changes to AOE responses on a test correction. Before the test card overhaul, the AOE questions were asked in a pre-test modal and as far as we're aware, the user did not have the ability to change AOE responses on a test correction. After the overhaul, the AOE questions were moved to be on the test card directly and now accessible for the user to make changes on a test correction.

## Testing

- Deployed on dev5
- Submit a test with some AOE responses
- Find that test in the Results page and View Details to verify the AOE response data appears as expected
- Start a Correct Test flow for that test result
- On the corrected test, make some change to the AOE response
- Go back to the Results page and View Details again to verify the AOE response has been updated