### PR TITLE
Change touchpointsFormHtmlString from a `const` to `let`

### DIFF
--- a/frontend/public/touchpoints.js
+++ b/frontend/public/touchpoints.js
@@ -654,7 +654,7 @@ var formOptions = {
 
 // Note: When updating Touchpoints you need to update this HTML
 // To whoever has to maintain this, I'm sorry this is so gross.
-const touchpointsFormHtmlString = `
+let touchpointsFormHtmlString = `
   <div class="fba-modal">
     <div id="fba-modal-dialog" class="fba-modal-dialog" role="dialog" aria-modal="true">
       <div class="touchpoints-form-wrapper" id="touchpoints-form-5b1efe87" data-touchpoints-form-id="5b1efe87" tabindex="-1">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- This fixes the error seen in the dev console 
<img width="1914" alt="Screenshot 2024-09-20 at 15 41 22" src="https://github.com/user-attachments/assets/5ed19409-56b0-4175-a9ae-cece5c0b0bfa">

> Uncaught SyntaxError: Identifier 'touchpointsFormHtmlString' has already been declared

## Changes Proposed

- Assign `touchpointsFormHtmlString` variable as a `let` than a `const` to prevent this error

## Additional Information


## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
