### PR TITLE
Support disease filter on results CSV download

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultResolver.java
@@ -5,6 +5,7 @@ import gov.cdc.usds.simplereport.api.model.OrganizationLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.api.model.TopLevelDashboardMetrics;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
+import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.TestOrderService;
 import gov.cdc.usds.simplereport.service.TestResultUploadService;
 import gov.cdc.usds.simplereport.service.errors.InvalidBulkTestResultUploadException;
@@ -25,6 +26,7 @@ public class TestResultResolver {
 
   private final TestOrderService tos;
   private final TestResultUploadService testResultUploadService;
+  private final DiseaseService diseaseService;
 
   @QueryMapping
   public Page<TestEvent> testResultsPage(
@@ -32,6 +34,7 @@ public class TestResultResolver {
       @Argument UUID patientId,
       @Argument String result,
       @Argument String role,
+      @Argument String disease,
       @Argument Date startDate,
       @Argument Date endDate,
       @Argument int pageNumber,
@@ -48,6 +51,7 @@ public class TestResultResolver {
           patientId,
           Translators.parseTestResult(result),
           Translators.parsePersonRole(role, true),
+          diseaseService.getDiseaseByName(disease),
           startDate,
           endDate,
           pageNumber,
@@ -58,6 +62,7 @@ public class TestResultResolver {
         patientId,
         Translators.parseTestResult(result),
         Translators.parsePersonRole(role, true),
+        diseaseService.getDiseaseByName(disease),
         startDate,
         endDate,
         pageNumber,
@@ -70,6 +75,7 @@ public class TestResultResolver {
       @Argument UUID patientId,
       @Argument String result,
       @Argument String role,
+      @Argument String disease,
       @Argument Date startDate,
       @Argument Date endDate,
       @Argument UUID orgId) {
@@ -78,6 +84,7 @@ public class TestResultResolver {
         patientId,
         Translators.parseTestResult(result),
         Translators.parsePersonRole(role, true),
+        diseaseService.getDiseaseByName(disease),
         startDate,
         endDate,
         orgId);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -19,6 +19,7 @@ import gov.cdc.usds.simplereport.db.model.Person_;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.Result_;
 import gov.cdc.usds.simplereport.db.model.SpecimenType;
+import gov.cdc.usds.simplereport.db.model.SupportedDisease;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.TestEvent_;
 import gov.cdc.usds.simplereport.db.model.TestOrder;
@@ -94,6 +95,7 @@ public class TestOrderService {
       UUID patientId,
       TestResult result,
       PersonRole role,
+      SupportedDisease disease,
       Date startDate,
       Date endDate,
       UUID orgId) {
@@ -137,6 +139,14 @@ public class TestOrderService {
       if (role != null) {
         p = cb.and(p, cb.equal(root.get(BaseTestInfo_.patient).get(Person_.role), role));
       }
+      if (disease != null) {
+        p =
+            cb.and(
+                p,
+                cb.equal(
+                    resultJoin.get(Result_.disease).get(IdentifiedEntity_.internalId),
+                    disease.getInternalId()));
+      }
       if (startDate != null) {
         p =
             cb.and(
@@ -173,6 +183,7 @@ public class TestOrderService {
       UUID patientId,
       TestResult result,
       PersonRole role,
+      SupportedDisease disease,
       Date startDate,
       Date endDate,
       int pageOffset,
@@ -182,7 +193,8 @@ public class TestOrderService {
         PageRequest.of(pageOffset, pageSize, Sort.by("createdAt").descending());
 
     return _testEventRepo.findAll(
-        buildTestEventSearchFilter(facilityId, patientId, result, role, startDate, endDate, null),
+        buildTestEventSearchFilter(
+            facilityId, patientId, result, role, disease, startDate, endDate, null),
         pageRequest);
   }
 
@@ -192,6 +204,7 @@ public class TestOrderService {
       UUID patientId,
       TestResult result,
       PersonRole role,
+      SupportedDisease disease,
       Date startDate,
       Date endDate,
       int pageOffset,
@@ -201,7 +214,8 @@ public class TestOrderService {
         PageRequest.of(pageOffset, pageSize, Sort.by("createdAt").descending());
 
     return _testEventRepo.findAll(
-        buildTestEventSearchFilter(null, patientId, result, role, startDate, endDate, null),
+        buildTestEventSearchFilter(
+            null, patientId, result, role, disease, startDate, endDate, null),
         pageRequest);
   }
 
@@ -211,13 +225,14 @@ public class TestOrderService {
       UUID patientId,
       TestResult result,
       PersonRole role,
+      SupportedDisease disease,
       Date startDate,
       Date endDate,
       UUID orgId) {
     return (int)
         _testEventRepo.count(
             buildTestEventSearchFilter(
-                facilityId, patientId, result, role, startDate, endDate, orgId));
+                facilityId, patientId, result, role, disease, startDate, endDate, orgId));
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -491,6 +491,7 @@ type Query {
     patientId: ID
     result: String
     role: String
+    disease: String
     startDate: DateTime
     endDate: DateTime
     pageNumber: Int = 0

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -116,7 +116,6 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
   private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
   private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
-  private static final PersonName MICHAEL = new PersonName("Michael", null, "Lorem", null);
   private Facility _site;
 
   @BeforeEach

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/TestOrderServiceTest.java
@@ -63,6 +63,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -115,6 +116,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   private static final PersonName JANNELLE = new PersonName("Jannelle", "Martha", "Cromack", null);
   private static final PersonName KACEY = new PersonName("Kacey", "L", "Mathie", null);
   private static final PersonName LEELOO = new PersonName("Leeloo", "Dallas", "Multipass", null);
+  private static final PersonName MICHAEL = new PersonName("Michael", null, "Lorem", null);
   private Facility _site;
 
   @BeforeEach
@@ -1255,11 +1257,12 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThrows(
         AccessDeniedException.class,
         () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+            _service.getFacilityTestEventsResults(
+                facilityId, null, null, null, null, null, null, 0, 10));
 
     TestUserIdentities.setFacilityAuthorities(facility);
     _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 10);
+        facility.getInternalId(), null, null, null, null, null, null, 0, 10);
   }
 
   @Test
@@ -1272,7 +1275,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     Page<TestEvent> testEventsByFacility =
         _service.getFacilityTestEventsResults(
-            facility.getInternalId(), null, null, null, null, null, 0, 10);
+            facility.getInternalId(), null, null, null, null, null, null, 0, 10);
     assertThat(testEventsByFacility.getTotalElements()).isEqualTo(1);
     assertThat(testEventsByFacility.getTotalPages()).isEqualTo(1);
   }
@@ -1289,7 +1292,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThrows(
         AccessDeniedException.class,
         () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+            _service.getFacilityTestEventsResults(
+                facilityId, null, null, null, null, null, null, 0, 10));
   }
 
   @Test
@@ -1301,7 +1305,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     _dataFactory.createTestEvent(p, facility);
 
     Page<TestEvent> testEventsByOrg =
-        _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10);
+        _service.getOrganizationTestEventsResults(null, null, null, null, null, null, 0, 10);
     assertThat(testEventsByOrg.getTotalElements()).isEqualTo(1);
     assertThat(testEventsByOrg.getTotalPages()).isEqualTo(1);
   }
@@ -1316,7 +1320,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     assertThrows(
         AccessDeniedException.class,
-        () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, 0, 10));
+        () -> _service.getOrganizationTestEventsResults(null, null, null, null, null, null, 0, 10));
   }
 
   @Test
@@ -1379,7 +1383,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // count queries
     long startQueryCount = QueryCountService.get().getSelect();
     _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 50);
