### PR TITLE
Add syphilis AOE data on result View Details

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/testresult/TestResultDataResolver.java
@@ -7,6 +7,7 @@ import gov.cdc.usds.simplereport.db.model.Person;
 import gov.cdc.usds.simplereport.db.model.Result;
 import gov.cdc.usds.simplereport.db.model.TestEvent;
 import gov.cdc.usds.simplereport.db.model.auxiliary.AskOnEntrySurvey;
+import gov.cdc.usds.simplereport.db.model.auxiliary.ResolvedSurveyData;
 import gov.cdc.usds.simplereport.db.repository.PatientLinkRepository;
 import java.time.LocalDate;
 import java.util.Date;
@@ -104,6 +105,11 @@ public class TestResultDataResolver implements InternalIdResolver<TestEvent> {
   @SchemaMapping(typeName = "TestResult", field = "results")
   public Set<Result> getResults(TestEvent testEvent) {
     return testEvent.getResults();
+  }
+
+  @SchemaMapping(typeName = "TestResult", field = "surveyData")
+  public ResolvedSurveyData getSurveyData(TestEvent testEvent) {
+    return new ResolvedSurveyData(getSurvey(testEvent));
   }
 
   @Override

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -295,12 +295,13 @@ type TestResult {
   symptomOnset: LocalDate
   genderOfSexualPartners: [String]
   deviceType: DeviceType
-  results: [MultiplexResult]
+  results: [MultiplexResult!]
   dateTested: DateTime
   correctionStatus: String
   reasonForCorrection: String
   createdBy: ApiUser
   patientLink: PatientLink
+  surveyData: AskOnEntrySurvey
 }
 
 type TestResultsPage {
@@ -314,7 +315,7 @@ type AskOnEntrySurvey {
   symptoms: String
   symptomOnset: LocalDate
   noSymptoms: Boolean
-  genderOfSexualPartners: [String]
+  genderOfSexualPartners: [String!]
 }
 
 type Result {

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
@@ -89,7 +89,7 @@ syphilisTestResult.results = [
 syphilisTestResult.surveyData.pregnancy = "77386006";
 syphilisTestResult.surveyData.syphilisHistory = "1087151000119108";
 syphilisTestResult.surveyData.symptoms =
-  '{"91554004":"false","15188001":"false","724386005":"false","56940005":"true","266128007":"true","46636008":"true","68225006":"false","195469007":"false","26284000":"false"}';
+  '{"91554004":"false","15188001":"false","724386005":"false","56940005":"true","266128007":"true","246636008":"true","68225006":"false","195469007":"false","26284000":"false"}';
 syphilisTestResult.surveyData.symptomOnset = "2024-09-24";
 syphilisTestResult.surveyData.noSymptoms = false;
 syphilisTestResult.surveyData.genderOfSexualPartners = [
@@ -195,7 +195,7 @@ describe("Syphilis TestResultDetailsModal", () => {
     expect(screen.getByText("Symptom onset")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash"
+        "Palmar (hand)/plantar (foot) rash, Blurred vision, Body Rash"
       )
     ).toBeInTheDocument();
     expect(screen.getByText("Gender of sexual partners")).toBeInTheDocument();

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
@@ -17,6 +17,14 @@ const nonMultiplexTestResult = {
   symptoms: '{"00000":"false"}',
   symptomOnset: "myOnset",
   pregnancy: null,
+  surveyData: {
+    pregnancy: null,
+    syphilisHistory: null,
+    symptoms: '{"00000":"false"}',
+    symptomOnset: "myOnset",
+    noSymptoms: false,
+    genderOfSexualPartners: null,
+  },
   deviceType: {
     name: "Fake device",
   },
@@ -67,8 +75,8 @@ hivTestResult.results = [
     __typename: "MultiplexResult",
   },
 ];
-hivTestResult.genderOfSexualPartners = ["female", "male", "other"];
-hivTestResult.pregnancy = "77386006";
+hivTestResult.surveyData.genderOfSexualPartners = ["female", "male", "other"];
+hivTestResult.surveyData.pregnancy = "77386006";
 
 const syphilisTestResult = JSON.parse(JSON.stringify(nonMultiplexTestResult));
 syphilisTestResult.results = [
@@ -78,8 +86,17 @@ syphilisTestResult.results = [
     __typename: "MultiplexResult",
   },
 ];
-syphilisTestResult.pregnancy = "77386006";
-syphilisTestResult.symptoms = '{"266128007":"true"}';
+syphilisTestResult.surveyData.pregnancy = "77386006";
+syphilisTestResult.surveyData.syphilisHistory = "1087151000119108";
+syphilisTestResult.surveyData.symptoms =
+  '{"91554004":"false","15188001":"false","724386005":"false","56940005":"true","266128007":"true","46636008":"true","68225006":"false","195469007":"false","26284000":"false"}';
+syphilisTestResult.surveyData.symptomOnset = "2024-09-24";
+syphilisTestResult.surveyData.noSymptoms = false;
+syphilisTestResult.surveyData.genderOfSexualPartners = [
+  "female",
+  "male",
+  "other",
+];
 
 const renderComponent = (testResult: TestResult) =>
   render(
@@ -176,8 +193,17 @@ describe("Syphilis TestResultDetailsModal", () => {
     expect(screen.getByText("Syphilis result")).toBeInTheDocument();
     expect(screen.getByText("Symptoms")).toBeInTheDocument();
     expect(screen.getByText("Symptom onset")).toBeInTheDocument();
-    expect(screen.getByText("Body Rash")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Gender of sexual partners")).toBeInTheDocument();
+    expect(screen.getByText("Female, Male, Other")).toBeInTheDocument();
     expect(screen.getByText("Pregnant?")).toBeInTheDocument();
+    expect(
+      screen.getByText("Previously told they have syphilis?")
+    ).toBeInTheDocument();
   });
 
   it("matches screenshot", () => {

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.test.tsx
@@ -89,7 +89,7 @@ syphilisTestResult.results = [
 syphilisTestResult.surveyData.pregnancy = "77386006";
 syphilisTestResult.surveyData.syphilisHistory = "1087151000119108";
 syphilisTestResult.surveyData.symptoms =
-  '{"91554004":"false","15188001":"false","724386005":"false","56940005":"true","266128007":"true","246636008":"true","68225006":"false","195469007":"false","26284000":"false"}';
+  '{"724386005":"false","195469007":"false","26284000":"false","266128007":"true","56940005":"true","91554004":"false","15188001":"false","246636008":"true","56317004":"false"}';
 syphilisTestResult.surveyData.symptomOnset = "2024-09-24";
 syphilisTestResult.surveyData.noSymptoms = false;
 syphilisTestResult.surveyData.genderOfSexualPartners = [

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
@@ -474,7 +474,7 @@ Object {
             <td
               class="padding-y-3 border-bottom-1px border-base-lighter"
             >
-              Body Rash
+              Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash
             </td>
           </tr>
           <tr>
@@ -486,7 +486,7 @@ Object {
             <td
               class="padding-y-3 border-bottom-1px border-base-lighter"
             >
-              Invalid date
+              09/24/2024
             </td>
           </tr>
           <tr>
@@ -494,6 +494,30 @@ Object {
               class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
             >
               Pregnant?
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Yes
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Gender of sexual partners
+            </th>
+            <td
+              class="padding-y-3 border-bottom-1px border-base-lighter"
+            >
+              Female, Male, Other
+            </td>
+          </tr>
+          <tr>
+            <th
+              class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+            >
+              Previously told they have syphilis?
             </th>
             <td
               class="padding-y-3 border-bottom-1px border-base-lighter"
@@ -634,7 +658,7 @@ Object {
           <td
             class="padding-y-3 border-bottom-1px border-base-lighter"
           >
-            Body Rash
+            Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash
           </td>
         </tr>
         <tr>
@@ -646,7 +670,7 @@ Object {
           <td
             class="padding-y-3 border-bottom-1px border-base-lighter"
           >
-            Invalid date
+            09/24/2024
           </td>
         </tr>
         <tr>
@@ -654,6 +678,30 @@ Object {
             class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
           >
             Pregnant?
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Yes
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Gender of sexual partners
+          </th>
+          <td
+            class="padding-y-3 border-bottom-1px border-base-lighter"
+          >
+            Female, Male, Other
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="text-bold text-no-strike text-ink padding-y-3 border-bottom-1px border-base-lighter width-card-lg text-left"
+          >
+            Previously told they have syphilis?
           </th>
           <td
             class="padding-y-3 border-bottom-1px border-base-lighter"

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/__snapshots__/TestResultDetailsModal.test.tsx.snap
@@ -474,7 +474,7 @@ Object {
             <td
               class="padding-y-3 border-bottom-1px border-base-lighter"
             >
-              Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash
+              Palmar (hand)/plantar (foot) rash, Blurred vision, Body Rash
             </td>
           </tr>
           <tr>
@@ -658,7 +658,7 @@ Object {
           <td
             class="padding-y-3 border-bottom-1px border-base-lighter"
           >
-            Blurred vision, Palmar (hand)/plantar (foot) rash, Body Rash
+            Palmar (hand)/plantar (foot) rash, Blurred vision, Body Rash
           </td>
         </tr>
         <tr>

--- a/frontend/src/app/testResults/viewResults/operations.graphql
+++ b/frontend/src/app/testResults/viewResults/operations.graphql
@@ -12,6 +12,14 @@ query GetTestResultDetails($id: ID!) {
     symptomOnset
     pregnancy
     genderOfSexualPartners
+    surveyData {
+      pregnancy
+      syphilisHistory
+      symptoms
+      symptomOnset
+      noSymptoms
+      genderOfSexualPartners
+    }
     deviceType {
       name
     }

--- a/frontend/src/app/utils/user.ts
+++ b/frontend/src/app/utils/user.ts
@@ -1,9 +1,9 @@
 type OptionalString = string | undefined | null;
 
 type RequiredUserFields = {
-  firstName: OptionalString;
-  middleName: OptionalString;
-  lastName: OptionalString;
+  firstName?: OptionalString;
+  middleName?: OptionalString;
+  lastName?: OptionalString;
   suffix?: OptionalString;
 };
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -101,7 +101,7 @@ export enum ArchivedStatus {
 
 export type AskOnEntrySurvey = {
   __typename?: "AskOnEntrySurvey";
-  genderOfSexualPartners?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  genderOfSexualPartners?: Maybe<Array<Scalars["String"]["output"]>>;
   noSymptoms?: Maybe<Scalars["Boolean"]["output"]>;
   pregnancy?: Maybe<Scalars["String"]["output"]>;
   symptomOnset?: Maybe<Scalars["LocalDate"]["output"]>;
@@ -1041,7 +1041,8 @@ export type TestResult = {
   patientLink?: Maybe<PatientLink>;
   pregnancy?: Maybe<Scalars["String"]["output"]>;
   reasonForCorrection?: Maybe<Scalars["String"]["output"]>;
-  results?: Maybe<Array<Maybe<MultiplexResult>>>;
+  results?: Maybe<Array<MultiplexResult>>;
+  surveyData?: Maybe<AskOnEntrySurvey>;
   symptomOnset?: Maybe<Scalars["LocalDate"]["output"]>;
   symptoms?: Maybe<Scalars["String"]["output"]>;
   syphilisHistory?: Maybe<Scalars["String"]["output"]>;
@@ -2444,7 +2445,7 @@ export type GetFacilityResultsForCsvWithCountQuery = {
         __typename?: "MultiplexResult";
         testResult: string;
         disease: { __typename?: "SupportedDisease"; name: string };
-      } | null> | null;
+      }> | null;
       deviceType?: {
         __typename?: "DeviceType";
         name: string;
@@ -2647,7 +2648,7 @@ export type GetResultsForDownloadQuery = {
         symptoms?: string | null;
         symptomOnset?: any | null;
         noSymptoms?: boolean | null;
-        genderOfSexualPartners?: Array<string | null> | null;
+        genderOfSexualPartners?: Array<string> | null;
       } | null;
     } | null> | null;
   } | null;
@@ -2695,7 +2696,7 @@ export type GetTestResultForPrintQuery = {
       __typename?: "MultiplexResult";
       testResult: string;
       disease: { __typename?: "SupportedDisease"; name: string };
-    } | null> | null;
+    }> | null;
     deviceType?: {
       __typename?: "DeviceType";
       name: string;
@@ -2801,7 +2802,7 @@ export type GetTestResultForCorrectionQuery = {
       __typename?: "MultiplexResult";
       testResult: string;
       disease: { __typename?: "SupportedDisease"; name: string };
-    } | null> | null;
+    }> | null;
     deviceType?: { __typename?: "DeviceType"; name: string } | null;
     patient?: {
       __typename?: "Patient";
@@ -2890,7 +2891,16 @@ export type GetTestResultDetailsQuery = {
       __typename?: "MultiplexResult";
       testResult: string;
       disease: { __typename?: "SupportedDisease"; name: string };
-    } | null> | null;
+    }> | null;
+    surveyData?: {
+      __typename?: "AskOnEntrySurvey";
+      pregnancy?: string | null;
+      syphilisHistory?: string | null;
+      symptoms?: string | null;
+      symptomOnset?: any | null;
+      noSymptoms?: boolean | null;
+      genderOfSexualPartners?: Array<string> | null;
+    } | null;
     deviceType?: { __typename?: "DeviceType"; name: string } | null;
     patient?: {
       __typename?: "Patient";
@@ -9151,6 +9161,14 @@ export const GetTestResultDetailsDocument = gql`
       symptomOnset
       pregnancy
       genderOfSexualPartners
+      surveyData {
+        pregnancy
+        syphilisHistory
+        symptoms
+        symptomOnset
+        noSymptoms
+        genderOfSexualPartners
+      }
       deviceType {
         name
       }


### PR DESCRIPTION
# BACKEND AND FRONTEND PULL REQUEST

## Related Issue

- Resolves #8099 

## Changes Proposed

- Adds AOE survey data as an object on the response from `GetTestResultDetails` query
- Shows syphilis AOE responses on the View Details modal

## Additional Information

- The GraphQL change is backwards compatible for any old cached frontends since the AOE data will still be available from that query at the top level as well as within the new `surveyData` object. A follow up PR will clean up the query to remove the loose AOE responses at the top level.

## Testing

- Deployed on dev6

## Screenshots

![image](https://github.com/user-attachments/assets/74b350fe-2ec9-45a8-b7d8-ac3d6242b9c7)
