### PR TITLE
Fetch OrganizationRoleClaims from DB when feature flag enabled

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/DemoAuthenticationConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/authorization/DemoAuthenticationConfiguration.java
@@ -181,12 +181,10 @@ public class DemoAuthenticationConfiguration {
           _oktaRepo.getOrganizationRoleClaimsForUser(username);
       List<OrganizationRoleClaims> oktaOrgRoleClaims =
           claims.isEmpty() ? List.of() : List.of(claims.get());
-      if (!isSiteAdmin()) {
-        if (_featureFlagsConfig.isOktaMigrationEnabled()) {
-          List<OrganizationRoleClaims> dbOrgRoleClaims =
-              _dbOrgRoleClaimsService.getOrganizationRoleClaims(username);
-          return dbOrgRoleClaims;
-        }
+      if (!isSiteAdmin() && _featureFlagsConfig.isOktaMigrationEnabled()) {
+        List<OrganizationRoleClaims> dbOrgRoleClaims =
+            _dbOrgRoleClaimsService.getOrganizationRoleClaims(username);
+        return dbOrgRoleClaims;
       }
       return oktaOrgRoleClaims;
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUser.java
@@ -87,6 +87,12 @@ public class ApiUser extends EternalSystemManagedEntity implements PersonEntity 
     }
   }
 