+        facility.getInternalId(), null, null, null, null, null, null, 0, 50);
     long firstPassTotal = QueryCountService.get().getSelect() - startQueryCount;
 
     // add more data
@@ -1392,7 +1396,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     // count queries again and make sure queries made didn't increase
     startQueryCount = QueryCountService.get().getSelect();
     _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 50);
+        facility.getInternalId(), null, null, null, null, null, null, 0, 50);
     long secondPassTotal = QueryCountService.get().getSelect() - startQueryCount;
     assertEquals(firstPassTotal, secondPassTotal);
   }
@@ -1498,7 +1502,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestEvent> events_before =
         _service
             .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
+                facility.getInternalId(), null, null, null, null, null, null, 0, 50)
             .toList();
     assertEquals(1, events_before.size());
 
@@ -1515,7 +1519,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestEvent> events_after =
         _service
             .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 50)
+                facility.getInternalId(), null, null, null, null, null, null, 0, 50)
             .toList();
     assertEquals(1, events_after.size());
     assertEquals(
@@ -1905,19 +1909,23 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     List<TestEvent> testEvents = makedata();
     List<TestEvent> results_page0 =
         _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 0, 5)
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, null, null, null, null, 0, 5)
             .toList();
     List<TestEvent> results_page1 =
         _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 1, 5)
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, null, null, null, null, 1, 5)
             .toList();
     List<TestEvent> results_page2 =
         _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 2, 5)
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, null, null, null, null, 2, 5)
             .toList();
     List<TestEvent> results_page3 =
         _service
