### PR TITLE
Fix Empty Syphilis Symptoms View

### DIFF
--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
@@ -70,6 +70,17 @@ hivTestResult.results = [
 hivTestResult.genderOfSexualPartners = ["female", "male", "other"];
 hivTestResult.pregnancy = "77386006";
 
+const syphilisTestResult = JSON.parse(JSON.stringify(nonMultiplexTestResult));
+syphilisTestResult.results = [
+  {
+    disease: { name: "Syphilis" as MultiplexDisease },
+    testResult: "POSITIVE" as TestResult,
+    __typename: "MultiplexResult",
+  },
+];
+syphilisTestResult.pregnancy = "77386006";
+syphilisTestResult.symptoms = '{"266128007":"true"}';
+
 const renderComponent = (testResult: TestResult) =>
   render(
     <DetachedTestResultDetailsModal
@@ -149,6 +160,28 @@ describe("HIV TestResultDetailsModal", () => {
 
   it("matches screenshot", () => {
     let view = renderComponent(hivTestResult);
+    expect(view).toMatchSnapshot();
+  });
+});
+
+describe("Syphilis TestResultDetailsModal", () => {
+  beforeEach(() => {
+    ReactDOM.createPortal = jest.fn((element, _node) => {
+      return element;
+    }) as any;
+  });
+
+  it("should have Syphilis specific symptoms", () => {
+    renderComponent(syphilisTestResult);
+    expect(screen.getByText("Syphilis result")).toBeInTheDocument();
+    expect(screen.getByText("Symptoms")).toBeInTheDocument();
+    expect(screen.getByText("Symptom onset")).toBeInTheDocument();
+    expect(screen.getByText("Body Rash")).toBeInTheDocument();
+    expect(screen.getByText("Pregnant?")).toBeInTheDocument();
+  });
+
+  it("matches screenshot", () => {
+    let view = renderComponent(syphilisTestResult);
     expect(view).toMatchSnapshot();
   });
 });

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
@@ -353,6 +353,383 @@ Object {
 }
 `;
 
+exports[`Syphilis TestResultDetailsModal matches screenshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="display-flex flex-justify flex-align-center"
+      >
+        <h1
+          class="font-heading-lg margin-0"
+          id="result-detail-title"
+        >
+          Result details
+        </h1>
+        <button
+          class="modal__close-button margin-top-0"
+          style="cursor: pointer;"
+        >
+          <img
+            alt="Close"
+            class="modal__close-img"
+            src="close.svg"
+          />
+        </button>
+      </div>
+      <div
+        class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
+      />
+      <h2
+        class="font-sans-md margin-top-3"
+      >
+        Patient
+      </h2>
+      <div
+        class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1 grid-row flex-row padding-0"
+      >
+        <div
+          class="grid-col padding-2 border-right-1px border-base-lighter"
+        >
+          <span
+            class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+          >
+            Name
+          </span>
+          <span
+            aria-describedby="result-detail-title"
+            class="font-sans-lg"
+          >
+            First Middle Last
+          </span>
+        </div>
+        <div
+          class="grid-col padding-2"
+        >
+          <span
+            class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+          >
+            Date of birth
+          </span>
+          <span
+            aria-describedby="result-detail-title"
+            class="font-sans-lg"
+          >
+            08/07/1990
+          </span>
+        </div>
+      </div>
+      <h2
+        class="font-sans-md margin-top-3"
+      >
+        Test information
+      </h2>
+      <table
+        class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1"
+      >
+        <tbody>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Syphilis result
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              POSITIVE
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Test date
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              01/28/2022 5:56pm
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Device
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Fake device
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Symptoms
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Body Rash
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Symptom onset
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Invalid date
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Pregnant?
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Yes
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 width-card-lg text-left"
+            >
+              Submitted by
+            </th>
+            <td
+              class="padding-y-3"
+            >
+              firstName middle last
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="display-flex flex-justify flex-align-center"
+    >
+      <h1
+        class="font-heading-lg margin-0"
+        id="result-detail-title"
+      >
+        Result details
+      </h1>
+      <button
+        class="modal__close-button margin-top-0"
+        style="cursor: pointer;"
+      >
+        <img
+          alt="Close"
+          class="modal__close-img"
+          src="close.svg"
+        />
+      </button>
+    </div>
+    <div
+      class="border-top border-base-lighter margin-x-neg-205 margin-top-1"
+    />
+    <h2
+      class="font-sans-md margin-top-3"
+    >
+      Patient
+    </h2>
+    <div
+      class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1 grid-row flex-row padding-0"
+    >
+      <div
+        class="grid-col padding-2 border-right-1px border-base-lighter"
+      >
+        <span
+          class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+        >
+          Name
+        </span>
+        <span
+          aria-describedby="result-detail-title"
+          class="font-sans-lg"
+        >
+          First Middle Last
+        </span>
+      </div>
+      <div
+        class="grid-col padding-2"
+      >
+        <span
+          class="text-bold text-no-strike text-ink display-block margin-bottom-1"
+        >
+          Date of birth
+        </span>
+        <span
+          aria-describedby="result-detail-title"
+          class="font-sans-lg"
+        >
+          08/07/1990
+        </span>
+      </div>
+    </div>
+    <h2
+      class="font-sans-md margin-top-3"
+    >
+      Test information
+    </h2>
+    <table
+      class="width-full font-sans-md add-list-reset border-base-lighter border-2px radius-md padding-x-2 padding-y-1"
+    >
+      <tbody>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Syphilis result
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            POSITIVE
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Test date
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            01/28/2022 5:56pm
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Device
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Fake device
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Symptoms
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Body Rash
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Symptom onset
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Invalid date
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Pregnant?
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Yes
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 width-card-lg text-left"
+          >
+            Submitted by
+          </th>
+          <td
+            class="padding-y-3"
+          >
+            firstName middle last
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`multiple diseases TestResultDetailsModal matches screenshot 1`] = `
 Object {
   "asFragment": [Function],

--- a/frontend/src/app/utils/symptoms.ts
+++ b/frontend/src/app/utils/symptoms.ts
@@ -1,20 +1,20 @@
 import {
-  respiratorySymptomsMap,
-  RespiratorySymptomCode,
-  RespiratorySymptomName,
+  AllSymptomsCode,
+  allSymptomsMap,
+  AllSymptomsName,
 } from "../../patientApp/timeOfTest/constants";
 
 export const symptomsStringToArray = (
   symptomString: string
-): RespiratorySymptomName[] => {
-  const parsed: { [k in RespiratorySymptomCode]: "true" | "false" } =
+): AllSymptomsName[] => {
+  const parsed: { [k in AllSymptomsCode]: "true" | "false" } =
     JSON.parse(symptomString);
   return Object.entries(parsed).reduce((acc, [code, symptomatic]) => {
     if (symptomatic === "true") {
-      acc.push(respiratorySymptomsMap[code as RespiratorySymptomCode]);
+      acc.push(allSymptomsMap[code as AllSymptomsCode]);
     }
     return acc;
-  }, [] as RespiratorySymptomName[]);
+  }, [] as AllSymptomsCode[]);
 };
 
 // symptoms should be a JSON string

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -140,33 +140,6 @@ export type AllSymptomsCode = keyof RespiratorySymptoms &
   keyof SyphilisSymptoms;
 export type AllSymptomsName = RespiratorySymptomName & SyphilisSymptomName;
 export const allSymptomsMap = {
-  "724386005": "Genital sore/lesion",
-  // Anal skin tag (195469007); Anal tag (195469007); Fibrous polyp of anus (195469007)
-  "195469007": "Anal sore/lesion",
-  // 	Ulcer of mouth (26284000); Oral ulcer (26284000); Mouth ulceration (26284000); Ulceration of oral mucosa (26284000); Mouth ulcer (26284000)
-  "26284000": "Sore(s) in mouth/lips",
-  "266128007": "Body Rash",
-  "56940005": "Palmar (hand)/plantar (foot) rash",
-  "91554004": "Flat white warts",
-  "15188001": "Hearing loss",
-  "46636008": "Blurred vision",
-  "68225006": "Patchy hair loss",
-  "426000000": "Fever over 100.4F",
-  "103001002": "Feeling feverish",
-  "43724002": "Chills",
-  "49727002": "Cough",
-  "267036007": "Shortness of breath",
-  "230145002": "Difficulty breathing",
-  "84229001": "Fatigue",
-  "68962001": "Muscle or body aches",
-  "25064002": "Headache",
-  "36955009": "New loss of taste",
-  "44169009": "New loss of smell",
-  "162397003": "Sore throat",
-  "68235000": "Nasal congestion",
-  "64531003": "Runny nose",
-  "422587007": "Nausea",
-  "422400008": "Vomiting",
-  "62315008": "Diarrhea",
-  "261665006": OTHER_SYMPTOM_NOT_LISTED_LITERAL,
-} as const;
+  ...syphilisSymptomsMap,
+  ...respiratorySymptomsMap,
+};

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -103,6 +103,7 @@ export const syphilisSymptomsMap = {
 
 export type SyphilisSymptoms = typeof syphilisSymptomsMap;
 export type SyphilisSymptomCode = keyof SyphilisSymptoms;
+export type SyphilisSymptomName = SyphilisSymptoms[SyphilisSymptomCode];
 
 const syphilisSymptomOrder: SyphilisSymptomCode[] =
   alphabetizeSymptomKeysFromMapValues(syphilisSymptomsMap);
@@ -134,3 +135,38 @@ export const syphilisSymptomDefinitions: SymptomDefinitionMap[] =
 export const SYMPTOM_SUBQUESTION_ERROR =
   "This question is required if the patient has symptoms.";
 export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";
+
+export type AllSymptomsCode = keyof RespiratorySymptoms &
+  keyof SyphilisSymptoms;
+export type AllSymptomsName = RespiratorySymptomName & SyphilisSymptomName;
+export const allSymptomsMap = {
+  "724386005": "Genital sore/lesion",
+  // Anal skin tag (195469007); Anal tag (195469007); Fibrous polyp of anus (195469007)
+  "195469007": "Anal sore/lesion",
+  // 	Ulcer of mouth (26284000); Oral ulcer (26284000); Mouth ulceration (26284000); Ulceration of oral mucosa (26284000); Mouth ulcer (26284000)
+  "26284000": "Sore(s) in mouth/lips",
+  "266128007": "Body Rash",
+  "56940005": "Palmar (hand)/plantar (foot) rash",
+  "91554004": "Flat white warts",
+  "15188001": "Hearing loss",
+  "46636008": "Blurred vision",
+  "68225006": "Patchy hair loss",
+  "426000000": "Fever over 100.4F",
+  "103001002": "Feeling feverish",
+  "43724002": "Chills",
+  "49727002": "Cough",
+  "267036007": "Shortness of breath",
+  "230145002": "Difficulty breathing",
+  "84229001": "Fatigue",
+  "68962001": "Muscle or body aches",
+  "25064002": "Headache",
+  "36955009": "New loss of taste",
+  "44169009": "New loss of smell",
+  "162397003": "Sore throat",
+  "68235000": "Nasal congestion",
+  "64531003": "Runny nose",
+  "422587007": "Nausea",
+  "422400008": "Vomiting",
+  "62315008": "Diarrhea",
+  "261665006": OTHER_SYMPTOM_NOT_LISTED_LITERAL,
+} as const;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7901 

## Changes Proposed

- Create an`AllSymptoms` type system and update the `symptomsStringToArray` function to return a type of `AllSymptomsName[]` instead of just a `RespiratorySymptomName[]`.

- Create an `allSymptomsMap` for `symptomsStringToArray` to utilize instead of only referencing against the `respiratorySymptomsMap`.

## Testing

1. Conduct a postive test with the syphilis device in dev6
2. Verify that syphilis symptoms are being displayed in the result view for the test

## Screenshots / Demos

<img width="799" alt="Screenshot 2024-08-21 at 1 58 43 PM" src="https://github.com/user-attachments/assets/87371a35-a909-4c09-963b-c1b6bf71620a">


<!---
## Checklist for Author and Reviewer

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
