### PR TITLE
Data Base Migration to Support Multiple Ordering Providers

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5671,3 +5671,23 @@ databaseChangeLog:
       rollback:
         - dropTable:
             tableName: facility_providers
+
+  - changeSet:
+      id: add-default-provider
+      author: bobby@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: add-default-provider-col
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: default_ordering_provider_id
+                  remarks: The default ordering provider for tests at this facility.
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk__facility__default_ordering_provider
+                    references: provider(internal_id)
+      rollback:
+        sql: |
+          ALTER TABLE ${database.defaultSchemaName}.facility DROP COLUMN  default_ordering_provider_id;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5710,3 +5710,21 @@ databaseChangeLog:
       rollback:
         sql: |
           TRUNCATE TABLE ${database.defaultSchemaName}.facility_providers;
+
+  - changeSet:
+      id: populate-default-provider-column
+      author: bobby@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: populate-default-provider-column
+        - sql: |
+            UPDATE ${database.defaultSchemaName}.facility
+            SET
+              default_ordering_provider_id = facility.ordering_provider_id
+            WHERE facility.default_ordering_provider_id is NULL;
+      rollback:
+        sql: |
+          UPDATE ${database.defaultSchemaName}.facility
+          SET
+            default_ordering_provider_id = NULL
+          WHERE facility.default_ordering_provider_id is NOT NULL;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5643,3 +5643,31 @@ databaseChangeLog:
         - dropColumn:
             tableName: test_order
             columnName: timer_started_at
+
+  - changeSet:
+      id: create-facility_providers-table
+      author: bobby@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: add-facility-providers-table
+        - createTable:
+            tableName: facility_providers
+            remarks: Many-to-many table for multiple providers configuration at a facility.
+            columns:
+              - column:
+                  name: facility_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_providers__facility
+                    references: facility
+              - column:
+                  name: provider_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk__facility_providers__provider
+                    references: provider
+      rollback:
+        - dropTable:
+            tableName: facility_providers

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5691,3 +5691,22 @@ databaseChangeLog:
       rollback:
         sql: |
           ALTER TABLE ${database.defaultSchemaName}.facility DROP COLUMN  default_ordering_provider_id;
+
+  - changeSet:
+      id: populate-facility-providers-table
+      author: bobby@skylight.digital
+      changes:
+        - tagDatabase:
+            tag: populate-facility-providers-table
+        - sql: |
+            INSERT INTO ${database.defaultSchemaName}.facility_providers (
+              facility_id,
+              provider_id
+            )
+            SELECT
+              internal_id,
+              ordering_provider_id
+            FROM ${database.defaultSchemaName}.facility;
+      rollback:
+        sql: |
+          TRUNCATE TABLE ${database.defaultSchemaName}.facility_providers;


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Part of #7982 

## Changes Proposed

- Updates database schema to have a `facility_providers table` and add  `default_ordering_provider_id` to the `facilities` table.

- Populate new table and column.

## Additional Information

- The `default_ordering_provider_id` will initially be seeded with the `ordering_provider_id` for a given a facility.  Once seeded and the backend implementation for for multiple ordering providers is complete, the `ordering_provider_id` column will be removed from the `facilities` table.

## Testing

- Run migration locally and confirm that a `facility_providers table` is created and populated.

- Run migration locally and confirm that the `default_ordering_provider_id` has been correctly added  and populated on the `facilities` table.

- Run rollback for each of the 4  database tags and confirm that they are working as expected.
