### PR TITLE
Fetch group info for users from DB when oktaMigrationEnabled is true

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/accountrequest/AccountRequestController.java
@@ -110,7 +110,8 @@ public class AccountRequestController {
             "This email address is already associated with a SimpleReport user.");
       }
 
-      OrganizationQueueItem item = _orgQueueService.queueNewRequest(organizationName, orgExternalId, request);
+      OrganizationQueueItem item =
+          _orgQueueService.queueNewRequest(organizationName, orgExternalId, request);
 
       return new AccountResponse(item.getExternalId());
     } catch (BadRequestException e) {
@@ -166,7 +167,8 @@ public class AccountRequestController {
   private List<String> getOrgAdminUserEmails(Organization org) {
     List<String> adminUserEmails;
     if (_featureFlagsConfig.isOktaMigrationEnabled()) {
-      adminUserEmails = _dbAuthService.getOrgAdminUsers(org).stream()
+      adminUserEmails =
+          _dbAuthService.getOrgAdminUsers(org).stream()
               .map(ApiUser::getLoginEmail)
               .collect(Collectors.toList());
     } else {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/repository/ApiUserRepository.java
@@ -1,6 +1,9 @@
 package gov.cdc.usds.simplereport.db.repository;
 
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -30,4 +33,37 @@ public interface ApiUserRepository extends EternalSystemManagedEntityRepository<
 
   @Query(BASE_QUERY + " and loginEmail IN :emails" + NAME_ORDER)
   List<ApiUser> findAllByLoginEmailInOrderByName(Collection<String> emails);
+
+  String API_USER_ROLE_LEFT_JOIN = " LEFT JOIN api_user_role aur ON aur.apiUser = e";
+  String BY_ORG_AND_UNDELETED_USER = " WHERE aur.organization = :org AND e.isDeleted = false";
+  String JOINED_NAME_ORDER =
+      " order by e.nameInfo.lastName, e.nameInfo.firstName, e.nameInfo.middleName, e.internalId";
+
+  @Query(
+      value =
+          "from #{#entityName} e"
+              + API_USER_ROLE_LEFT_JOIN
+              + BY_ORG_AND_UNDELETED_USER
+              + JOINED_NAME_ORDER)
+  List<ApiUser> findAllByOrganization(Organization org);
+
+  @Query(
+      value =
+          "from #{#entityName} e"
+              + API_USER_ROLE_LEFT_JOIN
+              + BY_ORG_AND_UNDELETED_USER
+              + " AND aur.role = :role"
+              + JOINED_NAME_ORDER)
+  List<ApiUser> findAllByOrganizationAndRole(Organization org, OrganizationRole role);
+
+  @Query(
+      value =
+          "from #{#entityName} e"
+              + API_USER_ROLE_LEFT_JOIN
+              + " LEFT JOIN api_user_facility auf ON auf.apiUser = e"
+              + " WHERE auf.facility = :facility"
+              + " AND e.isDeleted = false"
+              + " AND (aur.role = 'USER' OR aur.role = 'ENTRY_ONLY')"
+              + " GROUP BY e")
+  List<ApiUser> findAllBySingleFacilityAccess(Facility facility);
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -285,6 +285,12 @@ public class DemoOktaRepository implements OktaRepository {
     inactiveUsernames.removeAll(orgUsernamesMap.get(org.getExternalId()));
   }
 
+  @Override
+  public String activateUser(String username) {
+    inactiveUsernames.remove(username);
+    return "activationToken";
+  }
+
   // this method means nothing in a demo env
   public String activateOrganizationWithSingleUser(Organization org) {
     activateOrganization(org);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -576,6 +576,13 @@ public class LiveOktaRepository implements OktaRepository {
   }
 
   @Override
+  public String activateUser(String username) {
+    User oktaUser =
+        getUserOrThrowError(username, "Cannot activate Okta user with unrecognized username");
+    return activateUser(oktaUser);
+  }
+
+  @Override
   public void activateOrganization(Organization org) {
     var users = getOrgAdminUsers(org);
     for (User u : users) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -71,6 +71,8 @@ public interface OktaRepository {
 
   void activateOrganization(Organization org);
 
+  String activateUser(String username);
+
   String activateOrganizationWithSingleUser(Organization org);
 
   List<String> fetchAdminUserEmail(Organization org);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
@@ -48,7 +48,7 @@ public class DbAuthorizationService {
    * @param facility - Facility to get count for
    * @return Integer - count of ApiUsers
    */
-  public Integer getUserWithSingleFacilityAccessCount(Facility facility) {
+  public Integer getUsersWithSingleFacilityAccessCount(Facility facility) {
     List<ApiUser> users = _userRepo.findAllBySingleFacilityAccess(facility);
     return users.stream()
         .filter(user -> user.getFacilities().size() <= 1)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
@@ -1,0 +1,58 @@
+package gov.cdc.usds.simplereport.service;
+
+import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.repository.ApiUserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DbAuthorizationService {
+  private final ApiUserRepository _userRepo;
+
+  /**
+   * Fetches a list of ApiUsers that belong to an Organization sorted by last name, first name, and
+   * middle name
+   *
+   * @param org - Organization
+   * @return List of ApiUsers that belong to the org
+   */
+  @AuthorizationConfiguration.RequirePermissionManageUsers
+  public List<ApiUser> getUsersInOrganization(Organization org) {
+    return _userRepo.findAllByOrganization(org);
+  }
+
+  /**
+   * Fetches a list of ApiUsers that belong to an Organization and has the ADMIN role, sorted by
+   * last name, first name, and middle name
+   *
+   * @param org - Organization
+   * @return List of ApiUsers with ADMIN role in the org
+   */
+  public List<ApiUser> getOrgAdminUsers(Organization org) {
+    return _userRepo.findAllByOrganizationAndRole(org, OrganizationRole.ADMIN);
+  }
+
+  /**
+   * Fetches a count of ApiUsers that have permission to access the one defined facility and do not
+   * have the ALL_FACILITIES and/or ADMIN roles
+   *
+   * @param facility - Facility to get count for
+   * @return Integer - count of ApiUsers
+   */
+  public Integer getUserWithSingleFacilityAccessCount(Facility facility) {
+    List<ApiUser> users = _userRepo.findAllBySingleFacilityAccess(facility);
+    return users.stream()
+        .filter(user -> user.getFacilities().size() <= 1)
+        .collect(Collectors.toList())
+        .size();
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbAuthorizationService.java
@@ -49,7 +49,9 @@ public class DbAuthorizationService {
    * @return Integer - count of ApiUsers
    */
   public Integer getUsersWithSingleFacilityAccessCount(Facility facility) {
-    List<ApiUser> users = _userRepo.findAllBySingleFacilityAccess(facility);
+    List<ApiUser> users =
+        _userRepo.findAllByFacilityAndRoles(
+            facility, List.of(OrganizationRole.USER, OrganizationRole.ENTRY_ONLY));
     return users.stream()
         .filter(user -> user.getFacilities().size() <= 1)
         .collect(Collectors.toList())

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -491,15 +491,15 @@ public class OrganizationService {
         this.getFacilityById(facilityId)
             .orElseThrow(() -> new IllegalGraphqlArgumentException("Facility not found."));
 
-    Integer userWithSingleFacilityAccess;
+    Integer usersWithSingleFacilityAccess;
     if (featureFlagsConfig.isOktaMigrationEnabled()) {
-      userWithSingleFacilityAccess =
-          dbAuthorizationService.getUserWithSingleFacilityAccessCount(facility);
+      usersWithSingleFacilityAccess =
+          dbAuthorizationService.getUsersWithSingleFacilityAccessCount(facility);
     } else {
-      userWithSingleFacilityAccess = this.oktaRepository.getUsersInSingleFacility(facility);
+      usersWithSingleFacilityAccess = this.oktaRepository.getUsersInSingleFacility(facility);
     }
     return FacilityStats.builder()
-        .usersSingleAccessCount(userWithSingleFacilityAccess)
+        .usersSingleAccessCount(usersWithSingleFacilityAccess)
         .patientsSingleAccessCount(
             this.personRepository.countByFacilityAndIsDeleted(facility, false))
         .build();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -6,6 +6,7 @@ import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentExceptio
 import gov.cdc.usds.simplereport.api.model.errors.MisconfiguredUserException;
 import gov.cdc.usds.simplereport.api.model.errors.NonexistentOrgException;
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
 import gov.cdc.usds.simplereport.config.authorization.OrganizationRoleClaims;
 import gov.cdc.usds.simplereport.db.model.ApiUser;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
@@ -53,14 +54,16 @@ public class OrganizationService {
   private final OrganizationRepository organizationRepository;
   private final FacilityRepository facilityRepository;
   private final ProviderRepository providerRepository;
-  private final AuthorizationService authorizationService;
   private final PersonRepository personRepository;
   private final OktaRepository oktaRepository;
   private final CurrentOrganizationRolesContextHolder organizationRolesContext;
   private final OrderingProviderRequiredValidator orderingProviderValidator;
+  private final AuthorizationService authorizationService;
+  private final DbAuthorizationService dbAuthorizationService;
   private final PatientSelfRegistrationLinkService patientSelfRegistrationLinkService;
   private final DeviceTypeRepository deviceTypeRepository;
   private final EmailService emailService;
+  private final FeatureFlagsConfig featureFlagsConfig;
 
   public void resetOrganizationRolesContext() {
     organizationRolesContext.reset();
@@ -346,7 +349,14 @@ public class OrganizationService {
     org.setIdentityVerified(verified);
     boolean newStatus = organizationRepository.save(org).getIdentityVerified();
     if (oldStatus == false && newStatus == true) {
-      oktaRepository.activateOrganization(org);
+      if (featureFlagsConfig.isOktaMigrationEnabled()) {
+        List<ApiUser> orgAdmins = dbAuthorizationService.getOrgAdminUsers(org);
+        for (ApiUser orgAdmin : orgAdmins) {
+          oktaRepository.activateUser(orgAdmin.getLoginEmail());
+        }
+      } else {
+        oktaRepository.activateOrganization(org);
+      }
     }
     return newStatus;
   }
@@ -364,7 +374,19 @@ public class OrganizationService {
     }
     org.setIdentityVerified(true);
     organizationRepository.save(org);
-    return oktaRepository.activateOrganizationWithSingleUser(org);
+    if (featureFlagsConfig.isOktaMigrationEnabled()) {
+      Optional<ApiUser> orgAdmin =
+          dbAuthorizationService.getOrgAdminUsers(org).stream().findFirst();
+
+      if (orgAdmin.isPresent()) {
+        String orgAdminEmail = orgAdmin.get().getLoginEmail();
+        return oktaRepository.activateUser(orgAdminEmail);
+      } else {
+        throw new IllegalStateException("Organization does not have any org admins.");
+      }
+    } else {
+      return oktaRepository.activateOrganizationWithSingleUser(org);
+    }
   }
 
   private Facility createFacilityNoPermissions(
@@ -469,8 +491,15 @@ public class OrganizationService {
         this.getFacilityById(facilityId)
             .orElseThrow(() -> new IllegalGraphqlArgumentException("Facility not found."));
 
+    Integer userWithSingleFacilityAccess;
+    if (featureFlagsConfig.isOktaMigrationEnabled()) {
+      userWithSingleFacilityAccess =
+          dbAuthorizationService.getUserWithSingleFacilityAccessCount(facility);
+    } else {
+      userWithSingleFacilityAccess = this.oktaRepository.getUsersInSingleFacility(facility);
+    }
     return FacilityStats.builder()
-        .usersSingleAccessCount(this.oktaRepository.getUsersInSingleFacility(facility))
+        .usersSingleAccessCount(userWithSingleFacilityAccess)
         .patientsSingleAccessCount(
             this.personRepository.countByFacilityAndIsDeleted(facility, false))
         .build();
@@ -487,21 +516,30 @@ public class OrganizationService {
       log.warn(String.format("Organization with internal id %s not found", orgId));
       return List.of();
     }
-    List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
-    return adminUserEmails.stream()
-        .map(
-            adminUserEmail -> {
-              Optional<ApiUser> foundUser = apiUserRepository.findByLoginEmail(adminUserEmail);
-              if (foundUser.isEmpty()) {
-                log.warn(
-                    "Query for admin users in organization "
-                        + org.getInternalId()
-                        + " found a user in Okta but not in the database. Skipping...");
-              }
-              return foundUser.orElse(null);
-            })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+    List<ApiUser> adminUsers;
+
+    if (featureFlagsConfig.isOktaMigrationEnabled()) {
+      adminUsers = dbAuthorizationService.getOrgAdminUsers(org);
+    } else {
+      List<String> adminUserEmails = oktaRepository.fetchAdminUserEmail(org);
+      adminUsers =
+          adminUserEmails.stream()
+              .map(
+                  adminUserEmail -> {
+                    Optional<ApiUser> foundUser =
+                        apiUserRepository.findByLoginEmail(adminUserEmail);
+                    if (foundUser.isEmpty()) {
+                      log.warn(
+                          "Query for admin users in organization "
+                              + org.getInternalId()
+                              + " found a user in Okta but not in the database. Skipping...");
+                    }
+                    return foundUser.orElse(null);
+                  })
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+    }
+    return adminUsers;
   }
 
   private List<String> getOrgAdminUserEmails(UUID orgId) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/db/repository/BaseRepositoryTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.repository;
 
 import gov.cdc.usds.simplereport.config.DataSourceConfiguration;
+import gov.cdc.usds.simplereport.service.DbAuthorizationService;
 import gov.cdc.usds.simplereport.service.DbOrgRoleClaimsService;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import gov.cdc.usds.simplereport.test_util.DbTruncator;
@@ -26,6 +27,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import({
   SliceTestConfiguration.class,
+  DbAuthorizationService.class,
   DbOrgRoleClaimsService.class,
   DbTruncator.class,
   DataSourceConfiguration.class,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepositoryTest.java
@@ -383,6 +383,14 @@ class DemoOktaRepositoryTest {
   }
 
   @Test
+  void activateUser() {
+    _repo.createUser(AMOS, ABC, Set.of(ABC_1), Set.of(OrganizationRole.USER), false);
+    String activatedUserResponse = _repo.activateUser(AMOS.getUsername());
+    assertEquals(UserStatus.ACTIVE, _repo.getUserStatus(AMOS.getUsername()));
+    assertEquals("activationToken", activatedUserResponse);
+  }
+
+  @Test
   void deactivateUser() {
     _repo.createUser(AMOS, ABC, Set.of(ABC_1), Set.of(OrganizationRole.USER), true);
     _repo.createUser(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -77,7 +77,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
   // no-security and no-okta-mgmt profiles
   @Test
   @WithSimpleReportOrgAdminUser
-  void getUsersInCurrentOrg_adminUser_success() {
+  void getUsersInCurrentOrg_withAdminUser_withOktaMigrationDisabled_success() {
     initSampleData();
     List<ApiUser> users = _service.getUsersInCurrentOrg();
     assertEquals(6, users.size());
@@ -93,6 +93,33 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     assertEquals("Reynolds", users.get(4).getNameInfo().getLastName());
     assertEquals("allfacilities@example.com", users.get(5).getLoginEmail());
     assertEquals("Williams", users.get(5).getNameInfo().getLastName());
+
+    Organization currentOrg = _organizationService.getCurrentOrganization();
+    verify(_oktaRepo, times(1)).getAllUsersForOrganization(currentOrg);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getUsersInCurrentOrg_withAdminUser_withOktaMigrationEnabled_success() {
+    initSampleData();
+    when(_featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+
+    List<ApiUser> users = _service.getUsersInCurrentOrg();
+    assertEquals(6, users.size());
+    assertEquals("admin@example.com", users.get(0).getLoginEmail());
+    assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
+    assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
+    assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
+    assertEquals("invalid@example.com", users.get(2).getLoginEmail());
+    assertEquals("Irwin", users.get(2).getNameInfo().getLastName());
+    assertEquals("nobody@example.com", users.get(3).getLoginEmail());
+    assertEquals("Nixon", users.get(3).getNameInfo().getLastName());
+    assertEquals("notruby@example.com", users.get(4).getLoginEmail());
+    assertEquals("Reynolds", users.get(4).getNameInfo().getLastName());
+    assertEquals("allfacilities@example.com", users.get(5).getLoginEmail());
+    assertEquals("Williams", users.get(5).getNameInfo().getLastName());
+
+    verify(_oktaRepo, times(0)).getAllUsersForOrganization(any());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DbAuthorizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DbAuthorizationServiceTest.java
@@ -66,7 +66,7 @@ class DbAuthorizationServiceTest extends BaseServiceTest<DbAuthorizationService>
 
   @Test
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
-  void getUserWithSingleFacilityAccessCount_success() {
+  void getUsersWithSingleFacilityAccessCount_success() {
     Organization org = _dataFactory.saveOrganization("ABC org", "k12", "ABC_ORG", true);
     Facility fac1 = _dataFactory.createValidFacility(org, "BCD Facility");
     Facility fac2 = _dataFactory.createValidFacility(org, "CDE Facility");
@@ -79,17 +79,17 @@ class DbAuthorizationServiceTest extends BaseServiceTest<DbAuthorizationService>
         _dataFactory.createValidApiUser("user5@example.com", org, Role.USER, Set.of(fac1));
 
     // ADMIN not counted
-    Integer firstCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    Integer firstCount = _service.getUsersWithSingleFacilityAccessCount(fac1);
     assertEquals(3, firstCount);
 
     // DELETED user not counted
     _userService.setIsDeleted(user4.getInternalId(), true);
-    Integer secondCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    Integer secondCount = _service.getUsersWithSingleFacilityAccessCount(fac1);
     assertEquals(2, secondCount);
 
     // ALL_FACILITIES user not counted
     _userService.updateUserPrivileges(user5.getInternalId(), true, Set.of(), Role.USER);
-    Integer thirdCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    Integer thirdCount = _service.getUsersWithSingleFacilityAccessCount(fac1);
     assertEquals(1, thirdCount);
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DbAuthorizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DbAuthorizationServiceTest.java
@@ -1,0 +1,95 @@
+package gov.cdc.usds.simplereport.service;
+
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.DEFAULT_ORGANIZATION;
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.ORG_ADMIN_USER;
+import static gov.cdc.usds.simplereport.test_util.TestUserIdentities.SITE_ADMIN_USER_WITH_ORG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.cdc.usds.simplereport.api.model.Role;
+import gov.cdc.usds.simplereport.config.authorization.OrganizationRole;
+import gov.cdc.usds.simplereport.db.model.ApiUser;
+import gov.cdc.usds.simplereport.db.model.Facility;
+import gov.cdc.usds.simplereport.db.model.Organization;
+import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
+import gov.cdc.usds.simplereport.service.model.UserInfo;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {"spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"})
+class DbAuthorizationServiceTest extends BaseServiceTest<DbAuthorizationService> {
+  @Autowired ApiUserService _userService;
+  @Autowired FacilityRepository _facilityRepo;
+  @Autowired OrganizationService _orgService;
+
+  @BeforeEach
+  void setupData() {
+    initSampleData();
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void getUsersInOrganization_success() {
+    Organization org = _orgService.getOrganization(DEFAULT_ORGANIZATION);
+    List<ApiUser> users = _service.getUsersInOrganization(org);
+    assertEquals(6, users.size());
+    assertEquals("admin@example.com", users.get(0).getLoginEmail());
+    assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
+    assertEquals("bobbity@example.com", users.get(1).getLoginEmail());
+    assertEquals("Bobberoo", users.get(1).getNameInfo().getLastName());
+    assertEquals("invalid@example.com", users.get(2).getLoginEmail());
+    assertEquals("Irwin", users.get(2).getNameInfo().getLastName());
+    assertEquals("nobody@example.com", users.get(3).getLoginEmail());
+    assertEquals("Nixon", users.get(3).getNameInfo().getLastName());
+    assertEquals("notruby@example.com", users.get(4).getLoginEmail());
+    assertEquals("Reynolds", users.get(4).getNameInfo().getLastName());
+    assertEquals("allfacilities@example.com", users.get(5).getLoginEmail());
+    assertEquals("Williams", users.get(5).getNameInfo().getLastName());
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportOrgAdminUser
+  void getOrgAdminUsers_success() {
+    Organization org = _orgService.getOrganization(DEFAULT_ORGANIZATION);
+    List<ApiUser> users = _service.getOrgAdminUsers(org);
+    assertEquals(2, users.size());
+    assertEquals(ORG_ADMIN_USER, users.get(0).getLoginEmail());
+    assertEquals("Andrews", users.get(0).getNameInfo().getLastName());
+    assertEquals(Set.of(OrganizationRole.ADMIN), users.get(0).getRoles());
+    assertEquals(SITE_ADMIN_USER_WITH_ORG, users.get(1).getLoginEmail());
+    assertEquals("Reynolds", users.get(1).getNameInfo().getLastName());
+  }
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void getUserWithSingleFacilityAccessCount_success() {
+    Organization org = _dataFactory.saveOrganization("ABC org", "k12", "ABC_ORG", true);
+    Facility fac1 = _dataFactory.createValidFacility(org, "BCD Facility");
+    Facility fac2 = _dataFactory.createValidFacility(org, "CDE Facility");
+    _dataFactory.createValidApiUser("user1@example.com", org, Role.ADMIN, Set.of());
+    _dataFactory.createValidApiUser("user2@example.com", org, Role.ENTRY_ONLY, Set.of(fac1));
+    _dataFactory.createValidApiUser("user3@example.com", org, Role.USER, Set.of(fac1, fac2));
+    UserInfo user4 =
+        _dataFactory.createValidApiUser("user4@example.com", org, Role.USER, Set.of(fac1));
+    UserInfo user5 =
+        _dataFactory.createValidApiUser("user5@example.com", org, Role.USER, Set.of(fac1));
+
+    // ADMIN not counted
+    Integer firstCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    assertEquals(3, firstCount);
+
+    // DELETED user not counted
+    _userService.setIsDeleted(user4.getInternalId(), true);
+    Integer secondCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    assertEquals(2, secondCount);
+
+    // ALL_FACILITIES user not counted
+    _userService.updateUserPrivileges(user5.getInternalId(), true, Set.of(), Role.USER);
+    Integer thirdCount = _service.getUserWithSingleFacilityAccessCount(fac1);
+    assertEquals(1, thirdCount);
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -464,7 +464,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
     FacilityStats stats = _service.getFacilityStats(facilityId);
 
-    verify(dbAuthorizationService, times(0)).getUserWithSingleFacilityAccessCount(mockFacility);
+    verify(dbAuthorizationService, times(0)).getUsersWithSingleFacilityAccessCount(mockFacility);
     assertEquals(2, stats.getUsersSingleAccessCount());
     assertEquals(1, stats.getPatientsSingleAccessCount());
   }
@@ -476,7 +476,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     UUID facilityId = UUID.randomUUID();
     Facility mockFacility = mock(Facility.class);
     doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
-    doReturn(4).when(dbAuthorizationService).getUserWithSingleFacilityAccessCount(mockFacility);
+    doReturn(4).when(dbAuthorizationService).getUsersWithSingleFacilityAccessCount(mockFacility);
     doReturn(2).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
     FacilityStats stats = _service.getFacilityStats(facilityId);
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -19,6 +19,7 @@ import gov.cdc.usds.simplereport.api.model.FacilityStats;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.access.AccessDeniedException;
@@ -70,6 +72,8 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   @Autowired ApiUserRepository _apiUserRepo;
   @Autowired private DemoUserConfiguration userConfiguration;
   @Autowired @SpyBean private EmailService emailService;
+  @Autowired @SpyBean private DbAuthorizationService dbAuthorizationService;
+  @Autowired @MockBean private FeatureFlagsConfig featureFlagsConfig;
 
   @BeforeEach
   void setupData() {
@@ -328,9 +332,43 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   }
 
   @Test
-  void verifyOrganizationNoPermissions_noUser_success() {
+  void verifyOrganizationNoPermissions_noUser_withOktaMigrationDisabled_success() {
     Organization org = testDataFactory.saveUnverifiedOrganization();
     _service.verifyOrganizationNoPermissions(org.getExternalId());
+
+    org = _service.getOrganization(org.getExternalId());
+
+    verify(dbAuthorizationService, times(0)).getOrgAdminUsers(org);
+    verify(oktaRepository, times(1)).activateOrganizationWithSingleUser(org);
+    assertTrue(org.getIdentityVerified());
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void verifyOrganizationNoPermissions_noUser_withOktaMigrationEnabled_throws() {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    Organization org = testDataFactory.saveUnverifiedOrganization();
+    String orgExternalId = org.getExternalId();
+
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> _service.verifyOrganizationNoPermissions(orgExternalId));
+    assertEquals("Organization does not have any org admins.", e.getMessage());
+    verify(dbAuthorizationService, times(1)).getOrgAdminUsers(org);
+    verify(oktaRepository, times(0)).activateOrganizationWithSingleUser(org);
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void verifyOrganizationNoPermissions_withUsers_withOktaMigrationEnabled_success() {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    Organization org = testDataFactory.saveUnverifiedOrganizationWithUser("fake@example.com");
+
+    _service.verifyOrganizationNoPermissions(org.getExternalId());
+    verify(dbAuthorizationService, times(1)).getOrgAdminUsers(org);
+    verify(oktaRepository, times(1)).activateUser("fake@example.com");
+    verify(oktaRepository, times(0)).activateOrganizationWithSingleUser(org);
 
     org = _service.getOrganization(org.getExternalId());
     assertTrue(org.getIdentityVerified());
@@ -346,6 +384,31 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
             () -> _service.verifyOrganizationNoPermissions(orgExternalId));
 
     assertEquals("Organization is already verified.", e.getMessage());
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void setIdentityVerified_withOktaMigrationDisabled_success() {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(false);
+    Organization unverifiedOrg = testDataFactory.saveUnverifiedOrganization();
+
+    boolean status = _service.setIdentityVerified(unverifiedOrg.getExternalId(), true);
+    verify(dbAuthorizationService, times(0)).getOrgAdminUsers(unverifiedOrg);
+    verify(oktaRepository, times(1)).activateOrganization(unverifiedOrg);
+    assertTrue(status);
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void setIdentityVerified_withOktaMigrationEnabled_success() {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    Organization unverifiedOrg =
+        testDataFactory.saveUnverifiedOrganizationWithUser("fake@example.com");
+
+    boolean status = _service.setIdentityVerified(unverifiedOrg.getExternalId(), true);
+    verify(dbAuthorizationService, times(1)).getOrgAdminUsers(unverifiedOrg);
+    verify(oktaRepository, times(0)).activateOrganization(unverifiedOrg);
+    assertTrue(status);
   }
 
   @Test
@@ -393,15 +456,33 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Test
   @WithSimpleReportSiteAdminUser
-  void getFacilityStats_success() {
+  void getFacilityStats_withOktaMigrationDisabled_success() {
     UUID facilityId = UUID.randomUUID();
     Facility mockFacility = mock(Facility.class);
     doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
     doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
     doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
     FacilityStats stats = _service.getFacilityStats(facilityId);
+
+    verify(dbAuthorizationService, times(0)).getUserWithSingleFacilityAccessCount(mockFacility);
     assertEquals(2, stats.getUsersSingleAccessCount());
     assertEquals(1, stats.getPatientsSingleAccessCount());
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void getFacilityStats_withOktaMigrationEnabled_success() {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    UUID facilityId = UUID.randomUUID();
+    Facility mockFacility = mock(Facility.class);
+    doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
+    doReturn(4).when(dbAuthorizationService).getUserWithSingleFacilityAccessCount(mockFacility);
+    doReturn(2).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
+    FacilityStats stats = _service.getFacilityStats(facilityId);
+
+    verify(oktaRepository, times(0)).getUsersInSingleFacility(mockFacility);
+    assertEquals(4, stats.getUsersSingleAccessCount());
+    assertEquals(2, stats.getPatientsSingleAccessCount());
   }
 
   @Nested
@@ -512,9 +593,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     assertThat(adminIds).isEqualTo(expectedIds);
   }
 
-  @Test
-  @WithSimpleReportSiteAdminUser
-  void sendOrgAdminEmailCSVAsync_success() throws ExecutionException, InterruptedException {
+  private void sendOrgAdminEmailCSVAsyncTest() throws ExecutionException, InterruptedException {
     setupDataByFacility();
     String type = "facilities";
     reset(emailService);
@@ -543,6 +622,22 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     verify(emailService, times(1)).sendWithCSVAttachment(nonExistentOrgEmails, "PA", type);
     assertThat(nonExistentOrgEmails).isEmpty();
     reset(emailService);
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSVAsync_withOktaMigrationDisabled_success()
+      throws ExecutionException, InterruptedException {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(false);
+    sendOrgAdminEmailCSVAsyncTest();
+  }
+
+  @Test
+  @WithSimpleReportSiteAdminUser
+  void sendOrgAdminEmailCSVAsync_withOktaMigrationEnabled_success()
+      throws ExecutionException, InterruptedException {
+    when(featureFlagsConfig.isOktaMigrationEnabled()).thenReturn(true);
+    sendOrgAdminEmailCSVAsyncTest();
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -152,6 +152,13 @@ public class TestDataFactory {
     return saveOrganization(TestDataBuilder.createUnverifiedOrganization());
   }
 
+  public Organization saveUnverifiedOrganizationWithUser(String adminUsername) {
+    Organization org = saveOrganization(TestDataBuilder.createUnverifiedOrganization());
+    createValidFacility(org);
+    createValidApiUser(adminUsername, org, Role.ADMIN);
+    return org;
+  }
+
   public UserInfo createValidApiUser(String username, Organization org) {
     return createValidApiUser(username, org, Role.USER);
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #7598

## Changes Proposed
- Regardless of `oktaMigrationEnabled` flag status, continue to update groups and roles in Okta
- When the `oktaMigrationEnabled` flag is set to `true`, read groups and roles from **DB**
- When the `oktaMigrationEnabled` flag is set to `false`, read groups and roles from **Okta**
 
Affected flows:
- adding org to queue (checking if the org is a duplicate)
- reprovisioning user
- updating user roles and privileges
- `users` graphql query (I don't think we are calling this on the frontend 🤔)
- verifying a pending organization
- getting org admin users
- confirmation modal when deleting a facility via site admin "Manage facility" tool (it displays how many users and patients are associated with only that facility)
<img width="797" alt="Screenshot 2024-09-10 at 16 23 29" src="https://github.com/user-attachments/assets/15d05df5-8de8-4bb1-9121-482d54ad8843">

## Additional Information
- [Separate tickets](https://github.com/CDCgov/prime-simplereport/pull/8105/files#r1752181865) to address loading users with their status for the "Manage users" page

## Testing
dev2 - `oktaMigrationEnabled` - `true`
- [dev2 metabase link](https://dev2.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQxLCJqb2lucyI6W3sic3RyYXRlZ3kiOiJsZWZ0LWpvaW4iLCJhbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsNDMxLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIn1dLFsiZmllbGQiLDQ0LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIE5vIFBoaSBWaWV3IC0gQXBpIFVzZXIifV1dLCJzb3VyY2UtdGFibGUiOjExfSx7InN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJBcGkgVXNlciBGYWNpbGl0eSAtIEFwaSBVc2VyIiwiY29uZGl0aW9uIjpbIj0iLFsiZmllbGQiLDQzMSx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCJ9XSxbImZpZWxkIiw0MjYseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XV0sInNvdXJjZS10YWJsZSI6NDJ9XSwiYnJlYWtvdXQiOltbImZpZWxkIiw0MzEseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQifV0sWyJmaWVsZCIsNDMseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgTm8gUGhpIFZpZXcgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDQseyJiYXNlLXR5cGUiOiJ0eXBlL1Bvc3RncmVzRW51bSJ9XSxbImZpZWxkIiw0MjgseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBBcGkgVXNlciJ9XSxbImZpZWxkIiw0NDUseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiw0NDMseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiw0MjkseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQifV0sWyJmaWVsZCIsMzE3LHsiYmFzZS10eXBlIjoidHlwZS9UZXh0Iiwic291cmNlLWZpZWxkIjo0Mjl9XV0sIm9yZGVyLWJ5IjpbWyJkZXNjIixbImZpZWxkIiw0NDUseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XV1dfX0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9LCJvcmlnaW5hbF9jYXJkX2lkIjpudWxsfQ==)

dev3 - `oktaMigrationEnabled` - `false`
- [dev3 metabase link](https://dev3.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjEyMSwiam9pbnMiOlt7InN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJBcGkgVXNlciIsImNvbmRpdGlvbiI6WyI9IixbImZpZWxkIiwxMTY4LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIn1dLFsiZmllbGQiLDk0MCx7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCIsImpvaW4tYWxpYXMiOiJBcGkgVXNlciJ9XV0sInNvdXJjZS10YWJsZSI6OTR9LHsiZmllbGRzIjoiYWxsIiwic3RyYXRlZ3kiOiJsZWZ0LWpvaW4iLCJhbGlhcyI6IkFwaSBVc2VyIEZhY2lsaXR5IC0gSW50ZXJuYWwiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsOTQwLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIn1dLFsiZmllbGQiLDExNjMseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIgRmFjaWxpdHkgLSBJbnRlcm5hbCJ9XV0sInNvdXJjZS10YWJsZSI6MTIyfSx7ImZpZWxkcyI6ImFsbCIsInN0cmF0ZWd5IjoibGVmdC1qb2luIiwiYWxpYXMiOiJPcmdhbml6YXRpb24iLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsMTE2Nix7ImJhc2UtdHlwZSI6InR5cGUvVVVJRCJ9XSxbImZpZWxkIiwxMDYxLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6Ik9yZ2FuaXphdGlvbiJ9XV0sInNvdXJjZS10YWJsZSI6Nzl9XSwiYnJlYWtvdXQiOltbImZpZWxkIiw5NDAseyJiYXNlLXR5cGUiOiJ0eXBlL1VVSUQiLCJqb2luLWFsaWFzIjoiQXBpIFVzZXIifV0sWyJmaWVsZCIsOTM5LHsiYmFzZS10eXBlIjoidHlwZS9UZXh0Iiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIn1dLFsiZmllbGQiLDEyMTMseyJiYXNlLXR5cGUiOiJ0eXBlL1Bvc3RncmVzRW51bSJ9XSxbImZpZWxkIiwxMTY1LHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6IkFwaSBVc2VyIEZhY2lsaXR5IC0gSW50ZXJuYWwifV0sWyJmaWVsZCIsMTIxNCx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWUiLCJ0ZW1wb3JhbC11bml0IjoibWludXRlIn1dLFsiZmllbGQiLDEyMTIseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XSxbImZpZWxkIiwxMDYwLHsiYmFzZS10eXBlIjoidHlwZS9UZXh0Iiwiam9pbi1hbGlhcyI6Ik9yZ2FuaXphdGlvbiJ9XSxbImZpZWxkIiwxMDYxLHsiYmFzZS10eXBlIjoidHlwZS9VVUlEIiwiam9pbi1hbGlhcyI6Ik9yZ2FuaXphdGlvbiJ9XV19fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) to see roles and facilities at a glance

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