-            .getFacilityTestEventsResults(_site.getInternalId(), null, null, null, null, null, 3, 5)
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, null, null, null, null, 3, 5)
             .toList();
 
     Collections.reverse(testEvents);
@@ -1932,35 +1940,38 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @WithSimpleReportOrgAdminUser
   void getTestEventsResults_filtering() {
     List<TestEvent> testEvents = makedata();
+    List<TestEvent> fluATestEvents = makeSpecificDiseaseData(_diseaseService.fluA(), _site);
+    testEvents.addAll(fluATestEvents);
     List<TestEvent> positives =
         _service
             .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, 0, 10)
+                _site.getInternalId(), null, TestResult.POSITIVE, null, null, null, null, 0, 10)
             .toList();
     List<TestEvent> negatives =
         _service
             .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10)
+                _site.getInternalId(), null, TestResult.NEGATIVE, null, null, null, null, 0, 10)
             .toList();
     List<TestEvent> inconclusives =
         _service
             .getFacilityTestEventsResults(
-                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, 0, 10)
+                _site.getInternalId(), null, TestResult.UNDETERMINED, null, null, null, null, 0, 10)
             .toList();
     List<TestEvent> students =
         _service
             .getFacilityTestEventsResults(
-                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, 0, 10)
+                _site.getInternalId(), null, null, PersonRole.STUDENT, null, null, null, 0, 10)
             .toList();
     List<TestEvent> visitors =
         _service
             .getFacilityTestEventsResults(
-                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, 0, 10)
+                _site.getInternalId(), null, null, PersonRole.VISITOR, null, null, null, 0, 10)
             .toList();
     List<TestEvent> june1to3 =
         _service
             .getFacilityTestEventsResults(
                 _site.getInternalId(),
+                null,
                 null,
                 null,
                 null,
@@ -1973,6 +1984,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
         _service
             .getFacilityTestEventsResults(
                 _site.getInternalId(),
+                null,
                 null,
                 null,
                 null,
@@ -1990,6 +2002,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                 null,
                 null,
                 null,
+                null,
                 0,
                 10)
             .toList();
@@ -2002,8 +2015,14 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                 null,
                 null,
                 null,
+                null,
                 0,
                 10)
+            .toList();
+    List<TestEvent> fluAResults =
+        _service
+            .getFacilityTestEventsResults(
+                _site.getInternalId(), null, null, null, _diseaseService.fluA(), null, null, 0, 10)
             .toList();
     List<TestEvent> allFilters =
         _service
@@ -2012,6 +2031,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                 _dataFactory.getPersonByName(CHARLES).getInternalId(),
                 TestResult.POSITIVE,
                 PersonRole.RESIDENT,
+                _diseaseService.covid(),
                 convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)),
                 convertDate(LocalDateTime.of(2021, 6, 1, 23, 59, 59)),
                 0,
@@ -2023,17 +2043,24 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertTestResultsList(
         positives,
         testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.POSITIVE)
+            .filter(
+                t ->
+                    t.getResults().stream().anyMatch(r -> r.getTestResult() == TestResult.POSITIVE))
             .collect(Collectors.toList()));
     assertTestResultsList(
         negatives,
         testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.NEGATIVE)
