### PR TITLE
Logic app slack

### DIFF
--- a/ops/pentest/_config.tf
+++ b/ops/pentest/_config.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.100.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.14.0"
+    }
   }
   required_version = "~> 1.3.3"
 }

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -102,3 +102,10 @@ module "app_service_autoscale" {
 
   tags = local.management_tags
 }
+
+module "logic_app_workflow" {
+  source = "../services/alerts/alert_app"
+
+  global_vault = data.azurerm_key_vault.global
+
+}

--- a/ops/services/alerts/alert_app/_var.tf
+++ b/ops/services/alerts/alert_app/_var.tf
@@ -15,8 +15,8 @@ variable "global_vault" {
 }
 
 variable "channel" {
-  default     = "Shanice Musiitwa (ATL, she/her)"
-  description = "The Slack channel to post to."
+  default     = "project-sr-on-call-alerts"
+  description = "The Slack channel that the alerts are sent to."
 }
 
 

--- a/ops/services/alerts/alert_app/_var.tf
+++ b/ops/services/alerts/alert_app/_var.tf
@@ -15,5 +15,23 @@ variable "global_vault" {
 }
 
 variable "channel" {
-  default = "Shanice Musiitwa (ATL, she/her)"
+  default     = "Shanice Musiitwa (ATL, she/her)"
+  description = "The Slack channel to post to."
+}
+
+variable "slackConnectionName" {
+  type        = string
+  default     = "SlackConnection"
+  description = "The name for the Slack connection."
+}
+
+variable "connection_name" {
+  type        = string
+  description = "This connection must be manually activated in the Azure Console after deployment"
+  default     = "slack"
+}
+
+variable "logicAppName" {
+  default = "Slack-Integration-Workflow"
+
 }

--- a/ops/services/alerts/alert_app/_var.tf
+++ b/ops/services/alerts/alert_app/_var.tf
@@ -19,15 +19,10 @@ variable "channel" {
   description = "The Slack channel to post to."
 }
 
-variable "slackConnectionName" {
-  type        = string
-  default     = "SlackConnection"
-  description = "The name for the Slack connection."
-}
 
 variable "connection_name" {
   type        = string
-  description = "This connection must be manually activated in the Azure Console after deployment"
+  description = "This connection must be manually activated in the Azure Console after deployment to test other will have to wait for Alert Group to trigger it"
   default     = "slack"
 }
 

--- a/ops/services/alerts/alert_app/_var.tf
+++ b/ops/services/alerts/alert_app/_var.tf
@@ -1,0 +1,19 @@
+variable "rg_name" {
+  description = "Name of resource group to deploy into"
+  type        = string
+  default     = "prime-simple-report-pentest"
+}
+
+variable "rg_location" {
+  description = "Location of resource group to deploy into"
+  type        = string
+  default     = "eastus"
+}
+
+variable "global_vault" {
+
+}
+
+variable "channel" {
+  default = "Shanice Musiitwa (ATL, she/her)"
+}