+  public Set<Organization> getOrganizations() {
+    return this.roleAssignments.stream()
+        .map(ApiUserRole::getOrganization)
+        .collect(Collectors.toSet());
+  }
+
   public ApiUser clearRolesAndFacilities() {
     this.roleAssignments.clear();
     this.facilityAssignments.clear();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/ApiUserRole.java
@@ -20,6 +20,7 @@ public class ApiUserRole extends AuditedEntity {
 
   @ManyToOne
   @JoinColumn(name = "organization_id", nullable = false)
+  @Getter
   private Organization organization;
 
   @Column(nullable = false, columnDefinition = "organization_role")

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -234,7 +234,7 @@ public class ApiUserService {
 
     Optional<OrganizationRoleClaims> oktaRoleClaims = _oktaRepo.updateUser(userIdentity);
 
-    UserInfo user = consolidateNonSiteAdminUser(apiUser, oktaRoleClaims);
+    UserInfo user = consolidateUser(apiUser, oktaRoleClaims);
 
     createUserUpdatedAuditLog(
         apiUser.getInternalId(), getCurrentApiUser().getInternalId().toString());
@@ -290,7 +290,7 @@ public class ApiUserService {
     createUserUpdatedAuditLog(
         apiUser.getInternalId(), getCurrentApiUser().getInternalId().toString());
 
-    return consolidateNonSiteAdminUser(apiUser, oktaRoleClaims);
+    return consolidateUser(apiUser, oktaRoleClaims);
   }
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUser
@@ -303,7 +303,7 @@ public class ApiUserService {
             .getOrganizationRoleClaimsForUser(username)
             .orElseThrow(MisconfiguredUserException::new);
 
-    return consolidateNonSiteAdminUser(apiUser, Optional.ofNullable(oktaClaims));
+    return consolidateUser(apiUser, Optional.ofNullable(oktaClaims));
   }
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUser
@@ -315,7 +315,7 @@ public class ApiUserService {
         _oktaRepo
             .getOrganizationRoleClaimsForUser(username)
             .orElseThrow(MisconfiguredUserException::new);
-    return consolidateNonSiteAdminUser(apiUser, Optional.ofNullable(oktaClaims));
+    return consolidateUser(apiUser, Optional.ofNullable(oktaClaims));
   }
 
   @AuthorizationConfiguration.RequirePermissionManageTargetUserNotSelf
@@ -343,7 +343,7 @@ public class ApiUserService {
         _oktaRepo
             .getOrganizationRoleClaimsForUser(username)
             .orElseThrow(MisconfiguredUserException::new);
-    return consolidateNonSiteAdminUser(apiUser, Optional.ofNullable(oktaClaims));
+    return consolidateUser(apiUser, Optional.ofNullable(oktaClaims));
   }
 
   // This method is to re-send the invitation email to join SimpleReport
@@ -356,7 +356,7 @@ public class ApiUserService {
         _oktaRepo
             .getOrganizationRoleClaimsForUser(username)
             .orElseThrow(MisconfiguredUserException::new);
-    return consolidateNonSiteAdminUser(apiUser, Optional.ofNullable(oktaClaims));
+    return consolidateUser(apiUser, Optional.ofNullable(oktaClaims));
   }
 
   /**
@@ -689,12 +689,12 @@ public class ApiUserService {
     }
   }
 
-  private UserInfo consolidateUser(ApiUser apiUser, PartialOktaUser oktaUser) {
-    boolean isSiteAdmin = oktaUser.isSiteAdmin();
-    UserStatus userStatus = oktaUser.getStatus();
-    OrganizationRoleClaims oktaClaims =
-        oktaUser.getOrganizationRoleClaims().orElseThrow(UnidentifiedUserException::new);
-    OrganizationRoles orgRoles = _orgService.getOrganizationRoles(oktaClaims);
+  private OrganizationRoles getOrganizationRoles(
+      Optional<OrganizationRoleClaims> oktaClaims, ApiUser apiUser, boolean isSiteAdmin) {
+    OrganizationRoles orgRoles = null;
+    if (oktaClaims.isPresent()) {
+      orgRoles = _orgService.getOrganizationRoles(oktaClaims.get());
+    }
 
     if (!isSiteAdmin) {
       if (_featureFlagsConfig.isOktaMigrationEnabled()) {
@@ -704,21 +704,22 @@ public class ApiUserService {
       }
     }
 
+    return orgRoles;
+  }
+
+  private UserInfo consolidateUser(ApiUser apiUser, PartialOktaUser oktaUser) {
+    boolean isSiteAdmin = oktaUser.isSiteAdmin();
+    UserStatus userStatus = oktaUser.getStatus();
+    OrganizationRoleClaims oktaClaims =
+        oktaUser.getOrganizationRoleClaims().orElseThrow(UnidentifiedUserException::new);
+    OrganizationRoles orgRoles =
+        getOrganizationRoles(Optional.ofNullable(oktaClaims), apiUser, isSiteAdmin);
+
     return new UserInfo(apiUser, Optional.of(orgRoles), isSiteAdmin, userStatus);
   }
 
-  private UserInfo consolidateNonSiteAdminUser(
-      ApiUser apiUser, Optional<OrganizationRoleClaims> oktaClaims) {
-    OrganizationRoles orgRoles = null;
-    if (oktaClaims.isPresent()) {
-      orgRoles = _orgService.getOrganizationRoles(oktaClaims.get());
-    }
-
-    if (_featureFlagsConfig.isOktaMigrationEnabled()) {
-      orgRoles = getOrgRolesFromDB(apiUser);
-    } else {
-      setRolesAndFacilities(Optional.ofNullable(orgRoles), apiUser);
-    }
+  private UserInfo consolidateUser(ApiUser apiUser, Optional<OrganizationRoleClaims> oktaClaims) {
+    OrganizationRoles orgRoles = getOrganizationRoles(oktaClaims, apiUser, false);
     return new UserInfo(apiUser, Optional.of(orgRoles), false);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
@@ -10,7 +10,6 @@ import gov.cdc.usds.simplereport.db.model.Organization;
 import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -109,14 +108,12 @@ public class DbOrgRoleClaimsService {
     return oktaClaims.stream()
         .map(
             oktaClaim -> {
-              Set<OrganizationRole> copiedOktaOrgRoles = new HashSet<>();
-              Set<OrganizationRole> oktaOrgRoles = oktaClaim.getGrantedRoles();
-              copiedOktaOrgRoles.addAll(oktaOrgRoles);
-              copiedOktaOrgRoles.remove(OrganizationRole.NO_ACCESS);
+              Set<OrganizationRole> orgRoles =
+                  oktaClaim.getGrantedRoles().stream()
+                      .filter(c -> c != OrganizationRole.NO_ACCESS)
+                      .collect(Collectors.toSet());
               return new OrganizationRoleClaims(
-                  oktaClaim.getOrganizationExternalId(),
-                  oktaClaim.getFacilities(),
-                  copiedOktaOrgRoles);
+                  oktaClaim.getOrganizationExternalId(), oktaClaim.getFacilities(), orgRoles);
             })
         .collect(Collectors.toList());
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
@@ -1,0 +1,147 @@
+package gov.cdc.usds.simplereport.service;
+
+import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
+import gov.cdc.usds.simplereport.api.model.errors.NonexistentUserException;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
+import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DbOrgRoleClaimsService {
+  private final ApiUserRepository _userRepo;
+  private final IdentitySupplier _getCurrentUser;
+
+  /**
+   * Fetches the user by username and returns a list of OrganizationRoleClaims from the DB throws an
+   * exception if user does not have ONLY one org
+   *
+   * @param username - String of user email/username
+   * @return List of OrganizationRoleClaims from the DB
+   */
+  public List<OrganizationRoleClaims> getOrganizationRoleClaims(String username) {
+    try {
+      ApiUser user =
+          _userRepo.findByLoginEmail(username).orElseThrow(NonexistentUserException::new);
+      return List.of(getOrganizationRoleClaims(user));
+    } catch (NonexistentUserException | MisconfiguredUserException e) {
+      return new ArrayList<>();
+    }
+  }
+
+  public OrganizationRoleClaims getOrganizationRoleClaims(ApiUser user) {
+    Set<Organization> orgs = user.getOrganizations();
+    if (orgs.size() != 1) {
+      log.error("Misconfigured organizations in DB for User ID: {}", user.getInternalId());
+      throw new MisconfiguredUserException();
+    }
+    Set<OrganizationRole> roles = user.getRoles();
+    Set<UUID> facilityUUIDs =
+        user.getFacilities().stream().map(Facility::getInternalId).collect(Collectors.toSet());
+
+    String orgExternalId = orgs.stream().findFirst().get().getExternalId();
+    return new OrganizationRoleClaims(orgExternalId, facilityUUIDs, roles);
+  }
+
+  /**
+   * Compares two lists of OrganizationRoleClaims and checks if they are equal; If they are not
+   * equal, a message is logged with the affected User ID
+   *
+   * @param oktaClaims - List<OrganizationRoleClaims> from Okta
+   * @param dbClaims - List<OrganizationRoleClaims> from DB
+   * @return boolean
+   */
+  public boolean checkOrgRoleClaimsEquality(
+      List<OrganizationRoleClaims> oktaClaims, List<OrganizationRoleClaims> dbClaims) {
+    boolean hasEqualRoleClaims = false;
+    if (oktaClaims.size() == dbClaims.size()) {
+      List<OrganizationRoleClaims> sanitizedOktaClaims = sanitizeOktaOrgRoleClaims(oktaClaims);
+      hasEqualRoleClaims =
+          sanitizedOktaClaims.stream()
+              .allMatch(
+                  sanitizedOktaClaim ->
+                      dbClaims.stream()
+                          .anyMatch(dbClaim -> equalOrgRoleClaim(sanitizedOktaClaim, dbClaim)));
+    }
+    if (!hasEqualRoleClaims) {
+      logUnequalClaims();
+    }
+
+    return hasEqualRoleClaims;
+  }
+
+  /** Logs a message saying OrganizationRoleClaims are unequal with the affected User ID */
+  private void logUnequalClaims() {
+    // WIP: Currently assumes check is for the current user
+    // This may change based on where checkOrgRoleClaimsEquality is called
+    String username = _getCurrentUser.get().getUsername();
+    ApiUser user = _userRepo.findByLoginEmail(username).orElseThrow(NonexistentUserException::new);
+    log.error(
+        "Okta OrganizationRoleClaims do not match database OrganizationRoleClaims for User ID: {}",
+        user.getInternalId());
+  }
+
+  /**
+   * Removes NO_ACCESS OrganizationRole in order to compare with OrganizationRole from DB, NO_ACCESS
+   * role does not exist in DB, only in Okta
+   *
+   * @param oktaClaims - List<OrganizationRoleClaims> from Okta
+   * @return list of OrganizationRoleClaims without NO_ACCESS OrganizationRole
+   */
+  private List<OrganizationRoleClaims> sanitizeOktaOrgRoleClaims(
+      List<OrganizationRoleClaims> oktaClaims) {
+    return oktaClaims.stream()
+        .map(
+            oktaClaim -> {
+              Set<OrganizationRole> copiedOktaOrgRoles = new HashSet<>();
+              Set<OrganizationRole> oktaOrgRoles = oktaClaim.getGrantedRoles();
+              copiedOktaOrgRoles.addAll(oktaOrgRoles);
+              copiedOktaOrgRoles.remove(OrganizationRole.NO_ACCESS);
+              return new OrganizationRoleClaims(
+                  oktaClaim.getOrganizationExternalId(),
+                  oktaClaim.getFacilities(),
+                  copiedOktaOrgRoles);
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Compares two OrganizationRoleClaims for equality
+   *
+   * @param oktaClaim - OrganizationRoleClaims from Okta
+   * @param dbClaim - OrganizationRoleClaims from DB
+   * @return boolean
+   */
+  private boolean equalOrgRoleClaim(
+      OrganizationRoleClaims oktaClaim, OrganizationRoleClaims dbClaim) {
+    Set<OrganizationRole> oktaOrgRoles = oktaClaim.getGrantedRoles();
+    Set<OrganizationRole> dbOrgRoles = dbClaim.getGrantedRoles();
+    boolean equalRoles = CollectionUtils.isEqualCollection(oktaOrgRoles, dbOrgRoles);
+
+    Set<UUID> oktaFacilities = oktaClaim.getFacilities();
+    Set<UUID> dbFacilities = dbClaim.getFacilities();
+    boolean equalFacilities = CollectionUtils.isEqualCollection(oktaFacilities, dbFacilities);
+
+    String oktaExternalOrgId = oktaClaim.getOrganizationExternalId();
+    String dbExternalOrgId = dbClaim.getOrganizationExternalId();
+    boolean equalOrg = StringUtils.equals(oktaExternalOrgId, dbExternalOrgId);
+
+    return equalRoles && equalFacilities && equalOrg;
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseFullStackTest.java
@@ -14,7 +14,6 @@ import gov.cdc.usds.simplereport.db.model.auxiliary.HttpRequestDetails;
 import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
 import gov.cdc.usds.simplereport.logging.LoggingConstants;
-import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.AuditLoggerService;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
@@ -48,11 +47,9 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @ActiveProfiles("test")
 public abstract class BaseFullStackTest {
 
-  @Autowired private CurrentTenantDataAccessContextHolder _tenantDataAccessContextHolder;
   @Autowired private DbTruncator _truncator;
   @Autowired protected TestDataFactory _dataFactory;
   @SpyBean protected OrganizationService _orgService;
-  @SpyBean protected ApiUserService _apiUserService;
   @Autowired protected DemoOktaRepository _oktaRepo;
   @SpyBean AuditLoggerService auditLoggerServiceSpy;
   @Captor private ArgumentCaptor<ConsoleApiAuditEvent> auditLogCaptor;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseNonSpringBootTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/BaseNonSpringBootTestConfiguration.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport.api;
 
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.service.ApiUserService;
+import gov.cdc.usds.simplereport.service.DbOrgRoleClaimsService;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.OrganizationService;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -11,9 +14,12 @@ import org.springframework.test.context.ActiveProfiles;
 public class BaseNonSpringBootTestConfiguration {
 
   // Dependencies of TenantDataAccessFilter
+  @MockBean private ApiUserRepository _mockApiUserRepository;
   @MockBean private ApiUserService _mockApiUserService;
   @MockBean private ApiUserContextHolder _mockApiUserContextHolder;
+  @MockBean private DbOrgRoleClaimsService _mockDbOrgRoleClaimsService;
   @MockBean private OrganizationService _mockOrganizationService;
   @MockBean private CurrentTenantDataAccessContextHolder _mockContextHolder;
   @MockBean private DiseaseService _mockDiseaseService;
+  @MockBean private FeatureFlagsConfig _featureFlagsConfig;
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.config.DataSourceConfiguration;
+import gov.cdc.usds.simplereport.service.DbOrgRoleClaimsService;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
@@ -25,6 +26,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import({
   SliceTestConfiguration.class,
+  DbOrgRoleClaimsService.class,
   DbTruncator.class,
   DataSourceConfiguration.class,
   SpringTemplateEngine.class

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsServiceTest.java
@@ -1,0 +1,190 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
+import gov.cdc.usds.simplereport.test_util.OrganizationRoleClaimsTestUtils;
+import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {"spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"})
+class DbOrgRoleClaimsServiceTest extends BaseServiceTest<DbOrgRoleClaimsService> {
+  @Autowired OrganizationRoleClaimsTestUtils _orgRoleClaimsTestUtils;
+  @Autowired OrganizationService _organizationService;
+  @SpyBean ApiUserRepository _apiUserRepoSpy;
+
+  @Test
+  void getOrganizationRoleClaims_withEmail_success() {
+    initSampleData();
+    final String email = TestUserIdentities.STANDARD_USER;
+    Mockito.reset(_apiUserRepoSpy);
+
+    List<OrganizationRoleClaims> orgRoleClaims = _service.getOrganizationRoleClaims(email);
+
+    verify(_apiUserRepoSpy, times(1)).findByLoginEmail(email);
+    assertEquals(1, orgRoleClaims.size());
+    assertEquals(
+        Collections.unmodifiableSet(EnumSet.of(OrganizationRole.USER)),
+        orgRoleClaims.stream().findFirst().get().getGrantedRoles());
+
+    Set<UUID> facilityIds = orgRoleClaims.stream().findFirst().get().getFacilities();
+    assertEquals(1, facilityIds.size());
+    Facility facility =
+        _organizationService.getFacilityById(facilityIds.stream().findFirst().get()).get();
+    assertEquals("Injection Site", facility.getFacilityName());
+  }
+
+  @Test
+  void getOrganizationRoleClaims_withEmail_nonExistentUser_success() {
+    final String email = "nonexistentuser@fake.com";
+    Mockito.reset(_apiUserRepoSpy);
+
+    List<OrganizationRoleClaims> orgRoleClaims = _service.getOrganizationRoleClaims(email);
+
+    verify(_apiUserRepoSpy, times(1)).findByLoginEmail(email);
+    assertThat(orgRoleClaims).isEmpty();
+  }
+
+  @Test
+  void getOrganizationRoleClaims_withEmail_withMultipleOrgs_success() {
+    Organization gwu =
+        _dataFactory.saveOrganization("George Washington", "university", "gwu", true);
+    Organization gtown = _dataFactory.saveOrganization("Georgetown", "university", "gt", true);
+    final String email = TestUserIdentities.STANDARD_USER;
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(mockApiUser.getOrganizations()).thenReturn(Set.of(gwu, gtown));
+    when(_apiUserRepoSpy.findByLoginEmail(email)).thenReturn(Optional.of(mockApiUser));
+
+    List<OrganizationRoleClaims> orgRoleClaims = _service.getOrganizationRoleClaims(email);
+    assertThat(orgRoleClaims).isEmpty();
+  }
+
+  @Test
+  void getOrganizationRoleClaims_withApiUser_withMultipleOrgs_throws() {
+    Organization gwu =
+        _dataFactory.saveOrganization("George Washington", "university", "gwu", true);
+    Organization gtown = _dataFactory.saveOrganization("Georgetown", "university", "gt", true);
+    final String email = TestUserIdentities.STANDARD_USER;
+    ApiUser apiUser = _apiUserRepoSpy.findByLoginEmail(email).get();
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(mockApiUser.getOrganizations()).thenReturn(Set.of(gwu, gtown));
+
+    assertThrows(
+        MisconfiguredUserException.class, () -> _service.getOrganizationRoleClaims(apiUser));
+  }
+
+  @Test
+  void checkOrgRoleClaimsEquality_withIdenticalOrgRoleClaims_inDifferentOrder_isTrue() {
+    OrganizationRoleClaims firstOktaClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
+            Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+
+    OrganizationRoleClaims firstDbClaim =
+        createClaimsForCreatedOrg(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID, Set.of(OrganizationRole.USER));
+
+    OrganizationRoleClaims secondOktaClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.DB_FACILITY_NAMES,
+            Set.of(
+                OrganizationRole.NO_ACCESS,
+                OrganizationRole.ADMIN,
+                OrganizationRole.ALL_FACILITIES));
+
+    OrganizationRoleClaims secondDbClaim =
+        createClaimsForCreatedOrg(
+            OrganizationRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
+            Set.of(OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN));
+
+    assertTrue(
+        _service.checkOrgRoleClaimsEquality(
+            List.of(secondOktaClaim, firstOktaClaim), List.of(firstDbClaim, secondDbClaim)));
+  }
+
+  @Test
+  void checkOrgRoleClaimsEquality_withDifferentRoleOrder_isTrue() {
+    OrganizationRoleClaims oktaClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
+            Set.of(
+                OrganizationRole.NO_ACCESS,
+                OrganizationRole.USER,
+                OrganizationRole.ALL_FACILITIES));
+
+    OrganizationRoleClaims dbClaim =
+        createClaimsForCreatedOrg(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            Set.of(OrganizationRole.ALL_FACILITIES, OrganizationRole.USER));
+
+    assertTrue(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim)));
+  }
+
+  @Test
+  void checkOrgRoleClaimsEquality_withDifferentOrgClaims_isFalse() {
+    OrganizationRoleClaims oktaClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
+            Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+    OrganizationRoleClaims dbClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.DB_FACILITY_NAMES,
+            Set.of(OrganizationRole.ADMIN, OrganizationRole.ALL_FACILITIES));
+
+    Mockito.reset(_apiUserRepoSpy);
+
+    assertFalse(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim)));
+    verify(_apiUserRepoSpy, times(1)).findByLoginEmail(any());
+  }
+
+  @Test
+  void checkOrgRoleClaimsEquality_withDifferentOrgClaimsSize_isFalse() {
+    OrganizationRoleClaims oktaClaim =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
+            Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+
+    assertFalse(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of()));
+  }
+
+  private OrganizationRoleClaims createClaimsForCreatedOrg(
+      String orgExternalId, Set<OrganizationRole> orgRoles) {
+    Organization org = _organizationService.getOrganization(orgExternalId);
+    List<Facility> facilities = _organizationService.getFacilities(org);
+    Set<UUID> facilityIds =
+        facilities.stream().map(Facility::getInternalId).collect(Collectors.toSet());
+    return new OrganizationRoleClaims(orgExternalId, facilityIds, orgRoles);
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationServiceTest.java
@@ -1,20 +1,146 @@
 package gov.cdc.usds.simplereport.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import gov.cdc.usds.simplereport.config.AuthorizationProperties;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationExtractor;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
 import gov.cdc.usds.simplereport.service.errors.NobodyAuthenticatedException;
+import gov.cdc.usds.simplereport.test_util.OrganizationRoleClaimsTestUtils;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-class LoggedInAuthorizationServiceTest extends BaseServiceTest<DiseaseService> {
-  @Autowired LoggedInAuthorizationService loggedInAuthorizationService;
+class LoggedInAuthorizationServiceTest extends BaseServiceTest<AuthorizationService> {
+  @Autowired TenantDataAccessService tenantDataAccessService;
+  @Autowired @SpyBean ApiUserRepository apiUserRepository;
+  @Autowired OrganizationRoleClaimsTestUtils _orgRoleClaimsTestUtils;
 
   @Test
   void findAllOrganizationRoles_NobodyAuthenticatedException() {
     SecurityContextHolder.getContext().setAuthentication(null);
-    assertThrows(
-        NobodyAuthenticatedException.class,
-        () -> loggedInAuthorizationService.findAllOrganizationRoles());
+    assertThrows(NobodyAuthenticatedException.class, () -> _service.findAllOrganizationRoles());
+  }
+
+  @Test
+  void findAllOrganizationRoles_whenOktaMigrationDisabled_returnsRoleFromOkta() {
+    // GIVEN
+    AuthorizationService mockLoggedInAuthorizationService = getMockAuthService(false);
+
+    // WHEN
+    List<OrganizationRoleClaims> orgRoleClaims =
+        mockLoggedInAuthorizationService.findAllOrganizationRoles();
+
+    // THEN
+    assertEquals(1, orgRoleClaims.size());
+    OrganizationRoleClaims orgRoleClaim = orgRoleClaims.get(0);
+    assertEquals(
+        Collections.unmodifiableSet(EnumSet.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER)),
+        orgRoleClaim.getGrantedRoles());
+    assertTrue(
+        _orgRoleClaimsTestUtils.facilitiesEqual(
+            OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES, orgRoleClaim.getFacilities()));
+    assertEquals(
+        OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+        orgRoleClaim.getOrganizationExternalId());
+  }
+
+  @Test
+  void findAllOrganizationRoles_whenOktaMigrationEnabled_returnsRoleFromDB() {
+    // GIVEN
+    AuthorizationService mockLoggedInAuthorizationService = getMockAuthService(true);
+
+    // WHEN
+    List<OrganizationRoleClaims> orgRoleClaims =
+        mockLoggedInAuthorizationService.findAllOrganizationRoles();
+
+    // THEN
+    assertEquals(1, orgRoleClaims.size());
+    OrganizationRoleClaims orgRoleClaim = orgRoleClaims.get(0);
+    assertEquals(
+        Collections.unmodifiableSet(
+            EnumSet.of(OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN)),
+        orgRoleClaim.getGrantedRoles());
+    assertTrue(
+        _orgRoleClaimsTestUtils.facilitiesEqual(
+            _orgRoleClaimsTestUtils.DB_FACILITY_NAMES, orgRoleClaim.getFacilities()));
+    assertEquals(
+        _orgRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID, orgRoleClaim.getOrganizationExternalId());
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void findAllOrganizationRoles_whenOktaMigrationEnabled_doesNotFetchFromDB_forSiteAdmin() {
+    // GIVEN
+    AuthorizationProperties authProps = new AuthorizationProperties(null, "UNITTEST");
+    OrganizationRoleClaims dbClaims =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            _orgRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
+            _orgRoleClaimsTestUtils.DB_FACILITY_NAMES,
+            Set.of(OrganizationRole.ADMIN, OrganizationRole.ALL_FACILITIES));
+    DbOrgRoleClaimsService mockDbOrgRoleClaimsService = mock(DbOrgRoleClaimsService.class);
+    when(mockDbOrgRoleClaimsService.getOrganizationRoleClaims(anyString()))
+        .thenReturn(List.of(dbClaims));
+    FeatureFlagsConfig mockFeatureFlags = mock(FeatureFlagsConfig.class);
+    when(mockFeatureFlags.isOktaMigrationEnabled()).thenReturn(false);
+
+    LoggedInAuthorizationService mockLoggedInAuthorizationService =
+        new LoggedInAuthorizationService(
+            new OrganizationExtractor(authProps),
+            authProps,
+            mockDbOrgRoleClaimsService,
+            mockFeatureFlags);
+
+    // WHEN
+    List<OrganizationRoleClaims> orgRoleClaims =
+        mockLoggedInAuthorizationService.findAllOrganizationRoles();
+
+    // THEN
+    verify(mockDbOrgRoleClaimsService, times(0)).getOrganizationRoleClaims(anyString());
+    assertEquals(0, orgRoleClaims.size());
+  }
+
+  private LoggedInAuthorizationService getMockAuthService(boolean isOktaMigrationEnabled) {
+    FeatureFlagsConfig mockFeatureFlags = mock(FeatureFlagsConfig.class);
+    when(mockFeatureFlags.isOktaMigrationEnabled()).thenReturn(isOktaMigrationEnabled);
+
+    AuthorizationProperties authProps = new AuthorizationProperties(null, "UNITTEST");
+
+    OrganizationRoleClaims oktaClaims =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            _orgRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
+            _orgRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
+            Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
+    OrganizationExtractor mockOrgExtractor = mock(OrganizationExtractor.class);
+    when(mockOrgExtractor.convert(any())).thenReturn(List.of(oktaClaims));
+
+    OrganizationRoleClaims dbClaims =
+        _orgRoleClaimsTestUtils.createOrgRoleClaims(
+            _orgRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
+            _orgRoleClaimsTestUtils.DB_FACILITY_NAMES,
+            Set.of(OrganizationRole.ADMIN, OrganizationRole.ALL_FACILITIES));
+    DbOrgRoleClaimsService mockDbOrgRoleClaimsService = mock(DbOrgRoleClaimsService.class);
+    when(mockDbOrgRoleClaimsService.getOrganizationRoleClaims(anyString()))
+        .thenReturn(List.of(dbClaims));
+
+    return new LoggedInAuthorizationService(
+        mockOrgExtractor, authProps, mockDbOrgRoleClaimsService, mockFeatureFlags);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/OrganizationRoleClaimsTestUtils.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/OrganizationRoleClaimsTestUtils.java
@@ -1,0 +1,56 @@
+package gov.cdc.usds.simplereport.test_util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.service.OrganizationService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrganizationRoleClaimsTestUtils {
+  @Autowired OrganizationService _orgService;
+
+  @Autowired TestDataFactory _dataFactory;
+
+  public static final String OKTA_ORG_EXTERNAL_ID = "AIRPORT-ORG";
+  public static final String DB_ORG_EXTERNAL_ID = "K12-ORG";
+
+  public static final List<String> OKTA_FACILITY_NAMES =
+      List.of("Airport facility one", "Airport facility two");
+  public static final List<String> DB_FACILITY_NAMES =
+      List.of("K12 facility one", "K12 facility two");
+
+  public OrganizationRoleClaims createOrgRoleClaims(
+      String orgExternalId, List<String> facilityNames, Set<OrganizationRole> orgRoles) {
+    Organization createdOrg =
+        _dataFactory.saveOrganization(orgExternalId, "other", orgExternalId, true);
+    Set<UUID> facilityIds = new HashSet<>();
+    facilityNames.forEach(
+        facilityName -> {
+          Facility createdFacility = _dataFactory.createValidFacility(createdOrg, facilityName);
+          facilityIds.add(createdFacility.getInternalId());
+        });
+
+    return new OrganizationRoleClaims(orgExternalId, facilityIds, orgRoles);
+  }
+
+  public boolean facilitiesEqual(List<String> expectedFacilityNames, Set<UUID> actualFacilityIds) {
+    assertEquals(expectedFacilityNames.size(), actualFacilityIds.size());
+    List<String> actualFacilityNames =
+        actualFacilityIds.stream()
+            .map(facilityId -> _orgService.getFacilityById(facilityId).get().getFacilityName())
+            .collect(Collectors.toList());
+
+    return CollectionUtils.isEqualCollection(expectedFacilityNames, actualFacilityNames);
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.test_util;
 
+import static org.mockito.Mockito.mock;
+
 import gov.cdc.usds.simplereport.api.ApiUserContextHolder;
 import gov.cdc.usds.simplereport.api.CurrentAccountRequestContextHolder;
 import gov.cdc.usds.simplereport.api.CurrentOrganizationRolesContextHolder;
@@ -22,6 +24,7 @@ import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.AuthorizationService;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
+import gov.cdc.usds.simplereport.service.DbOrgRoleClaimsService;
 import gov.cdc.usds.simplereport.service.DiseaseCacheService;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.LoggedInAuthorizationService;
@@ -154,8 +157,13 @@ public class SliceTestConfiguration {
 
   @Bean
   public AuthorizationService realAuthorizationService(OrganizationExtractor extractor) {
+    FeatureFlagsConfig mockFeatureFlags = mock(FeatureFlagsConfig.class);
+    DbOrgRoleClaimsService mockDbOrgRoleClaimsService = mock(DbOrgRoleClaimsService.class);
     return new LoggedInAuthorizationService(
-        extractor, new AuthorizationProperties(null, "UNITTEST"));
+        extractor,
+        new AuthorizationProperties(null, "UNITTEST"),
+        mockDbOrgRoleClaimsService,
+        mockFeatureFlags);
   }
 
   @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Continuation of #7598
- See "Additional Information" section for work that remains

## Changes Proposed

- When the feature flag is enabled, fetch role and facility information for users from DB
- Creation of `DbOrgRoleClaimsService`
   - handles transforming a `ApiUser`s role and facility information to `OrganizationRoleClaims` and returning those claims
   - method introduced to check for equality between the `OrganizationRoleClaims` from Okta and the DB and log if there is an error
   - Refactoring of `consolidateUser` method in `ApiUserService`

## Additional Information
- Remaining work (will be introduced in separate PRs)
   1. behind the feature flag, leverage our DB instead of okta's group api endpoint to fetch group information for orgs
   2. utilize the [method for checking equality of roles from Okta and DB](https://github.com/CDCgov/prime-simplereport/pull/8030/files#diff-936db6b279085759a6e121f7d19c3bbb1cd4c9686c2d6379b765771f9a778ae8R70) and create an alert when this they are different

## Testing
**Envs**
- `oktaMigrationEnabled` FALSE on dev2
  - [dev2 metabase link](https://dev2.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQxLCJqb2lucyI6W3sic3RyYXRlZ3kiOiJsZWZ0LWpvaW4iLCJhbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsNDMxLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIn1dLFsiZmllbGQiLDQ0LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIifV1dLCJzb3VyY2UtdGFibGUiOjExfSx7InN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJBcGkgVXNlciBGYWNpbGl0eSAtIEFwaSBVc2VyIiwiY29uZGl0aW9uIjpbIj0iLFsiZmllbGQiLDQzMSx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCJ9XSxbImZpZWxkIiw0MjYseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XV0sInNvdXJjZS10YWJsZSI6NDJ9XSwiYnJlYWtvdXQiOltbImZpZWxkIiw0MzEseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQifV0sWyJmaWVsZCIsNDMseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgTm8gUGhpIFZpZXcgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDQseyJiYXNlLXR5cGUiOiJ0eXBlL1Bvc3RncmVzRW51bSJ9XSxbImZpZWxkIiw0MjgseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDUseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiw0NDMseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XV19fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) to see roles and facilities at a glance
  - roles and facilities should be added whenever we read role/facility info from Okta

- `oktaMigrationEnabled` TRUE on dev3
  - [dev3 metabase link](https://dev3.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjEyMSwiam9pbnMiOlt7InN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJBcGkgVXNlciIsImNvbmRpdGlvbiI6WyI9IixbImZpZWxkIiwxMTY4LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIn1dLFsiZmllbGQiLDk0MCx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCIsImpvaW4tYWxpYXMiOiJBcGkgVXNlciJ9XV0sInNvdXJjZS10YWJsZSI6OTR9LHsiZmllbGRzIjoiYWxsIiwic3RyYXRlZ3kiOiJsZWZ0LWpvaW4iLCJhbGlhcyI6IkFwaSBVc2VyIEZhY2lsaXR5IC0gSW50ZXJuYWwiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsOTQwLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIn1dLFsiZmllbGQiLDExNjMseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBJbnRlcm5hbCJ9XV0sInNvdXJjZS10YWJsZSI6MTIyfV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsOTQwLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIn1dLFsiZmllbGQiLDkzOSx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCIsImpvaW4tYWxpYXMiOiJBcGkgVXNlciJ9XSxbImZpZWxkIiwxMjEzLHsiYmFzZS10eXBlIjoidHlwZS9Qb3N0Z3Jlc0VudW0ifV0sWyJmaWVsZCIsMTE2NSx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCIsImpvaW4tYWxpYXMiOiJBcGkgVXNlciBGYWNpbGl0eSAtIEludGVybmFsIn1dLFsiZmllbGQiLDEyMTQseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiwxMjEyLHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZSIsInRlbXBvcmFsLXVuaXQiOiJtaW51dGUifV1dfX0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==) to see roles and facilities at a glance
  - roles and facilities should be not be updated when we read role/facility info from Okta
  - when we update role and facilities, we should still be updating Okta and DB
  - list of users in the org will be incorrect and still fetched from Okta until bullet point number 1 from "Remaining work" is completed

Some scenarios to try in both environments:

- **Site Admin role**
  - ghost into different orgs (no role/facility saved in DB)
  - can manage users
    - send account setup email
    - edit name
    - edit email
    - reset password
    - reset MFA
    - delete user
    - update organization/facility/role access
  - add organization admin
- **Org Admin role**
  - can manage users
    - send account setup email
    - edit name
    - edit email
    - reset password
    - reset MFA
    - delete user
    - update facility/role access
  - add user

⚠️ On dev3, when fetching a user that is not in the DB (e.g. gegax77227@miqlab.com), it will show the following due to a `MisconfiguredUserException` being thrown:
<img width="1172" alt="Screenshot 2024-08-16 at 07 27 09" src="https://github.com/user-attachments/assets/7a2c2da9-7742-49a0-901b-b1503ea766d7">
I think this makes sense if we are only enabling this flag after all users have been migrated over. Once the other work goes in, this user wouldn't be appear in the "Manage users" page so this error wouldn't be visible to end-users.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->