### PR TITLE
Update userIsInSameOrg to use DB when feature flag enabled

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifierTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/config/authorization/UserAuthorizationVerifierTest.java
@@ -1,0 +1,108 @@
+package gov.cdc.usds.simplereport.config.authorization;
+
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.ALL_FACILITIES_USER;
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.OTHER_ORG_ADMIN;
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.OTHER_ORG_USER;
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.STANDARD_USER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
+import gov.cdc.usds.simplereport.service.BaseServiceTest;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {"spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"})
+class UserAuthorizationVerifierTest extends BaseServiceTest<UserAuthorizationVerifier> {
+  @Autowired @SpyBean ApiUserRepository _apiUserRepo;
+  @MockBean FeatureFlagsConfig _featureFlagsConfig;
+
+  @BeforeEach
+  public void setup() {
+    initSampleData();
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void userIsInSameOrg_whenOktaMigrationDisabled_forUsersInSameOrg_returnsTrue() {
+    // GIVEN
+    when(_featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(false);
+    ApiUser user = _apiUserRepo.findByLoginEmail(ALL_FACILITIES_USER).get();
+    ApiUser userSpy = spy(user);
+    when(_apiUserRepo.findByIdIncludeArchived(user.getInternalId()))
+        .thenReturn(Optional.of(userSpy));
+
+    // WHEN
+    boolean isSameOrg = _service.userIsInSameOrg(user.getInternalId());
+
+    // THEN
+    verify(userSpy, times(0)).getOrganizations();
+    assertTrue(isSameOrg);
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void userIsInSameOrg_whenOktaMigrationDisabled_forUsersInDifferentOrgs_returnsFalse() {
+    // GIVEN
+    when(_featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(false);
+    ApiUser user = _apiUserRepo.findByLoginEmail(OTHER_ORG_USER).get();
+    ApiUser userSpy = spy(user);
+    when(_apiUserRepo.findByIdIncludeArchived(user.getInternalId()))
+        .thenReturn(Optional.of(userSpy));
+
+    // WHEN
+    boolean isSameOrg = _service.userIsInSameOrg(user.getInternalId());
+
+    // THEN
+    verify(userSpy, times(0)).getOrganizations();
+    assertFalse(isSameOrg);
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void userIsInSameOrg_whenOktaMigrationEnabled_forUsersInSameOrg_returnsTrue() {
+    // GIVEN
+    when(_featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    ApiUser user = _apiUserRepo.findByLoginEmail(STANDARD_USER).get();
+    ApiUser userSpy = spy(user);
+    when(_apiUserRepo.findByIdIncludeArchived(user.getInternalId()))
+        .thenReturn(Optional.of(userSpy));
+
+    // WHEN
+    boolean isSameOrg = _service.userIsInSameOrg(user.getInternalId());
+
+    // THEN
+    verify(userSpy, times(1)).getOrganizations();
+    assertTrue(isSameOrg);
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportEntryOnlyUser
+  void userIsInSameOrg_whenOktaMigrationEnabled_forUsersInDifferentOrgs_returnsFalse() {
+    // GIVEN
+    when(_featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    ApiUser user = _apiUserRepo.findByLoginEmail(OTHER_ORG_ADMIN).get();
+    ApiUser userSpy = spy(user);
+    when(_apiUserRepo.findByIdIncludeArchived(user.getInternalId()))
+        .thenReturn(Optional.of(userSpy));
+
+    // WHEN
+    boolean isSameOrg = _service.userIsInSameOrg(user.getInternalId());
+
+    // THEN
+    verify(userSpy, times(1)).getOrganizations();
+    assertFalse(isSameOrg);
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Part of #7598
- Follow up to #8030
  - [comment here](https://github.com/CDCgov/prime-simplereport/pull/8030#pullrequestreview-2257765180) 

## Changes Proposed
- Ensure that when calling the `userIsInSameOrg` permission check we check the DB for the user's org when the feature flag is enabled

## Additional Information
- N/A

## Testing
- dev2 has a [different branch](https://github.com/CDCgov/prime-simplereport/compare/elisa/7598-feature-flag-on-update-permission-check?expand=1) with the `oktaMigrationEnabled` set to `true` deployed
- [dev2 metabase link](https://dev2.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQxLCJqb2lucyI6W3sic3RyYXRlZ3kiOiJsZWZ0LWpvaW4iLCJhbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsNDMxLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIn1dLFsiZmllbGQiLDQ0LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIifV1dLCJzb3VyY2UtdGFibGUiOjExfSx7InN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJBcGkgVXNlciBGYWNpbGl0eSAtIEFwaSBVc2VyIiwiY29uZGl0aW9uIjpbIj0iLFsiZmllbGQiLDQzMSx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCJ9XSxbImZpZWxkIiw0MjYseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XV0sInNvdXJjZS10YWJsZSI6NDJ9XSwiYnJlYWtvdXQiOltbImZpZWxkIiw0MzEseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQifV0sWyJmaWVsZCIsNDMseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgTm8gUGhpIFZpZXcgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDQseyJiYXNlLXR5cGUiOiJ0eXBlL1Bvc3RncmVzRW51bSJ9XSxbImZpZWxkIiw0MjgseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDUseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiw0NDMseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiw0MjkseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQifV1dLCJvcmRlci1ieSI6W1siZGVzYyIsWyJmaWVsZCIsNDQ1LHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZSIsInRlbXBvcmFsLXVuaXQiOiJtaW51dGUifV1dXX19LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwib3JpZ2luYWxfY2FyZF9pZCI6bnVsbH0=)
- log in as org admin or site admin
- check that any method with the following permission checks still work:
  - [RequirePermissionManageTargetUserNotSelf](https://github.com/search?q=repo%3ACDCgov%2Fprime-simplereport%20RequirePermissionManageTargetUserNotSelf&type=code)
  - [RequirePermissionManageTargetUser](https://github.com/search?q=repo%3ACDCgov%2Fprime-simplereport+RequirePermissionManageTargetUser&type=code)

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->