--- a/ops/services/alerts/alert_app/data.tf
+++ b/ops/services/alerts/alert_app/data.tf
@@ -1,0 +1,19 @@
+data "azurerm_key_vault_secret" "azure_alert_slack_webhook" {
+  name         = "azure-alert-slack-webhook"
+  key_vault_id = var.global_vault.id
+}
+
+
+data "azurerm_subscription" "primary" {
+
+}
+
+# Resource Groups
+data "azurerm_resource_group" "rg" {
+  # Environments are assembled into shared resource groups by environment level.
+  name = "${local.project}-${local.name}-${local.env_level}"
+}
+
+data "azurerm_resource_group" "rg_global" {
+  name = "${local.project}-${local.name}-management"
+}

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -17,7 +17,9 @@ resource "azurerm_logic_app_workflow" "slack_workflow" {
   name     = var.logicAppName
   location = data.azurerm_resource_group.rg.location
   parameters = {
-    connections = local.slack_api_id
+    connections = jsonencode({
+      name = local.slack_api_id
+    })
   }
   resource_group_name = data.azurerm_resource_group.rg.name
   workflow_parameters = {

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -30,9 +30,9 @@ resource "azurerm_logic_app_action_http" "workflow_action" {
   name         = "Http"
   method       = "POST"
   #How to get this uri programmtically
-  uri = "https://management.azure.com/subscriptions/${data.azurerm_subscription.primary.id}/resourceGroups/${data.azurerm_resource_group.rg.name}/providers/Microsoft.Logic/workflows/${azurerm_logic_app_action_http.workflow_action.name}/listCallbackUrl?api-version=2016-06-01"
+  uri = data.azurerm_key_vault_secret.azure_alert_slack_webhook.value
   body = jsonencode({
-    longUrl = "@{triggerBody()['context']['portalLink']}"
+    "text" : "Hi from postman"
   })
   headers = {
     Content-Type = "application/json"
@@ -115,7 +115,7 @@ resource "azurerm_api_connection" "res-6" {
 
 
 
-#Define the action group, call it as local variable
+
 resource "azurerm_monitor_action_group" "on_call_action_group" {
   name                = "OnCallEngineer"
   resource_group_name = data.azurerm_resource_group.rg.name

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_logic_app_action_custom" "res-3" {
     inputs = {
       host = {
         connection = {
-          name = azurerm_api_connection.api_connection_1.connection
+          name = azurerm_api_connection.api_connection_1.name
         }
       }
       method = "post"

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_logic_app_action_http" "workflow_action" {
   #How to get this uri programmtically
   uri = data.azurerm_key_vault_secret.azure_alert_slack_webhook.value
   body = jsonencode({
-    "text" : "@{triggerBody()?['data']?['essentials']?['alertId']}"
+    "text" : "@{triggerBody()?['data']?['essentials']}"
   })
   headers = {
     Content-Type = "application/json"

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_logic_app_workflow" "slack_workflow" {
   location = data.azurerm_resource_group.rg.location
   #Create below api_connection
   parameters = {
-    connections = azurerm_api_connection.res-6.id
+    connections = azurerm_api_connection.api_connection_1.id
   }
   resource_group_name = data.azurerm_resource_group.rg.name
   workflow_parameters = {
@@ -95,17 +95,17 @@ resource "azurerm_logic_app_trigger_http_request" "res-4" {
 
 }
 
-resource "azurerm_logic_app_api_connection" "slack" {
-  name                = var.slackConnectionName
-  location            = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
-
-  api {
-    id = "/subscriptions/${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/${data.azurerm_resource_group.rg_global.location}/managedApis/${var.connection_name}"
-  }
-
-  display_name = "slack"
-}
+# resource "azurerm_logic_app_api_connection" "slack" {
+#   name                = var.slackConnectionName
+#   location            = data.azurerm_resource_group.rg.location
+#   resource_group_name = data.azurerm_resource_group.rg.name
+#
+#   api {
+#     id = "/subscriptions/${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/${data.azurerm_resource_group.rg_global.location}/managedApis/${var.connection_name}"
+#   }
+#
+#   display_name = "slack"
+# }
 
 
 resource "azapi_resource" "createApiConnectionslack" {

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -109,10 +109,10 @@ resource "azurerm_logic_app_trigger_http_request" "res-4" {
 
 
 resource "azapi_resource" "createApiConnectionslack" {
-  type      = "Microsoft.Web/connections@2015-08-01-preview"
-  name      = var.connection_name
-  parent_id = data.azurerm_resource_group.rg.id
-  location  = data.azurerm_resource_group.rg.location
+  type                      = "Microsoft.Web/connections@2015-08-01-preview"
+  name                      = var.connection_name
+  parent_id                 = data.azurerm_resource_group.rg.id
+  location                  = data.azurerm_resource_group.rg.location
   schema_validation_enabled = false
 
 
@@ -125,7 +125,7 @@ resource "azapi_resource" "createApiConnectionslack" {
         description = "Slack is a team communication tool, that brings together all of your team communications in one place, instantly searchable and available wherever you go."
         iconUri     = "https://connectoricons-prod.azureedge.net/releases/v1.0.1669/1.0.1669.3522/slack/icon.png"
         brandColor  = "#78D4B6"
-        id          = "/subscriptions/${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/${data.azurerm_resource_group.rg_global.location}/managedApis/${var.connection_name}"
+        id          = "${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/${data.azurerm_resource_group.rg_global.location}/managedApis/${var.connection_name}"
         type        = "Microsoft.Web/locations/managedApis"
       }
     }

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -135,7 +135,7 @@ resource "azapi_resource" "createApiConnectionslack" {
 
 
 resource "azurerm_api_connection" "api_connection_1" {
-  managed_api_id      = azapi_resource.createApiConnectionslack.id
+  managed_api_id      = "${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/${data.azurerm_resource_group.rg_global.location}/managedApis/${var.connection_name}"
   name                = "SlackConnection"
   resource_group_name = data.azurerm_resource_group.rg.name
 }

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -109,7 +109,7 @@ resource "azurerm_logic_app_trigger_http_request" "res-4" {
 
 
 resource "azapi_resource" "createApiConnectionslack" {
-  type      = "Microsoft.Web/connections@2018-06-07-01"
+  type      = "Microsoft.Web/connections@2015-08-01-preview"
   name      = var.connection_name
   parent_id = data.azurerm_resource_group.rg.id
   location  = data.azurerm_resource_group.rg.location

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -113,6 +113,7 @@ resource "azapi_resource" "createApiConnectionslack" {
   name      = var.connection_name
   parent_id = data.azurerm_resource_group.rg.id
   location  = data.azurerm_resource_group.rg.location
+  schema_validation_enabled = false
 
 
   body = jsonencode({

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -95,19 +95,23 @@ resource "azurerm_logic_app_trigger_http_request" "res-4" {
 
 }
 
+
+
 data "azurerm_managed_api" "data_api" {
   name     = "managed-api-1"
   location = data.azurerm_resource_group.rg.location
 }
 
+
+
 resource "azurerm_api_connection" "api_connection_1" {
-  managed_api_id      = data.azurerm_managed_api.data_api
+  managed_api_id      = data.azurerm_managed_api.data_api.id
   name                = "SlackConnection"
   resource_group_name = data.azurerm_resource_group.rg.name
 }
 
 resource "azurerm_api_connection" "res-6" {
-  managed_api_id      = data.azurerm_managed_api.data_api
+  managed_api_id      = data.azurerm_managed_api.data_api.id
   name                = "slack-1"
   resource_group_name = data.azurerm_resource_group.rg.name
 }

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_logic_app_workflow" "slack_workflow" {
   name     = var.logicAppName
   location = data.azurerm_resource_group.rg.location
   parameters = {
-    "$connections" = "{\"slack\":{\"connectionId\":\"/${data.azurerm_subscription.primary.id}/resourceGroups/${data.azurerm_resource_group.rg.name}/providers/Microsoft.Web/connections/slack\",\"connectionName\":\"slack\",\"id\":\"/${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/eastus/managedApis/slack\"}}"
+    "$connections" = "{\"slack\":{\"connectionId\":\"${data.azurerm_subscription.primary.id}/resourceGroups/${data.azurerm_resource_group.rg.name}/providers/Microsoft.Web/connections/slack\",\"connectionName\":\"slack\",\"id\":\"${data.azurerm_subscription.primary.id}/providers/Microsoft.Web/locations/eastus/managedApis/slack\"}}"
   }
   resource_group_name = data.azurerm_resource_group.rg.name
   workflow_parameters = {

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_logic_app_action_custom" "res-3" {
     inputs = {
       host = {
         connection = {
-          name = azurerm_api_connection.res-6.connection
+          name = azurerm_api_connection.api_connection_1.connection
         }
       }
       method = "post"
@@ -138,12 +138,12 @@ resource "azurerm_api_connection" "api_connection_1" {
   name                = "SlackConnection"
   resource_group_name = data.azurerm_resource_group.rg.name
 }
-
-resource "azurerm_api_connection" "res-6" {
-  managed_api_id      = azapi_resource.createApiConnectionslack.id
-  name                = "slack-1"
-  resource_group_name = data.azurerm_resource_group.rg.name
-}
+#
+# resource "azurerm_api_connection" "res-6" {
+#   managed_api_id      = azapi_resource.createApiConnectionslack.id
+#   name                = "slack-1"
+#   resource_group_name = data.azurerm_resource_group.rg.name
+# }
 
 
 

--- a/ops/services/alerts/alert_app/main.tf
+++ b/ops/services/alerts/alert_app/main.tf
@@ -1,0 +1,129 @@
+locals {
+  project   = "prime"
+  name      = "simple-report"
+  env_level = "pentest"
+  management_tags = {
+    prime-app      = "simple-report"
+    resource_group = data.azurerm_resource_group.rg.name
+  }
+}
+
+
+# Define the Logic App Workflow
+resource "azurerm_logic_app_workflow" "slack_workflow" {
+  name     = "alert-logic-app"
+  location = data.azurerm_resource_group.rg.location
+  #Create below api_connection
+  parameters = {
+    connections = azurerm_api_connection.res-6.id
+  }
+  resource_group_name = data.azurerm_resource_group.rg.name
+  workflow_parameters = {
+    connection = "{\"defaultValue\":{},\"type\":\"Object\"}"
+  }
+}
+
+
+# Define the Logic App Workflow Action
+resource "azurerm_logic_app_action_http" "workflow_action" {
+  logic_app_id = azurerm_logic_app_workflow.slack_workflow.id
+  name         = "Http"
+  method       = "POST"
+  #How to get this uri programmtically
+  uri = "https://management.azure.com/subscriptions/${data.azurerm_subscription.primary.id}/resourceGroups/${data.azurerm_resource_group.rg.name}/providers/Microsoft.Logic/workflows/${azurerm_logic_app_action_http.workflow_action.name}/listCallbackUrl?api-version=2016-06-01"
+  body = jsonencode({
+    longUrl = "@{triggerBody()['context']['portalLink']}"
+  })
+  headers = {
+    Content-Type = "application/json"
+  }
+}
+
+
+resource "azurerm_logic_app_action_custom" "res-3" {
+  body = jsonencode({
+    inputs = {
+      host = {
+        connection = {
+          name = azurerm_api_connection.res-6.id
+        }
+      }
+      method = "post"
+      path   = "/chat.postMessage"
+      queries = {
+        channel = var.channel
+        text    = "Azure Alert - '@{triggerBody()['context']['name']}' @{triggerBody()['status']} on '@{triggerBody()['context']['resourceName']}'.  Details: @{body('Http')['id']}"
+      }
+    }
+    runAfter = {
+      Http = ["Succeeded"]
+    }
+    type = "ApiConnection"
+  })
+  logic_app_id = azurerm_logic_app_workflow.slack_workflow.id
+  name         = "Post_Message"
+}
+
+resource "azurerm_logic_app_trigger_http_request" "res-4" {
+  logic_app_id = azurerm_logic_app_workflow.slack_workflow.id
+  name         = "manual"
+  schema = jsonencode({
+    "$schema" = "http://json-schema.org/draft-04/schema#"
+    properties = {
+      context = {
+        properties = {
+          name = {
+            type = "string"
+          }
+          portalLink = {
+            type = "string"
+          }
+          resourceName = {
+            type = "string"
+          }
+        }
+        required = ["name", "portalLink", "resourceName"]
+        type     = "object"
+      }
+      status = {
+        type = "string"
+      }
+    }
+    required = ["status", "context"]
+    type     = "object"
+  })
+
+}
+
+data "azurerm_managed_api" "data_api" {
+  name     = "managed-api-1"
+  location = data.azurerm_resource_group.rg.location
+}
+
+resource "azurerm_api_connection" "api_connection_1" {
+  managed_api_id      = data.azurerm_managed_api.data_api
+  name                = "SlackConnection"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+resource "azurerm_api_connection" "res-6" {
+  managed_api_id      = data.azurerm_managed_api.data_api
+  name                = "slack-1"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+
+
+
+#Define the action group, call it as local variable
+resource "azurerm_monitor_action_group" "on_call_action_group" {
+  name                = "OnCallEngineer"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  short_name          = "OnCall"
+  webhook_receiver {
+    name                    = "logicappaction"
+    service_uri             = data.azurerm_key_vault_secret.azure_alert_slack_webhook.value
+    use_common_alert_schema = false
+  }
+}
+

--- a/ops/services/alerts/alert_app/provider.tf
+++ b/ops/services/alerts/alert_app/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.100.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.14.0"
+    }
+  }
+}


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- PagerDuty is not accessible due to actions outside of our control. So this resource was created to send Azure monitor alerts directly to a slack channel for On call engineers



## Changes Proposed

- There's a Logic App Workflow that integrates with an API connection.
  - The Logic App has a trigger called When a HTTP request is received that is initiated when an alert is sent, it invokes the REST API ( slack api uri) that will post it as a message to slack
###   Resources that are deployed to the resource group

<img width="534" alt="Screenshot 2024-08-15 at 8 56 57 PM" src="https://github.com/user-attachments/assets/cccd32c9-2765-487c-85ce-8f318b2bd874">


### Logic App architecture 
<img width="828" alt="Screenshot 2024-08-15 at 1 08 54 AM" src="https://github.com/user-attachments/assets/c7d28a99-f58c-4cf9-abe9-7703000d24ca">


## Additional Information

- We are unable to use a Webhook uri to send the alerts to slack due to slack having a custom schema required for messages so the Logic app allows us to use this custom schema

## Testing

- Via Azure Portal tester can manually send a sample payload to trigger Logic app workflow
-- Confirm in the slack channel named #project-sr-on-call-alerts that the alert was successfully sent. It should look similar to the slack message below.
- This PR has already been verified on `pentest`
<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---