### PR TITLE
Update CSV Result Code Validation 

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -1,8 +1,10 @@
 package gov.cdc.usds.simplereport.validators;
 
+import static gov.cdc.usds.simplereport.api.Translators.ABNORMAL_SNOMEDS;
 import static gov.cdc.usds.simplereport.api.Translators.CANADIAN_STATE_CODES;
 import static gov.cdc.usds.simplereport.api.Translators.COUNTRY_CODES;
 import static gov.cdc.usds.simplereport.api.Translators.GENDER_IDENTITIES;
+import static gov.cdc.usds.simplereport.api.Translators.NORMAL_SNOMEDS;
 import static gov.cdc.usds.simplereport.api.Translators.PAST_DATE_FLEXIBLE_FORMATTER;
 import static gov.cdc.usds.simplereport.api.Translators.STATE_CODES;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.BOARDING_HOUSE_LITERAL;
@@ -44,6 +46,8 @@ import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_SN
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getGenderIdentityAbbreviationMap;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.TIMEZONE_SUFFIX_REGEX;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.validTimeZoneIdMap;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.concat;
 
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
@@ -69,8 +73,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
@@ -104,12 +106,12 @@ public class CsvValidatorUtils {
   private static final String CLIA_REGEX = "^[A-Za-z0-9]{2}[Dd][A-Za-z0-9]{7}$";
   private static final String ALPHABET_REGEX = "^[a-zA-Z\\s]+$";
   private static final Set<String> VALID_STATE_CODES =
-      Stream.concat(
+      concat(
               STATE_CODES.stream().map(String::toLowerCase),
               CANADIAN_STATE_CODES.stream().map(String::toLowerCase))
-          .collect(Collectors.toSet());
+          .collect(toSet());
   private static final Set<String> VALID_COUNTRY_CODES =
-      COUNTRY_CODES.stream().map(String::toLowerCase).collect(Collectors.toSet());
+      COUNTRY_CODES.stream().map(String::toLowerCase).collect(toSet());
   private static final String UNKNOWN_LITERAL = "unknown";
   private static final String UNKNOWN_CODE = "unk";
   private static final String OTHER_LITERAL = "other";
@@ -610,9 +612,16 @@ public class CsvValidatorUtils {
     if (value == null) {
       return errors;
     }
+    boolean snomedValue = value.matches(SNOMED_REGEX);
     boolean nonSNOMEDValue = value.matches(ALPHABET_REGEX);
     if (nonSNOMEDValue) {
       return validateInSet(input, acceptableValues);
+    }
+    if (snomedValue) {
+      Set<String> acceptedSNOWMEDS =
+          concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream())
+              .collect(toSet());
+      return validateInSet(input, acceptedSNOWMEDS);
     }
     return errors;
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -184,9 +184,11 @@ public class CsvValidatorUtils {
           "y", "yes",
           "n", "no",
           "u", UNKNOWN_CODE);
-  private static final Set<String> TEST_RESULT_VALUES =
+  private static final Set<String> ACCEPTED_LITERAL_TEST_RESULT_VALUES =
       Set.of(POSITIVE_LITERAL, "negative", "not detected", DETECTED_LITERAL, "invalid result");
 
+  private static final Set<String> ACCEPTED_TEST_RESULT_SNOMEDS =
+      concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream()).collect(toSet());
   private static final Set<String> RESIDENCE_VALUES =
       Set.of(
           HOSPITAL_SNOMED, HOSPITAL_LITERAL,
@@ -272,11 +274,9 @@ public class CsvValidatorUtils {
         + " test result.";
   }
 
-  public static Set<String> acceptedSNOWMEDS =
-      concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream()).collect(toSet());
-
   public static List<FeedbackMessage> validateTestResult(ValueOrError input) {
-    return validateSpecificValueOrSNOMED(input, TEST_RESULT_VALUES, acceptedSNOWMEDS);
+    return validateSpecificValueOrSNOMED(
+        input, ACCEPTED_LITERAL_TEST_RESULT_VALUES, ACCEPTED_TEST_RESULT_SNOMEDS);
   }
 
   public static List<FeedbackMessage> validateTestPerformedCode(ValueOrError input) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -189,6 +189,10 @@ public class CsvValidatorUtils {
 
   private static final Set<String> ACCEPTED_TEST_RESULT_SNOMEDS =
       concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream()).collect(toSet());
+
+  private static final Set<String> ALL_ACCEPTED_TEST_RESULT_VALUES =
+      concat(ACCEPTED_LITERAL_TEST_RESULT_VALUES.stream(), ACCEPTED_TEST_RESULT_SNOMEDS.stream())
+          .collect(toSet());
   private static final Set<String> RESIDENCE_VALUES =
       Set.of(
           HOSPITAL_SNOMED, HOSPITAL_LITERAL,
@@ -275,8 +279,7 @@ public class CsvValidatorUtils {
   }
 
   public static List<FeedbackMessage> validateTestResult(ValueOrError input) {
-    return validateSpecificValueOrSNOMED(
-        input, ACCEPTED_LITERAL_TEST_RESULT_VALUES, ACCEPTED_TEST_RESULT_SNOMEDS);
+    return validateSpecificValueOrSNOMED(input);
   }
 
   public static List<FeedbackMessage> validateTestPerformedCode(ValueOrError input) {
@@ -608,24 +611,15 @@ public class CsvValidatorUtils {
     return displayValueToDatabaseValue.get(biologicalSex.toLowerCase());
   }
 
-  private static List<FeedbackMessage> validateSpecificValueOrSNOMED(
-      ValueOrError input, Set<String> acceptableStringLiterals, Set<String> acceptableSNOMEDS) {
+  private static List<FeedbackMessage> validateSpecificValueOrSNOMED(ValueOrError input) {
     List<FeedbackMessage> errors = new ArrayList<>();
     String value = parseString(input.getValue());
 
     if (value == null) {
       return errors;
     }
-    boolean nonSNOMEDValue = value.matches(ALPHABET_REGEX);
-    boolean snomedValue = value.matches(SNOMED_REGEX);
 
-    if (nonSNOMEDValue) {
-      return validateInSet(input, acceptableStringLiterals);
-    } else if (snomedValue) {
-      return validateInSet(input, acceptableSNOMEDS);
-    } else {
-      return errors;
-    }
+    return validateInSet(input, ALL_ACCEPTED_TEST_RESULT_VALUES);
   }
 
   public static Set<String> extractSubstringsGenderOfSexualPartners(String value) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -609,21 +609,23 @@ public class CsvValidatorUtils {
       ValueOrError input, Set<String> acceptableValues) {
     List<FeedbackMessage> errors = new ArrayList<>();
     String value = parseString(input.getValue());
+
     if (value == null) {
       return errors;
     }
-    boolean snomedValue = value.matches(SNOMED_REGEX);
     boolean nonSNOMEDValue = value.matches(ALPHABET_REGEX);
+    boolean snowmedValue = value.matches(SNOMED_REGEX);
+
     if (nonSNOMEDValue) {
       return validateInSet(input, acceptableValues);
-    }
-    if (snomedValue) {
+    } else if (snowmedValue) {
       Set<String> acceptedSNOWMEDS =
           concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream())
               .collect(toSet());
       return validateInSet(input, acceptedSNOWMEDS);
+    } else {
+      return errors;
     }
-    return errors;
   }
 
   public static Set<String> extractSubstringsGenderOfSexualPartners(String value) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -142,9 +142,12 @@ public class CsvValidatorUtils {
   private static final String NOT_HISPANIC_CODE = "2186-5";
   private static final String NOT_HISPANIC_DB_VALUE = "not_hispanic";
   private static final String POSITIVE_LITERAL = "positive";
+  private static final String NEGATIVE_LITERAL = "negative";
   private static final String POSITIVE_CODE = "10828004";
   private static final String DETECTED_LITERAL = "detected";
+  private static final String NOT_DETECTED_LITERAL = "not detected";
   private static final String DETECTED_CODE = "260373001";
+  private static final String INVALID_RESULT_LITERAL = "invalid result";
   private static final Set<String> POSITIVE_TEST_RESULT_VALUES =
       Set.of(POSITIVE_LITERAL, DETECTED_LITERAL, POSITIVE_CODE, DETECTED_CODE);
   private static final Set<String> GENDER_VALUES =
@@ -185,7 +188,12 @@ public class CsvValidatorUtils {
           "n", "no",
           "u", UNKNOWN_CODE);
   private static final Set<String> ACCEPTED_LITERAL_TEST_RESULT_VALUES =
-      Set.of(POSITIVE_LITERAL, "negative", "not detected", DETECTED_LITERAL, "invalid result");
+      Set.of(
+          POSITIVE_LITERAL,
+          NEGATIVE_LITERAL,
+          NOT_DETECTED_LITERAL,
+          DETECTED_LITERAL,
+          INVALID_RESULT_LITERAL);
 
   private static final Set<String> ACCEPTED_TEST_RESULT_SNOMEDS =
       concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream()).collect(toSet());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -272,8 +272,11 @@ public class CsvValidatorUtils {
         + " test result.";
   }
 
+  public static Set<String> acceptedSNOWMEDS =
+      concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream()).collect(toSet());
+
   public static List<FeedbackMessage> validateTestResult(ValueOrError input) {
-    return validateSpecificValueOrSNOMED(input, TEST_RESULT_VALUES);
+    return validateSpecificValueOrSNOMED(input, TEST_RESULT_VALUES, acceptedSNOWMEDS);
   }
 
   public static List<FeedbackMessage> validateTestPerformedCode(ValueOrError input) {
@@ -606,7 +609,7 @@ public class CsvValidatorUtils {
   }
 
   private static List<FeedbackMessage> validateSpecificValueOrSNOMED(
-      ValueOrError input, Set<String> acceptableValues) {
+      ValueOrError input, Set<String> acceptableStringLiterals, Set<String> acceptableSNOMEDS) {
     List<FeedbackMessage> errors = new ArrayList<>();
     String value = parseString(input.getValue());
 
@@ -614,15 +617,12 @@ public class CsvValidatorUtils {
       return errors;
     }
     boolean nonSNOMEDValue = value.matches(ALPHABET_REGEX);
-    boolean snowmedValue = value.matches(SNOMED_REGEX);
+    boolean snomedValue = value.matches(SNOMED_REGEX);
 
     if (nonSNOMEDValue) {
-      return validateInSet(input, acceptableValues);
-    } else if (snowmedValue) {
-      Set<String> acceptedSNOWMEDS =
-          concat(NORMAL_SNOMEDS.keySet().stream(), ABNORMAL_SNOMEDS.keySet().stream())
-              .collect(toSet());
-      return validateInSet(input, acceptedSNOWMEDS);
+      return validateInSet(input, acceptableStringLiterals);
+    } else if (snomedValue) {
+      return validateInSet(input, acceptableSNOMEDS);
     } else {
       return errors;
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -324,16 +324,31 @@ class CsvValidatorUtilsTest {
   }
 
   @Test
-  void validTestResultSNOMED() {
-    ValueOrError positiveTestResult = new ValueOrError("10828004", "test_result");
-    ValueOrError negativeTestResult = new ValueOrError("260385009", "test_result");
-    assertThat(validateTestResult(positiveTestResult)).hasSize(0);
-    assertThat(validateTestResult(negativeTestResult)).hasSize(0);
+  void validTestResult() {
+
+    ValueOrError positiveSNOMED = new ValueOrError("10828004", "test_result");
+    assertThat(validateTestResult(positiveSNOMED)).hasSize(0);
+
+    ValueOrError positiveLiteral = new ValueOrError("positive", "test_result");
+    assertThat(validateTestResult(positiveLiteral)).hasSize(0);
+
+    ValueOrError negativeSNOMED = new ValueOrError("260385009", "test_result");
+    assertThat(validateTestResult(negativeSNOMED)).hasSize(0);
+
+    ValueOrError negativeLiteral = new ValueOrError("negative", "test_result");
+    assertThat(validateTestResult(negativeLiteral)).hasSize(0);
   }
 
   @Test
-  void invalidTestResultSNOMED() {
-    ValueOrError invalidTestResult = new ValueOrError("404684003", "test_result");
-    assertThat(validateTestResult(invalidTestResult)).hasSize(1);
+  void invalidTestResult() {
+
+    ValueOrError invalidSNOMED = new ValueOrError("404684003", "test_result");
+    assertThat(validateTestResult(invalidSNOMED)).hasSize(1);
+
+    ValueOrError invalidLiteral = new ValueOrError("postitv", "test_result");
+    assertThat(validateTestResult(invalidLiteral)).hasSize(1);
+
+    ValueOrError randomChar = new ValueOrError("-", "test_result");
+    assertThat(validateTestResult(randomChar)).hasSize(1);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -13,6 +13,7 @@ import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePar
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validatePhoneNumber;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateRequiredFieldsForPositiveResult;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateSpecimenType;
+import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateTestResult;
 import static gov.cdc.usds.simplereport.validators.CsvValidatorUtils.validateZipCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -320,5 +321,19 @@ class CsvValidatorUtilsTest {
             validateRequiredFieldsForPositiveResult(
                 testResult, DiseaseService.HIV_NAME, List.of(genders, pregnant)))
         .hasSize(2);
+  }
+
+  @Test
+  void validTestResultSNOMED() {
+    ValueOrError positiveTestResult = new ValueOrError("10828004", "test_result");
+    ValueOrError negativeTestResult = new ValueOrError("260385009", "test_result");
+    assertThat(validateTestResult(positiveTestResult)).hasSize(0);
+    assertThat(validateTestResult(negativeTestResult)).hasSize(0);
+  }
+
+  @Test
+  void invalidTestResultSNOMED() {
+    ValueOrError invalidTestResult = new ValueOrError("404684003", "test_result");
+    assertThat(validateTestResult(invalidTestResult)).hasSize(1);
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
resolves #7898 

## Changes Proposed

- Adjust the validation for the `test_result` field in the bulk uploader to only validate against a static list of SNOMEDs or string literals that map to a specific SNOMED.

## Additional Information

- @emyl3 pointed out in [the comments for this ticket](https://github.com/CDCgov/prime-simplereport/issues/7898#issuecomment-2223933627) that some of these SNOWMEDs while supported by SR will make the COVID pipeline fail as certain codes that are used as results for STD's are not valid codes on the COVID pipeline. That issue is not addressed in this PR and I will be creating a new ticket where that issue can be addressed. 

## Testing

- Can be tested on either a local version of this branch or on dev5 by uploading a CSV to the bulk uploader. 
- For the `test_results` row, all cells with any of [these SNOMEDs](https://github.com/CDCgov/prime-reportstream/blob/1ffae4ca0b04cd0aa9f169e26813ecd86df71bb5/prime-router/src/main/kotlin/metadata/Mappers.kt#L768) should pass along with any of the result SNOMEDs that we are using for HIV and Syphilis as well. Any other SNOMED should cause the upload to fail and alert the user of the value that is failing.

