### PR TITLE
Pin axios resolution to ^0.28.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "@uswds/uswds": "^3.8.0",
     "apollo-upload-client": "^17.0.0",
+    "axios": "^0.28.1",
     "browserslist": "4.21.10",
     "classnames": "^2.2.6",
     "flagged": "^2.0.10",
@@ -240,7 +241,8 @@
     "node-fetch": "^2.6.12",
     "react-scripts/**/nth-check": "^2.1.1",
     "undici": "5.22.1",
-    "webpack@>5.0.0": "5.76.0"
+    "webpack@>5.0.0": "5.76.0",
+    "axios": "^0.28.1"
   },
   "msw": {
     "workerDirectory": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "@uswds/uswds": "^3.8.0",
     "apollo-upload-client": "^17.0.0",
-    "axios": "^0.28.1",
+    "axios": "0.28.0",
     "browserslist": "4.21.10",
     "classnames": "^2.2.6",
     "flagged": "^2.0.10",
@@ -242,7 +242,7 @@
     "react-scripts/**/nth-check": "^2.1.1",
     "undici": "5.22.1",
     "webpack@>5.0.0": "5.76.0",
-    "axios": "^0.28.1"
+    "axios": "0.28.0"
   },
   "msw": {
     "workerDirectory": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,9 @@
       "jest-dom"
     ],
     "rules": {
-      "@typescript-eslint/no-unused-vars": ["error"],
+      "@typescript-eslint/no-unused-vars": [
+        "error"
+      ],
       "import/no-unresolved": 0,
       "import/first": 1,
       "import/order": [
@@ -199,6 +201,7 @@
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
+    "babel-jest": "^29.7.0",
     "chromatic": "^10.2.0",
     "dayjs": "^1.10.7",
     "depcheck": "^1.4.3",
@@ -229,9 +232,7 @@
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
     "typescript": "^5.3.2",
-    "webpack": "^5.76.0",
-    "axios": "^1.7.2",
-    "babel-jest": "^29.7.0"
+    "webpack": "^5.76.0"
   },
   "resolutions": {
     "http-cache-semantics": "4.1.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6798,12 +6798,14 @@ axios-retry@3.2.0:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+axios@^0.26.1, axios@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.1.tgz#2a7bcd34a3837b71ee1a5ca3762214b86b703e70"
+  integrity sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==
   dependencies:
-    follow-redirects "^1.14.8"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -9746,7 +9748,7 @@ focus-trap@^7.5.4:
   dependencies:
     tabbable "^6.2.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.8:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -9795,7 +9797,7 @@ fork-ts-checker-webpack-plugin@^8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@4.0.0:
+form-data@4.0.0, form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
   integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
@@ -14428,6 +14430,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6805,15 +6805,6 @@ axios@^0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -9755,7 +9746,7 @@ focus-trap@^7.5.4:
   dependencies:
     tabbable "^6.2.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.8, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0, follow-redirects@^1.14.8:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -9804,7 +9795,7 @@ fork-ts-checker-webpack-plugin@^8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@4.0.0, form-data@^4.0.0:
+form-data@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
   integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
@@ -14437,11 +14428,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6798,10 +6798,10 @@ axios-retry@3.2.0:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.26.1, axios@^0.28.1:
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.1.tgz#2a7bcd34a3837b71ee1a5ca3762214b86b703e70"
-  integrity sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==
+axios@0.28.0, axios@^0.26.1:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.0.tgz#801a4d991d0404961bccef46800e1170f8278c89"
+  integrity sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7926 

## Changes Proposed

- Instead of upgrading `smartystreets-javascript-sdk` to version 4 or 5 which encounters an internal error when the SDK attempts to reference an undefined `axios` module, this pins the `axios` version to at least 0.28.1 which resolves [the Snyk security vulnerability](https://app.snyk.io/org/prime-simplereport/project/9b116ed0-0b91-4572-ad4d-dac6bad2c3c5#issue-SNYK-JS-AXIOS-6032459).

## Additional Information

- As far as we're aware, there are no other compelling reasons to do a major version upgrade for the `smartystreets-javascript-sdk` dependency at this time since otherwise we run into that `axios` undefined reference error.

## Testing

- Deployed on dev5
- Go to Edit Facility page and change the facility address to one that is known to trigger a suggestion like the following:

201 W Capital
Jefferson City, MO 65101
USA

should suggest changing it to

201 W Capitol Ave
Jefferson City, MO 65101-6809
Cole, USA