+            .filter(
+                t ->
+                    t.getResults().stream().anyMatch(r -> r.getTestResult() == TestResult.NEGATIVE))
             .collect(Collectors.toList()));
     assertTestResultsList(
         inconclusives,
         testEvents.stream()
-            .filter(t -> t.getCovidTestResult().orElse(null) == TestResult.UNDETERMINED)
+            .filter(
+                t ->
+                    t.getResults().stream()
+                        .anyMatch(r -> r.getTestResult() == TestResult.UNDETERMINED))
             .collect(Collectors.toList()));
     assertTestResultsList(
         students,
@@ -2077,6 +2104,17 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                         && t.getPatient().getNameInfo().equals(AMOS))
             .collect(Collectors.toList()));
     assertTestResultsList(
+        fluAResults,
+        testEvents.stream()
+            .filter(
+                t ->
+                    t.getResults().stream()
+                        .anyMatch(
+                            r ->
+                                Objects.equals(
+                                    r.getDisease().getName(), _diseaseService.fluA().getName())))
+            .collect(Collectors.toList()));
+    assertTestResultsList(
         allFilters,
         testEvents.stream()
             .filter(
@@ -2084,6 +2122,12 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
                     t.getPatient().getNameInfo().equals(CHARLES)
                         && t.getCovidTestResult().orElse(null) == TestResult.POSITIVE
                         && t.getPatient().getRole() == PersonRole.RESIDENT
+                        && t.getResults().stream()
+                            .anyMatch(
+                                r ->
+                                    Objects.equals(
+                                        r.getDisease().getName(),
+                                        _diseaseService.covid().getName()))
                         && !t.getDateTested()
                             .before(convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)))
                         && !t.getDateTested()
@@ -2103,7 +2147,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     var res =
         _service
             .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10)
+                facility.getInternalId(), null, null, null, null, null, null, 0, 10)
             .toList();
     assertEquals(1, res.size());
   }
@@ -2121,7 +2165,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     var res =
         _service
             .getFacilityTestEventsResults(
-                facility.getInternalId(), null, null, null, null, null, 0, 10)
+                facility.getInternalId(), null, null, null, null, null, null, 0, 10)
             .toList();
     assertEquals(2, res.size());
   }
@@ -2144,7 +2188,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
 
     var res =
         _service.getFacilityTestEventsResults(
-            facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, 0, 10);
+            facility.getInternalId(), null, TestResult.NEGATIVE, null, null, null, null, 0, 10);
 
     var expected = List.of(expected_allNeg.getInternalId(), expected_covidPos.getInternalId());
     var actualInternalIds = res.stream().map(TestEvent::getInternalId).collect(Collectors.toList());
@@ -2158,7 +2202,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void getTestResultsCount() {
     makedata();
     int size =
-        _service.getTestResultsCount(_site.getInternalId(), null, null, null, null, null, null);
+        _service.getTestResultsCount(
+            _site.getInternalId(), null, null, null, null, null, null, null);
     assertEquals(11, size);
   }
 
@@ -2167,7 +2212,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   void getTestResultsCount_forOrganization() {
     var testEvents = makeAdminData();
     var orgId = testEvents.get(0).getOrganization().getInternalId();
-    int size = _service.getTestResultsCount(null, null, null, null, null, null, orgId);
+    int size = _service.getTestResultsCount(null, null, null, null, null, null, null, orgId);
     assertEquals(4, size);
   }
 
@@ -2177,7 +2222,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     var otherOrgId = UUID.randomUUID();
     assertThrows(
         AccessDeniedException.class,
-        () -> _service.getTestResultsCount(null, null, null, null, null, null, otherOrgId));
+        () -> _service.getTestResultsCount(null, null, null, null, null, null, null, otherOrgId));
   }
 
   @Test
@@ -2236,7 +2281,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
   @WithSimpleReportOrgAdminUser
   void getTopLevelDashboardMetrics_showsNonCovidResults() {
     makedata();
-    makeSpecificDiseaseData(_diseaseService.fluA());
+    makeSpecificDiseaseData(_diseaseService.fluA(), null);
     Date startDate = Date.from(Instant.parse("2000-01-01T00:00:00Z"));
     Date endDate = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(3));
 
@@ -2261,7 +2306,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     assertThrows(
         AccessDeniedException.class,
         () ->
-            _service.getFacilityTestEventsResults(facilityId, null, null, null, null, null, 0, 10));
+            _service.getFacilityTestEventsResults(
+                facilityId, null, null, null, null, null, null, 0, 10));
     assertThrows(AccessDeniedException.class, () -> _service.getTestResult(testEventId));
 
     // make sure the corrected event is not sent to storage queue
