### PR TITLE
Update Syphilis AOE copy and order

### DIFF
--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -116,7 +116,7 @@ describe("Conducting a COVID test from:", () => {
         cy.contains("label", "Yes").click();
       });
 
-    cy.contains("legend", "Is the patient currently experiencing any symptoms?")
+    cy.contains("legend", "Is the patient currently experiencing or showing signs of symptoms?")
       .next("div")
       .within(() => {
         cy.contains("label", "No").click();
@@ -126,7 +126,7 @@ describe("Conducting a COVID test from:", () => {
       "not.exist",
     );
 
-    cy.contains("legend", "Is the patient currently experiencing any symptoms?")
+    cy.contains("legend", "Is the patient currently experiencing or showing signs of symptoms?")
       .next("div")
       .within(() => {
         cy.contains("label", "Yes").click();
@@ -187,7 +187,7 @@ describe("Conducting a COVID test from:", () => {
         cy.contains("label", "No").click();
       });
 
-    cy.contains("legend", "Is the patient currently experiencing any symptoms?")
+    cy.contains("legend", "Is the patient currently experiencing or showing signs of symptoms?")
       .next("div")
       .within(() => {
         cy.contains("label", "No").click();
@@ -253,7 +253,7 @@ describe("Conducting a COVID test from:", () => {
         cy.contains("label", "No").click();
       });
 
-    cy.contains("legend", "Is the patient currently experiencing any symptoms?")
+    cy.contains("legend", "Is the patient currently experiencing or showing signs of symptoms?")
       .next("div")
       .within(() => {
         cy.contains("label", "No").click();

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -1147,7 +1147,7 @@ describe("TestCard", () => {
       ).toBeInTheDocument();
       expect(
         screen.queryByText(
-          "Is the patient currently experiencing any symptoms?"
+          "Is the patient currently experiencing or showing signs of symptoms?"
         )
       ).not.toBeInTheDocument();
     });
@@ -1227,7 +1227,9 @@ describe("TestCard", () => {
 
       expect(screen.getByText("Is the patient pregnant?")).toBeInTheDocument();
       expect(
-        screen.getByText("Is the patient currently experiencing any symptoms?")
+        screen.getByText(
+          "Is the patient currently experiencing or showing signs of symptoms?"
+        )
       ).toBeInTheDocument();
       expect(
         screen.getByText("What is the gender of their sexual partners?")
@@ -1258,7 +1260,7 @@ describe("TestCard", () => {
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(
-          "Is the patient currently experiencing any symptoms?"
+          "Is the patient currently experiencing or showing signs of symptoms?"
         )
       ).not.toBeInTheDocument();
       expect(
@@ -1280,7 +1282,7 @@ describe("TestCard", () => {
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(
-          "Is the patient currently experiencing any symptoms?"
+          "Is the patient currently experiencing or showing signs of symptoms?"
         )
       ).not.toBeInTheDocument();
       expect(

--- a/frontend/src/app/testQueue/TestCard/__snapshots__/TestCard.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCard/__snapshots__/TestCard.test.tsx.snap
@@ -151,7 +151,7 @@ Object {
               />
             </div>
             <div
-              class="grid-container"
+              class="grid-container sr-test-card-form-container"
             >
               <div
                 class="grid-row grid-gap"
@@ -557,7 +557,7 @@ Object {
                           <legend
                             class="usa-legend"
                           >
-                            Is the patient currently experiencing any symptoms?
+                            Is the patient currently experiencing or showing signs of symptoms?
                           </legend>
                           <div
                             class=""

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.scss
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.scss
@@ -2,3 +2,10 @@
   border-left-width: 0 !important;
   padding-left: 0 !important;
 }
+
+.sr-test-card-form-container {
+  .usa-label,
+  .usa-legend {
+    max-width: none;
+  }
+}

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -381,7 +381,7 @@ const TestCardForm = ({
         showModal={isSubmitModalOpen}
         onClose={() => setIsSubmitModalOpen(false)}
       />
-      <div className="grid-container">
+      <div className="grid-container sr-test-card-form-container">
         {/* error and warning alerts */}
         {showCorrectionWarning && (
           <Alert type="warning" headingLevel="h4" className="margin-top-2">

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -21,7 +21,7 @@ Object {
         />
       </div>
       <div
-        class="grid-container"
+        class="grid-container sr-test-card-form-container"
       >
         <div
           class="grid-row grid-gap"
@@ -416,7 +416,7 @@ Object {
                     <legend
                       class="usa-legend"
                     >
-                      Is the patient currently experiencing any symptoms?
+                      Is the patient currently experiencing or showing signs of symptoms?
                     </legend>
                     <div
                       class=""
@@ -539,7 +539,7 @@ Object {
       />
     </div>
     <div
-      class="grid-container"
+      class="grid-container sr-test-card-form-container"
     >
       <div
         class="grid-row grid-gap"
@@ -934,7 +934,7 @@ Object {
                   <legend
                     class="usa-legend"
                   >
-                    Is the patient currently experiencing any symptoms?
+                    Is the patient currently experiencing or showing signs of symptoms?
                   </legend>
                   <div
                     class=""
@@ -1124,7 +1124,7 @@ exports[`TestCardForm initial state matches snapshot for flu device 1`] = `
     />
   </div>
   <div
-    class="grid-container"
+    class="grid-container sr-test-card-form-container"
   >
     <div
       class="grid-row grid-gap"
@@ -1556,7 +1556,7 @@ Object {
         />
       </div>
       <div
-        class="grid-container"
+        class="grid-container sr-test-card-form-container"
       >
         <div
           class="grid-row grid-gap"
@@ -1831,7 +1831,7 @@ Object {
       />
     </div>
     <div
-      class="grid-container"
+      class="grid-container sr-test-card-form-container"
     >
       <div
         class="grid-row grid-gap"
@@ -2176,7 +2176,7 @@ Object {
         />
       </div>
       <div
-        class="grid-container"
+        class="grid-container sr-test-card-form-container"
       >
         <div
           class="grid-row grid-gap"
@@ -2726,7 +2726,7 @@ Object {
                     <legend
                       class="usa-legend"
                     >
-                      Is the patient currently experiencing any symptoms?
+                      Is the patient currently experiencing or showing signs of symptoms?
                     </legend>
                     <div
                       class=""
@@ -2849,7 +2849,7 @@ Object {
       />
     </div>
     <div
-      class="grid-container"
+      class="grid-container sr-test-card-form-container"
     >
       <div
         class="grid-row grid-gap"
@@ -3399,7 +3399,7 @@ Object {
                   <legend
                     class="usa-legend"
                   >
-                    Is the patient currently experiencing any symptoms?
+                    Is the patient currently experiencing or showing signs of symptoms?
                   </legend>
                   <div
                     class=""
@@ -3592,7 +3592,7 @@ Object {
         />
       </div>
       <div
-        class="grid-container"
+        class="grid-container sr-test-card-form-container"
       >
         <div
           class="grid-row grid-gap"
@@ -3803,105 +3803,18 @@ Object {
             id="syphillis-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
           >
             <div
-              class="grid-col-auto"
-            >
-              <div
-                class="usa-form-group"
-              >
-                <fieldset
-                  class="usa-fieldset prime-radios"
-                  data-testid="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                  id="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                >
-                  <legend
-                    class="usa-legend"
-                  >
-                    Has the patient been told they have syphilis before?
-                    <abbr
-                      class="usa-hint usa-hint--required"
-                      title="required"
-                    >
-                       
-                      *
-                    </abbr>
-                  </legend>
-                  <div
-                    class=""
-                  >
-                    <div
-                      class="usa-radio"
-                    >
-                      <input
-                        class="usa-radio__input"
-                        data-required="true"
-                        id="21-val-1087151000119108"
-                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                        type="radio"
-                        value="1087151000119108"
-                      />
-                      <label
-                        class="usa-radio__label"
-                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-1087151000119108"
-                        for="21-val-1087151000119108"
-                      >
-                        Yes
-                      </label>
-                    </div>
-                    <div
-                      class="usa-radio"
-                    >
-                      <input
-                        class="usa-radio__input"
-                        data-required="true"
-                        id="21-val-14732006"
-                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                        type="radio"
-                        value="14732006"
-                      />
-                      <label
-                        class="usa-radio__label"
-                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-14732006"
-                        for="21-val-14732006"
-                      >
-                        No
-                      </label>
-                    </div>
-                    <div
-                      class="usa-radio"
-                    >
-                      <input
-                        class="usa-radio__input"
-                        data-required="true"
-                        id="21-val-261665006"
-                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                        type="radio"
-                        value="261665006"
-                      />
-                      <label
-                        class="usa-radio__label"
-                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
-                        for="21-val-261665006"
-                      >
-                        Prefer not to answer
-                      </label>
-                    </div>
-                  </div>
-                </fieldset>
-              </div>
-            </div>
-            <div
               class="grid-row"
             >
               <div
-                class="tablet:grid-col-6"
+                class="grid-col-12 desktop:grid-col-6"
               >
                 <div
                   class="usa-form-group"
                 >
                   <label
                     class="usa-label"
-                    for="22"
-                    id="label-for-22"
+                    for="21"
+                    id="label-for-21"
                   >
                     What is the gender of their sexual partners?
                      
@@ -3952,13 +3865,13 @@ Object {
                   <div
                     class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                     data-testid="multi-select"
-                    id="22"
+                    id="21"
                   >
                     <input
                       aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
                       aria-expanded="false"
                       aria-invalid="false"
-                      aria-labelledby="label-for-22"
+                      aria-labelledby="label-for-21"
                       aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
                       aria-required="true"
                       autocapitalize="off"
@@ -4107,6 +4020,93 @@ Object {
               </div>
             </div>
             <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Has the patient been told they have syphilis before?
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="22-val-1087151000119108"
+                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="1087151000119108"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-1087151000119108"
+                        for="22-val-1087151000119108"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="22-val-14732006"
+                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="14732006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-14732006"
+                        for="22-val-14732006"
+                      >
+                        No
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="22-val-261665006"
+                        name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="261665006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                        for="22-val-261665006"
+                      >
+                        Prefer not to answer
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+            <div
               class="grid-row"
             >
               <div
@@ -4201,7 +4201,7 @@ Object {
               class="grid-row"
             >
               <div
-                class="grid-col-auto"
+                class="grid-col-12"
               >
                 <div
                   class="usa-form-group"
@@ -4214,7 +4214,7 @@ Object {
                     <legend
                       class="usa-legend"
                     >
-                      Is the patient currently experiencing any symptoms?
+                      Is the patient currently experiencing or showing signs of symptoms?
                       <abbr
                         class="usa-hint usa-hint--required"
                         title="required"
@@ -4347,7 +4347,7 @@ Object {
       />
     </div>
     <div
-      class="grid-container"
+      class="grid-container sr-test-card-form-container"
     >
       <div
         class="grid-row grid-gap"
@@ -4558,105 +4558,18 @@ Object {
           id="syphillis-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
         >
           <div
-            class="grid-col-auto"
-          >
-            <div
-              class="usa-form-group"
-            >
-              <fieldset
-                class="usa-fieldset prime-radios"
-                data-testid="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                id="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-              >
-                <legend
-                  class="usa-legend"
-                >
-                  Has the patient been told they have syphilis before?
-                  <abbr
-                    class="usa-hint usa-hint--required"
-                    title="required"
-                  >
-                     
-                    *
-                  </abbr>
-                </legend>
-                <div
-                  class=""
-                >
-                  <div
-                    class="usa-radio"
-                  >
-                    <input
-                      class="usa-radio__input"
-                      data-required="true"
-                      id="21-val-1087151000119108"
-                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                      type="radio"
-                      value="1087151000119108"
-                    />
-                    <label
-                      class="usa-radio__label"
-                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-1087151000119108"
-                      for="21-val-1087151000119108"
-                    >
-                      Yes
-                    </label>
-                  </div>
-                  <div
-                    class="usa-radio"
-                  >
-                    <input
-                      class="usa-radio__input"
-                      data-required="true"
-                      id="21-val-14732006"
-                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                      type="radio"
-                      value="14732006"
-                    />
-                    <label
-                      class="usa-radio__label"
-                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-14732006"
-                      for="21-val-14732006"
-                    >
-                      No
-                    </label>
-                  </div>
-                  <div
-                    class="usa-radio"
-                  >
-                    <input
-                      class="usa-radio__input"
-                      data-required="true"
-                      id="21-val-261665006"
-                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
-                      type="radio"
-                      value="261665006"
-                    />
-                    <label
-                      class="usa-radio__label"
-                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
-                      for="21-val-261665006"
-                    >
-                      Prefer not to answer
-                    </label>
-                  </div>
-                </div>
-              </fieldset>
-            </div>
-          </div>
-          <div
             class="grid-row"
           >
             <div
-              class="tablet:grid-col-6"
+              class="grid-col-12 desktop:grid-col-6"
             >
               <div
                 class="usa-form-group"
               >
                 <label
                   class="usa-label"
-                  for="22"
-                  id="label-for-22"
+                  for="21"
+                  id="label-for-21"
                 >
                   What is the gender of their sexual partners?
                    
@@ -4707,13 +4620,13 @@ Object {
                 <div
                   class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
                   data-testid="multi-select"
-                  id="22"
+                  id="21"
                 >
                   <input
                     aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
                     aria-expanded="false"
                     aria-invalid="false"
-                    aria-labelledby="label-for-22"
+                    aria-labelledby="label-for-21"
                     aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
                     aria-required="true"
                     autocapitalize="off"
@@ -4862,6 +4775,93 @@ Object {
             </div>
           </div>
           <div
+            class="grid-col-auto"
+          >
+            <div
+              class="usa-form-group"
+            >
+              <fieldset
+                class="usa-fieldset prime-radios"
+                data-testid="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                id="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+              >
+                <legend
+                  class="usa-legend"
+                >
+                  Has the patient been told they have syphilis before?
+                  <abbr
+                    class="usa-hint usa-hint--required"
+                    title="required"
+                  >
+                     
+                    *
+                  </abbr>
+                </legend>
+                <div
+                  class=""
+                >
+                  <div
+                    class="usa-radio"
+                  >
+                    <input
+                      class="usa-radio__input"
+                      data-required="true"
+                      id="22-val-1087151000119108"
+                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                      type="radio"
+                      value="1087151000119108"
+                    />
+                    <label
+                      class="usa-radio__label"
+                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-1087151000119108"
+                      for="22-val-1087151000119108"
+                    >
+                      Yes
+                    </label>
+                  </div>
+                  <div
+                    class="usa-radio"
+                  >
+                    <input
+                      class="usa-radio__input"
+                      data-required="true"
+                      id="22-val-14732006"
+                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                      type="radio"
+                      value="14732006"
+                    />
+                    <label
+                      class="usa-radio__label"
+                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-14732006"
+                      for="22-val-14732006"
+                    >
+                      No
+                    </label>
+                  </div>
+                  <div
+                    class="usa-radio"
+                  >
+                    <input
+                      class="usa-radio__input"
+                      data-required="true"
+                      id="22-val-261665006"
+                      name="syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                      type="radio"
+                      value="261665006"
+                    />
+                    <label
+                      class="usa-radio__label"
+                      data-cy="radio-group-option-syphilisHistory-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                      for="22-val-261665006"
+                    >
+                      Prefer not to answer
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+          <div
             class="grid-row"
           >
             <div
@@ -4956,7 +4956,7 @@ Object {
             class="grid-row"
           >
             <div
-              class="grid-col-auto"
+              class="grid-col-12"
             >
               <div
                 class="usa-form-group"
@@ -4969,7 +4969,7 @@ Object {
                   <legend
                     class="usa-legend"
                   >
-                    Is the patient currently experiencing any symptoms?
+                    Is the patient currently experiencing or showing signs of symptoms?
                     <abbr
                       class="usa-hint usa-hint--required"
                       title="required"

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -71,7 +71,7 @@ const CovidAoEForm = ({
         <div className="grid-col-auto">
           <YesNoRadioGroup
             name={`has-any-symptoms-${testOrder.internalId}`}
-            legend="Is the patient currently experiencing any symptoms?"
+            legend="Is the patient currently experiencing or showing signs of symptoms?"
             value={hasSymptoms}
             onChange={onHasAnySymptomsChange}
           />

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HIVAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HIVAoEForm.tsx
@@ -59,7 +59,7 @@ export const HIVAoEForm = ({
         </div>
       </div>
       <div className="grid-row">
-        <div className="tablet:grid-col-12">
+        <div className="grid-col-12 desktop:grid-col-6">
           <MultiSelect
             name={`sexual-partner-gender-${testOrder.internalId}`}
             options={GENDER_IDENTITY_VALUES}
@@ -73,7 +73,6 @@ export const HIVAoEForm = ({
                 </span>
               </>
             }
-            dropdownClassName={"width-mobile-lg"}
             labelClassName={"multi-select-dropdown"}
             required={true}
             validationStatus={

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/SyphilisAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/SyphilisAoEForm.tsx
@@ -74,22 +74,8 @@ export const SyphilisAoEForm = ({
       className="grid-col"
       id={`syphillis-aoe-form-${testOrder.patient.internalId}`}
     >
-      <div className="grid-col-auto">
-        <RadioGroup
-          legend="Has the patient been told they have syphilis before?"
-          name={`syphilisHistory-${testOrder.internalId}`}
-          onChange={onSyphilisHistoryChange}
-          buttons={syphilisHistoryResponses}
-          required
-          selectedRadio={responses.syphilisHistory}
-          validationStatus={showSyphilisHistoryError ? "error" : undefined}
-          errorMessage={
-            showSyphilisHistoryError && "Please answer this required question."
-          }
-        />
-      </div>
       <div className="grid-row">
-        <div className="tablet:grid-col-6">
+        <div className="grid-col-12 desktop:grid-col-6">
           <MultiSelect
             name={`sexual-partner-gender-${testOrder.internalId}`}
             options={GENDER_IDENTITY_VALUES}
@@ -116,6 +102,20 @@ export const SyphilisAoEForm = ({
           ></MultiSelect>
         </div>
       </div>
+      <div className="grid-col-auto">
+        <RadioGroup
+          legend="Has the patient been told they have syphilis before?"
+          name={`syphilisHistory-${testOrder.internalId}`}
+          onChange={onSyphilisHistoryChange}
+          buttons={syphilisHistoryResponses}
+          required
+          selectedRadio={responses.syphilisHistory}
+          validationStatus={showSyphilisHistoryError ? "error" : undefined}
+          errorMessage={
+            showSyphilisHistoryError && "Please answer this required question."
+          }
+        />
+      </div>
       <div className="grid-row">
         <div className="grid-col-auto">
           <RadioGroup
@@ -133,10 +133,10 @@ export const SyphilisAoEForm = ({
         </div>
       </div>
       <div className="grid-row">
-        <div className="grid-col-auto">
+        <div className="grid-col-12">
           <YesNoRadioGroup
             name={`has-any-symptoms-${testOrder.internalId}`}
-            legend="Is the patient currently experiencing any symptoms?"
+            legend="Is the patient currently experiencing or showing signs of symptoms?"
             value={hasSymptoms}
             required
             onChange={onHasAnySymptomsChange}
@@ -148,8 +148,8 @@ export const SyphilisAoEForm = ({
         </div>
       </div>
       {hasSymptoms === "YES" && (
-        <div className={"grid-row grid-gap width-full flex-start"}>
-          <div className={`flex-${CHECKBOX_COLS_TO_DISPLAY - 1}`}>
+        <div className={"grid-row grid-gap width-full"}>
+          <div className={"grid-col-12 desktop:grid-col-9 padding-right-0"}>
             <Checkboxes
               boxes={syphilisSymptomDefinitions.map(({ label, value }) => ({
                 label,
@@ -176,6 +176,7 @@ export const SyphilisAoEForm = ({
             required
             label="Date of symptom onset"
             aria-label="Symptom onset date"
+            className={""}
             min={formatDate(new Date("Jan 1, 2020"))}
             max={formatDate(moment().toDate())}
             value={

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -208,7 +208,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   />
                 </div>
                 <div
-                  class="grid-container"
+                  class="grid-container sr-test-card-form-container"
                 >
                   <div
                     class="grid-row grid-gap"
@@ -602,7 +602,7 @@ exports[`TestQueue should render the test queue 1`] = `
                               <legend
                                 class="usa-legend"
                               >
-                                Is the patient currently experiencing any symptoms?
+                                Is the patient currently experiencing or showing signs of symptoms?
                               </legend>
                               <div
                                 class=""
@@ -1228,7 +1228,7 @@ exports[`TestQueue should render the test queue 1`] = `
                   />
                 </div>
                 <div
-                  class="grid-container"
+                  class="grid-container sr-test-card-form-container"
                 >
                   <div
                     class="grid-row grid-gap"
@@ -1622,7 +1622,7 @@ exports[`TestQueue should render the test queue 1`] = `
                               <legend
                                 class="usa-legend"
                               >
-                                Is the patient currently experiencing any symptoms?
+                                Is the patient currently experiencing or showing signs of symptoms?
                               </legend>
                               <div
                                 class=""

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -83,7 +83,7 @@ const GENDER_SEXUAL_PARTNERS_FEMALE_OVERRIDE = {
 };
 const BLURRED_VISION_OVERRIDE = {
   symptoms:
-    '{"15188001":false,"26284000":false,"46636008":true,"56940005":false,"68225006":false,"91554004":false,"195469007":false,"266128007":false,"724386005":false}',
+    '{"15188001":false,"26284000":false,"56317004":false,"56940005":false,"91554004":false,"195469007":false,"246636008":true,"266128007":false,"724386005":false}',
 };
 
 const FIRST_CARD_SYMPTOM_OVERRIDE = {

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -97,8 +97,8 @@ export const syphilisSymptomsMap = {
   "56940005": "Palmar (hand)/plantar (foot) rash",
   "91554004": "Flat white warts",
   "15188001": "Hearing loss",
-  "46636008": "Blurred vision",
-  "68225006": "Patchy hair loss",
+  "246636008": "Blurred vision",
+  "56317004": "Alopecia",
 } as const;
 
 export type SyphilisSymptoms = typeof syphilisSymptomsMap;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #8100 

## Changes Proposed

- This ticket became mostly a copy change and style update ticket since I think Bob(?) had already done all of the work to add syphilis AOE to the test card.
- Change "Is the patient currently experiencing any symptoms?" to "Is the patient currently experiencing or showing signs of symptoms?" for all diseases
- Fix incorrect SNOMED for "Blurred vision"
- Add "Alopecia" to symptoms
- Change order of AOE Syphilis questions as requested in the ticket
- Make style updates to Syphilis form to satisfy the following part of acceptance criteria:
> Responsiveness: The Results screen should adapt to different screen sizes and devices, providing a consistent experience across platforms.


## Additional Information
- I thought there would be more work for this ticket... Let me know if I'm missing any context from that ticket 😅 


## Testing
- Test locally and test Test Cards
   - see updated symptoms copy for every disease
   - try responsiveness of Syphilis form at different breakpoints
   - see updated symptoms for Syphilis
   
  
## Screenshots / Demos
**Before**
- Desktop
<img width="1915" alt="Screenshot 2024-09-20 at 10 24 17" src="https://github.com/user-attachments/assets/c0f35a82-de3a-49a9-943e-7d68a2d4e7a9">

- iPad
<img width="651" alt="Screenshot 2024-09-20 at 10 25 05" src="https://github.com/user-attachments/assets/0ba70529-a668-4739-b18e-94be8834af23">
<img width="590" alt="Screenshot 2024-09-20 at 10 25 12" src="https://github.com/user-attachments/assets/e255f14b-3c5c-4ed1-a7c8-ff8b4b02dd15">

**After**
- Desktop
<img width="1001" alt="Screenshot 2024-09-20 at 10 26 22" src="https://github.com/user-attachments/assets/3e7c77c2-0e7f-4138-a0d1-2adbf9d2a8be">

- iPad
<img width="666" alt="Screenshot 2024-09-20 at 10 26 37" src="https://github.com/user-attachments/assets/18741321-e831-42d1-a7a4-9d3381e161f4">
<img width="635" alt="Screenshot 2024-09-20 at 10 26 41" src="https://github.com/user-attachments/assets/6c13a801-0a7b-4eb2-94bd-a71a17a1e0bd">

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
