### PR TITLE
Add mutation to clear user roles and facilities

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -177,7 +177,7 @@ public class UserMutationResolver {
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
   @MutationMapping
-  public ApiUser markUserRolesAndFacilitiesAsDeleted(@Argument String username) {
-    return _us.markUserRolesAndFacilitiesAsDeleted(username);
+  public ApiUser clearUserRolesAndFacilities(@Argument String username) {
+    return _us.clearUserRolesAndFacilities(username);
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolver.java
@@ -174,4 +174,10 @@ public class UserMutationResolver {
         username, orgExternalId, accessAllFacilities, facilityIdsToAssign, role);
     return new User(_us.getUserByLoginEmail(username));
   }
+
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  @MutationMapping
+  public ApiUser markUserRolesAndFacilitiesAsDeleted(@Argument String username) {
+    return _us.markUserRolesAndFacilitiesAsDeleted(username);
+  }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -71,6 +71,10 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
     }
   }
 
+  public Set<OrganizationRole> getRoles() {
+    return this.roleAssignments.stream().map(ApiUserRole::getRole).collect(Collectors.toSet());
+  }
+
   public void setRoles(Set<OrganizationRole> newOrgRoles, Organization org) {
     this.roleAssignments.clear();
     for (OrganizationRole orgRole : newOrgRoles) {
@@ -81,5 +85,11 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
       }
       this.roleAssignments.add(new ApiUserRole(this, org, orgRole));
     }