@@ -2271,7 +2317,7 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     TestUserIdentities.setFacilityAuthorities(facility);
     TestEvent correctedTestEvent = _service.markAsError(_e.getInternalId(), reasonMsg);
     _service.getFacilityTestEventsResults(
-        facility.getInternalId(), null, null, null, null, null, 0, 10);
+        facility.getInternalId(), null, null, null, null, null, null, 0, 10);
     _service.getTestResult(_e.getInternalId()).getTestOrder();
     // make sure the corrected event is sent to storage queue
     verify(testEventReportingService).report(correctedTestEvent);
@@ -2504,27 +2550,30 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
     return testEvents;
   }
 
-  private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease) {
+  private List<TestEvent> makeSpecificDiseaseData(SupportedDisease disease, Facility site) {
     Organization org = _organizationService.getCurrentOrganization();
-    _site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
+    if (site == null) {
+      site = _dataFactory.createValidFacility(org, "The Facility for " + disease.getName());
+    }
     Map<PersonName, TestResult> patientsToResults = new HashMap<>();
-    patientsToResults.put(AMOS, TestResult.POSITIVE);
-    patientsToResults.put(CHARLES, TestResult.NEGATIVE);
+    patientsToResults.put(DEXTER, TestResult.POSITIVE);
+    patientsToResults.put(ELIZABETH, TestResult.NEGATIVE);
 
     Map<PersonName, Date> patientsToDates = new HashMap<>();
-    patientsToDates.put(AMOS, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
-    patientsToDates.put(CHARLES, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
+    patientsToDates.put(DEXTER, convertDate(LocalDateTime.of(2021, 6, 1, 0, 0, 0)));
+    patientsToDates.put(ELIZABETH, convertDate(LocalDateTime.of(2021, 6, 1, 12, 0, 0)));
 
     Map<PersonName, PersonRole> patientsToRoles = new HashMap<>();
-    patientsToRoles.put(AMOS, PersonRole.RESIDENT);
-    patientsToRoles.put(CHARLES, PersonRole.RESIDENT);
+    patientsToRoles.put(DEXTER, PersonRole.RESIDENT);
+    patientsToRoles.put(ELIZABETH, PersonRole.RESIDENT);
 
     Map<PersonName, AskOnEntrySurvey> patientsToSurveys = new HashMap<>();
     patientsToSurveys.put(
-        AMOS, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
+        DEXTER, new AskOnEntrySurvey(null, null, Map.of("fake", true), false, null, null));
     patientsToSurveys.put(
-        CHARLES, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
+        ELIZABETH, new AskOnEntrySurvey(null, null, Collections.emptyMap(), false, null, null));
 
+    Facility finalSite = site;
     return patientsToResults.keySet().stream()
         .map(
             n -> {
@@ -2533,8 +2582,8 @@ class TestOrderServiceTest extends BaseServiceTest<TestOrderService> {
               AskOnEntrySurvey s = patientsToSurveys.get(n);
               Date d = patientsToDates.get(n);
 
-              Person person = _dataFactory.createMinimalPerson(org, _site, n, r);
-              return _dataFactory.createTestEvent(person, _site, s, t, d, disease);
+              Person person = _dataFactory.createMinimalPerson(org, finalSite, n, r);
+              return _dataFactory.createTestEvent(person, finalSite, s, t, d, disease);
             })
         .collect(Collectors.toList());
   }

--- a/frontend/src/app/testResults/operations.graphql
+++ b/frontend/src/app/testResults/operations.graphql
@@ -20,6 +20,7 @@ query GetFacilityResultsForCsvWithCount(
   $patientId: ID
   $result: String
   $role: String
+  $disease: String
   $startDate: DateTime
   $endDate: DateTime
   $pageNumber: Int
@@ -30,6 +31,7 @@ query GetFacilityResultsForCsvWithCount(
     patientId: $patientId
     result: $result
     role: $role
+    disease: $disease
     startDate: $startDate
     endDate: $endDate
     pageNumber: $pageNumber

--- a/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
+++ b/frontend/src/app/testResults/viewResults/DownloadResultsCsvModal.tsx
@@ -72,7 +72,8 @@ export const DownloadResultsCsvModal = ({
       try {
         const csvResults = parseDataForCSV(
           data.testResultsPage.content,
-          disabledFeatureDiseaseList
+          disabledFeatureDiseaseList,
+          filterParams
         );
         setResults(csvResults);
       } catch (e) {

--- a/frontend/src/app/utils/testResultCSV.ts
+++ b/frontend/src/app/utils/testResultCSV.ts
@@ -73,7 +73,8 @@ export type ResultCsvRow =
 
 export function parseDataForCSV(
   data: QueriedTestResult[],
-  excludedDiseases: MULTIPLEX_DISEASES[] = []
+  excludedDiseases: MULTIPLEX_DISEASES[] = [],
+  filterParams?: FilterParams
 ): ResultCsvRow[] {
   let csvRows: ResultCsvRow[] = [];
   data.sort(byDateTested).forEach((r: QueriedTestResult) => {
@@ -146,7 +147,10 @@ export function parseDataForCSV(
       if (
         excludedDiseases.some(
           (d) => d.toLowerCase() === result?.disease.name.toLowerCase()
-        )
+        ) ||
+        (filterParams?.disease &&
+          result?.disease.name.toLowerCase() !==
+            filterParams.disease.toLowerCase())
       ) {
         return;
       }

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -875,6 +875,7 @@ export type QueryTestResultsCountArgs = {
 };
 
 export type QueryTestResultsPageArgs = {
+  disease?: InputMaybe<Scalars["String"]["input"]>;
   endDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   facilityId?: InputMaybe<Scalars["ID"]["input"]>;
   pageNumber?: InputMaybe<Scalars["Int"]["input"]>;
@@ -2401,6 +2402,7 @@ export type GetFacilityResultsForCsvWithCountQueryVariables = Exact<{
   patientId?: InputMaybe<Scalars["ID"]["input"]>;
   result?: InputMaybe<Scalars["String"]["input"]>;
   role?: InputMaybe<Scalars["String"]["input"]>;
+  disease?: InputMaybe<Scalars["String"]["input"]>;
   startDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   endDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   pageNumber?: InputMaybe<Scalars["Int"]["input"]>;
@@ -7779,6 +7781,7 @@ export const GetFacilityResultsForCsvWithCountDocument = gql`
     $patientId: ID
     $result: String
     $role: String
+    $disease: String
     $startDate: DateTime
     $endDate: DateTime
     $pageNumber: Int
@@ -7789,6 +7792,7 @@ export const GetFacilityResultsForCsvWithCountDocument = gql`
       patientId: $patientId
       result: $result
       role: $role
+      disease: $disease
       startDate: $startDate
       endDate: $endDate
       pageNumber: $pageNumber
@@ -7874,6 +7878,7 @@ export const GetFacilityResultsForCsvWithCountDocument = gql`
  *      patientId: // value for 'patientId'
  *      result: // value for 'result'
  *      role: // value for 'role'
+ *      disease: // value for 'disease'
  *      startDate: // value for 'startDate'
  *      endDate: // value for 'endDate'
  *      pageNumber: // value for 'pageNumber'


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7948 

## Changes Proposed

- Adds support for disease filter parameter on the results CSV download

## Additional Information

- The main results list page and the csv download use different but very similar queries and search filters.
- The key difference between the two is that the csv download has some additional data from the test event AOE responses while the main results list page does not.
- Main results page calls the query mapping to `ResultResolver.resultsPage` which then calls `ResultService.getFacilityResults` or `ResultService.getOrganizationResults`. These service methods then call `ResultRepository.findAll` and pass in a JPA `Specification<Results>` that is created with the Jakarta criteria builder in `buildResultSearchFilter`.
- The CSV download calls the query mapping to `TestResultResolver.testResultsPage` which then calls `TestOrderService.getOrganizationTestEventsResults` or `TestOrderService.getFacilityTestEventsResults`. These service methods then call `TestEventRepository.findAll` and pass in a JPA `Specification<TestEvent>` that is created with the Jakarta criteria builder in `buildTestEventSearchFilter`.
- For both `buildTestEventSearchFilter` and `buildResultSearchFilter` there is fairly identical logic for applying the filters on the joins.
- A future ticket should refactor some of this to ideally use one query and support both use cases whether or not it requires the additional AOE data.

### GraphQL backwards compatibility

- I looked over [this wiki section regarding GQL backwards compatibility](https://github.com/CDCgov/prime-simplereport/wiki/GraphQL-Flow#how-do-i-edit-a-query-or-mutation) and I believe since we are only adding a new optional field that there will not be any issues with including both frontend and backend changes in the same PR.

## Testing

- Deployed on dev5