### PR TITLE
create table for facility_providers

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5643,3 +5643,26 @@ databaseChangeLog:
         - dropColumn:
             tableName: test_order
             columnName: timer_started_at
+
+  - changeSet:
+      id: create-facility_providers-table
+      author: bobby@skylight.digital
+      changes:
+        - createTable:
+            tableName: facility_providers
+            remarks: Many-to-many table for multiple providers configuration at a facility.
+            columns:
+              - column:
+                  name: facility_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_providers__facility
+                    references: facility
+              - column:
+                  name: provider_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_providers__provider
+                    references: provider

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5671,3 +5671,34 @@ databaseChangeLog:
       rollback:
         - dropTable:
             tableName: facility_providers
+
+  - changeSet:
+      id: add-default-provider
+      author: bobby@skylight.digital
+      changes:
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_ordering_provider_id
+                  remarks: The default ordering provider (if any) for tests at this facility.
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk__facility__default_ordering_provider
+                    references: provider(internal_id)
+
+  - changeSet:
+      id: populate-facility-providers-table
+      author: bobby@skylight.digital
+      changes:
+        - sql:
+            comment: Populate the facilities table from the organization table
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.facility_providers (
+                facility_id,
+                provider_id
+              )
+              SELECT
+                internal_id,
+                ordering_provider_id
+              FROM ${database.defaultSchemaName}.facility;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5702,3 +5702,17 @@ databaseChangeLog:
                 internal_id,
                 ordering_provider_id
               FROM ${database.defaultSchemaName}.facility;
+
+  - changeSet:
+      id: populate-default-provider-column
+      author: bobby@skylight.digital
+      changes:
+        - sql:
+            comment: Populate the default provider column with current provider
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.facility (
+                default_ordering_provider_id
+              )
+              SELECT
+                ordering_provider_id
+              FROM ${database.defaultSchemaName}.facility;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5707,12 +5707,8 @@ databaseChangeLog:
       id: populate-default-provider-column
       author: bobby@skylight.digital
       changes:
-        - sql:
-            comment: Populate the default provider column with current provider
             sql: |
-              INSERT INTO ${database.defaultSchemaName}.facility (
-                default_ordering_provider_id
-              )
-              SELECT
-                ordering_provider_id
-              FROM ${database.defaultSchemaName}.facility;
+              UPDATE ${database.defaultSchemaName}.facility
+              SET
+                  default_ordering_provider_id = facility.ordering_provider_id
+              WHERE facility.default_ordering_provider_id is NULL

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5676,6 +5676,8 @@ databaseChangeLog:
       id: add-default-provider
       author: bobby@skylight.digital
       changes:
+        - tagDatabase:
+            tag: add-default-provider-col
         - addColumn:
             tableName: facility
             columns:
@@ -5691,6 +5693,8 @@ databaseChangeLog:
       id: populate-facility-providers-table
       author: bobby@skylight.digital
       changes:
+        - tagDatabase:
+            tag: populate-facility-providers-table
         - sql:
             comment: Populate the facilities table from the organization table
             sql: |
@@ -5702,11 +5706,16 @@ databaseChangeLog:
                 internal_id,
                 ordering_provider_id
               FROM ${database.defaultSchemaName}.facility;
+      rollback:
+        sql: |
+          TRUNCATE TABLE ${database.defaultSchemaName}.facility_providers CASCADE;              
 
   - changeSet:
       id: populate-default-provider-column
       author: bobby@skylight.digital
       changes:
+        - tagDatabase:
+            tag: populate-default-provider-col
             sql: |
               UPDATE ${database.defaultSchemaName}.facility
               SET

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5648,6 +5648,8 @@ databaseChangeLog:
       id: create-facility_providers-table
       author: bobby@skylight.digital
       changes:
+        - tagDatabase:
+            tag: add-facility-providers-table
         - createTable:
             tableName: facility_providers
             remarks: Many-to-many table for multiple providers configuration at a facility.

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5666,3 +5666,6 @@ databaseChangeLog:
                     nullable: false
                     foreignKeyName: fk__facility_providers__provider
                     references: provider
+      rollback:
+        - dropTable:
+            tableName: facility_providers


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- part of #7982 

## Changes Proposed

- Migration to create a `facility_providers` table that is a many to many relation between  a provider's `provider_id` and a facility's `facility_id`. This relationship updates the DB's logic such that a facility can support multiple ordering providers. 

## Additional Information

- This logic follows the same pattern as our already existing[ `facility_device_type table`](https://www.simplereport.gov/metabase/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjExfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==).

## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->