+  }
+
+  public ApiUser clearRolesAndFacilities() {
+    this.roleAssignments.clear();
+    this.facilityAssignments.clear();
+    return this;
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -24,6 +25,7 @@ public class ApiUserRole extends AuditedEntity {
   @Column(nullable = false, columnDefinition = "organization_role")
   @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Enumerated(EnumType.STRING)
+  @Getter
   private OrganizationRole role;
 
   protected ApiUserRole() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -384,7 +384,7 @@ public class ApiUserService {
    * @return ApiUser
    */
   @AuthorizationConfiguration.RequireGlobalAdminUser
-  public ApiUser markUserRolesAndFacilitiesAsDeleted(String username) {
+  public ApiUser clearUserRolesAndFacilities(String username) {
     ApiUser foundUser =
         _apiUserRepo.findByLoginEmail(username).orElseThrow(NonexistentUserException::new);
     foundUser.clearRolesAndFacilities();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -376,6 +376,21 @@ public class ApiUserService {
     return new UserInfo(apiUser, Optional.of(orgRoles), false);
   }
 
+  /**
+   * Clear a user's roles and facilities - intended to be used on site admin users only,
+   * non-site-admin users will be in a misconfigured state without roles and facilities
+   *
+   * @param username
+   * @return ApiUser
+   */
+  @AuthorizationConfiguration.RequireGlobalAdminUser
+  public ApiUser markUserRolesAndFacilitiesAsDeleted(String username) {
+    ApiUser foundUser =
+        _apiUserRepo.findByLoginEmail(username).orElseThrow(NonexistentUserException::new);
+    foundUser.clearRolesAndFacilities();
+    return foundUser;
+  }
+
   private ApiUser getApiUser(UUID id) {
     return getApiUser(id, false);
   }

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -64,6 +64,9 @@ extend type Mutation {
     accessAllFacilities: Boolean = false,
     facilities: [ID] = [],
     role: Role!): User!
+  markUserRolesAndFacilitiesAsDeleted(
+    username: String!
+  ): ApiUser
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag
   deleteE2EOktaOrganizations(orgExternalId: String!): Organization
   sendOrgAdminEmailCSV(type: String!, state: String!): Boolean

--- a/backend/src/main/resources/graphql/admin.graphqls
+++ b/backend/src/main/resources/graphql/admin.graphqls
@@ -64,7 +64,7 @@ extend type Mutation {
     accessAllFacilities: Boolean = false,
     facilities: [ID] = [],
     role: Role!): User!
-  markUserRolesAndFacilitiesAsDeleted(
+  clearUserRolesAndFacilities(
     username: String!
   ): ApiUser
   updateFeatureFlag(name: String!, value: Boolean!):FeatureFlag

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolverTest.java
@@ -1,12 +1,17 @@
 package gov.cdc.usds.simplereport.api.apiuser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.User;
+import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
@@ -21,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @WithSimpleReportOrgAdminUser
 class UserMutationResolverTest extends BaseServiceTest<ApiUserService> {
+  @Autowired ApiUserRepository apiUserRepository;
   @Mock ApiUserService mockedApiUserService;
 
   @Autowired private TestDataFactory _dataFactory;
@@ -32,11 +38,11 @@ class UserMutationResolverTest extends BaseServiceTest<ApiUserService> {
   @BeforeEach
   void setup() {
     Organization org = _dataFactory.saveValidOrganization();
-    orgUserInfo = _dataFactory.createValidApiUser("demo@example.com", org);
+    orgUserInfo = _dataFactory.createValidApiUser("demo@example.com", org, Role.USER);
   }
 
   @Test
-  void reactivateUserAndResetPassword_orgAdmin_success() {
+  void reactivateUserAndResetPassword_success() {
     UUID userInfoInternalId = orgUserInfo.getInternalId();
 
     // GIVEN
@@ -49,5 +55,35 @@ class UserMutationResolverTest extends BaseServiceTest<ApiUserService> {
     // THEN
     assertThat(resetUser.getInternalId()).isEqualTo(userInfoInternalId);
     verify(mockedApiUserService, times(1)).reactivateUserAndResetPassword(userInfoInternalId);
+  }
+
+  @Test
+  void markUserRolesAndFacilitiesAsDeleted_nonExistentUser_throwException() {
+    String username = orgUserInfo.getEmail();
+
+    // GIVEN
+    ApiUser foundUser = apiUserRepository.findByLoginEmail(username).get();
+    when(mockedApiUserService.markUserRolesAndFacilitiesAsDeleted(username)).thenReturn(foundUser);
+
+    // WHEN
+    ApiUser resetUser = userMutationResolver.markUserRolesAndFacilitiesAsDeleted(username);
+
+    // THEN
+    assertThat(resetUser.getLoginEmail()).isEqualTo(orgUserInfo.getEmail());
+    verify(mockedApiUserService, times(1)).markUserRolesAndFacilitiesAsDeleted(username);
+  }
+
+  @Test
+  void markUserRolesAndFacilitiesAsDeleted_failure() {
+    String username = "nonexistentuser@examplemail.com";
+
+    when(mockedApiUserService.markUserRolesAndFacilitiesAsDeleted(username))
+        .thenThrow(new NonexistentUserException());
+
+    assertThrows(
+        NonexistentUserException.class,
+        () -> {
+          userMutationResolver.markUserRolesAndFacilitiesAsDeleted(username);
+        });
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/apiuser/UserMutationResolverTest.java
@@ -58,32 +58,32 @@ class UserMutationResolverTest extends BaseServiceTest<ApiUserService> {
   }
 
   @Test
-  void markUserRolesAndFacilitiesAsDeleted_nonExistentUser_throwException() {
+  void clearUserRolesAndFacilities_nonExistentUser_throwException() {
     String username = orgUserInfo.getEmail();
 
     // GIVEN
     ApiUser foundUser = apiUserRepository.findByLoginEmail(username).get();
-    when(mockedApiUserService.markUserRolesAndFacilitiesAsDeleted(username)).thenReturn(foundUser);
+    when(mockedApiUserService.clearUserRolesAndFacilities(username)).thenReturn(foundUser);
 
     // WHEN
-    ApiUser resetUser = userMutationResolver.markUserRolesAndFacilitiesAsDeleted(username);
+    ApiUser resetUser = userMutationResolver.clearUserRolesAndFacilities(username);
 
     // THEN
     assertThat(resetUser.getLoginEmail()).isEqualTo(orgUserInfo.getEmail());
-    verify(mockedApiUserService, times(1)).markUserRolesAndFacilitiesAsDeleted(username);
+    verify(mockedApiUserService, times(1)).clearUserRolesAndFacilities(username);
   }
 
   @Test
-  void markUserRolesAndFacilitiesAsDeleted_failure() {
+  void clearUserRolesAndFacilities_failure() {
     String username = "nonexistentuser@examplemail.com";
 
-    when(mockedApiUserService.markUserRolesAndFacilitiesAsDeleted(username))
+    when(mockedApiUserService.clearUserRolesAndFacilities(username))
         .thenThrow(new NonexistentUserException());
 
     assertThrows(
         NonexistentUserException.class,
         () -> {
-          userMutationResolver.markUserRolesAndFacilitiesAsDeleted(username);
+          userMutationResolver.clearUserRolesAndFacilities(username);
         });
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -569,27 +569,26 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
-  void orgAdminUser_markUserRolesAndFacilitiesAsDeleted_error() {
+  void orgAdminUser_clearUserRolesAndFacilities_error() {
     String username = "nonexistentuser@examplemail.com";
-    assertThrows(
-        AccessDeniedException.class, () -> _service.markUserRolesAndFacilitiesAsDeleted(username));
+    assertThrows(AccessDeniedException.class, () -> _service.clearUserRolesAndFacilities(username));
   }
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void siteAdminUser_markUserRolesAndFacilitiesAsDeleted_nonExistentUser_throws() {
+  void siteAdminUser_clearUserRolesAndFacilities_nonExistentUser_throws() {
     final String email = "nonexistentuser@examplemail.com";
 
     assertThrows(
         NonexistentUserException.class,
         () -> {
-          _service.markUserRolesAndFacilitiesAsDeleted(email);
+          _service.clearUserRolesAndFacilities(email);
         });
   }
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void siteAdminUser_markUserRolesAndFacilitiesAsDeleted_success() {
+  void siteAdminUser_clearUserRolesAndFacilities_success() {
     initSampleData();
     final String email = TestUserIdentities.STANDARD_USER;
     ApiUser foundUser = _apiUserRepo.findByLoginEmail(email).get();
@@ -601,7 +600,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     assertEquals(1, initialOrgRoles.size());
     assertEquals("USER", initialOrgRoles.stream().findFirst().get().getName());
 
-    ApiUser updatedUser = _service.markUserRolesAndFacilitiesAsDeleted(email);
+    ApiUser updatedUser = _service.clearUserRolesAndFacilities(email);
     // check facilities and roles after deletion
     int updatedFacilitiesCount = updatedUser.getFacilities().size();
     int updatedOrgRolesCount = updatedUser.getRoles().size();

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -209,6 +209,7 @@ export type Mutation = {
   markFacilityAsDeleted?: Maybe<Scalars["String"]["output"]>;
   markOrganizationAsDeleted?: Maybe<Scalars["String"]["output"]>;
   markPendingOrganizationAsDeleted?: Maybe<Scalars["String"]["output"]>;
+  markUserRolesAndFacilitiesAsDeleted?: Maybe<ApiUser>;
   reactivateUser?: Maybe<User>;
   reactivateUserAndResetPassword?: Maybe<User>;
   removePatientFromQueue?: Maybe<Scalars["String"]["output"]>;
@@ -380,6 +381,10 @@ export type MutationMarkOrganizationAsDeletedArgs = {
 export type MutationMarkPendingOrganizationAsDeletedArgs = {
   deleted: Scalars["Boolean"]["input"];
   orgExternalId: Scalars["String"]["input"];
+};
+
+export type MutationMarkUserRolesAndFacilitiesAsDeletedArgs = {
+  username: Scalars["String"]["input"];
 };
 
 export type MutationReactivateUserArgs = {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -195,6 +195,7 @@ export type Mutation = {
   addUser?: Maybe<User>;
   addUserToCurrentOrg?: Maybe<User>;
   adminUpdateOrganization?: Maybe<Scalars["String"]["output"]>;
+  clearUserRolesAndFacilities?: Maybe<ApiUser>;
   correctTestMarkAsCorrection?: Maybe<TestResult>;
   correctTestMarkAsError?: Maybe<TestResult>;
   createApiUserNoOkta?: Maybe<ApiUser>;
@@ -209,7 +210,6 @@ export type Mutation = {
   markFacilityAsDeleted?: Maybe<Scalars["String"]["output"]>;
   markOrganizationAsDeleted?: Maybe<Scalars["String"]["output"]>;
   markPendingOrganizationAsDeleted?: Maybe<Scalars["String"]["output"]>;
-  markUserRolesAndFacilitiesAsDeleted?: Maybe<ApiUser>;
   reactivateUser?: Maybe<User>;
   reactivateUserAndResetPassword?: Maybe<User>;
   removePatientFromQueue?: Maybe<Scalars["String"]["output"]>;
@@ -304,6 +304,10 @@ export type MutationAdminUpdateOrganizationArgs = {
   type: Scalars["String"]["input"];
 };
 
+export type MutationClearUserRolesAndFacilitiesArgs = {
+  username: Scalars["String"]["input"];
+};
+
 export type MutationCorrectTestMarkAsCorrectionArgs = {
   id: Scalars["ID"]["input"];
   reason?: InputMaybe<Scalars["String"]["input"]>;
@@ -381,10 +385,6 @@ export type MutationMarkOrganizationAsDeletedArgs = {
 export type MutationMarkPendingOrganizationAsDeletedArgs = {
   deleted: Scalars["Boolean"]["input"];
   orgExternalId: Scalars["String"]["input"];
-};
-
-export type MutationMarkUserRolesAndFacilitiesAsDeletedArgs = {
-  username: Scalars["String"]["input"];
 };
 
 export type MutationReactivateUserArgs = {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of cleanup effort for bug introduced by #7828 where I was saving role and facility information for site admins when they ghosted into an organization
  - #7969 stopped saving site admin facility and role info when ghosting into orgs

## Changes Proposed

- Introduces a mutation that takes a user's email and marks their `ApiUserRole` and `ApiUserFacility` entries as deleted

## Additional Information

- Left the mutation flexible to be called on any user, but wrote a comment about the repercussions of calling the mutation on a non-site-admin user
  - will be ok to call this while the feature flag is off because user role and facility info will be repopulated but if this is called after the transition it will be an issue

## Testing
- deployed on dev2 
- call this mutation on a user that has role and facility entries populated, check in metabase they are deleted
```
mutation ($username: String!) {
    clearUserRolesAndFacilities (
        username: $username
    ) {
        nameInfo {
            firstName
        }
    }
}
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
