### PR TITLE
Log error if Okta and DB role claims unequal

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -721,6 +721,10 @@ public class ApiUserService {
     OrganizationRoles orgRoles =
         getOrganizationRoles(Optional.ofNullable(oktaClaims), apiUser, isSiteAdmin);
 
+    _dbOrgRoleClaimsService.checkOrgRoleClaimsEquality(
+        List.of(oktaClaims),
+        List.of(_dbOrgRoleClaimsService.getOrganizationRoleClaims(apiUser)),
+        apiUser.getLoginEmail());
     return new UserInfo(apiUser, Optional.of(orgRoles), isSiteAdmin, userStatus);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
@@ -67,7 +67,9 @@ public class DbOrgRoleClaimsService {
    * @return boolean
    */
   public boolean checkOrgRoleClaimsEquality(
-      List<OrganizationRoleClaims> oktaClaims, List<OrganizationRoleClaims> dbClaims) {
+      List<OrganizationRoleClaims> oktaClaims,
+      List<OrganizationRoleClaims> dbClaims,
+      String username) {
     boolean hasEqualRoleClaims = false;
     if (oktaClaims.size() == dbClaims.size()) {
       List<OrganizationRoleClaims> sanitizedOktaClaims = sanitizeOktaOrgRoleClaims(oktaClaims);
@@ -79,17 +81,18 @@ public class DbOrgRoleClaimsService {
                           .anyMatch(dbClaim -> equalOrgRoleClaim(sanitizedOktaClaim, dbClaim)));
     }
     if (!hasEqualRoleClaims) {
-      logUnequalClaims();
+      logUnequalClaims(username);
     }
 
     return hasEqualRoleClaims;
   }
 
-  /** Logs a message saying OrganizationRoleClaims are unequal with the affected User ID */
-  private void logUnequalClaims() {
-    // WIP: Currently assumes check is for the current user
-    // This may change based on where checkOrgRoleClaimsEquality is called
-    String username = _getCurrentUser.get().getUsername();
+  /**
+   * Logs a message saying OrganizationRoleClaims are unequal with the affected User ID *
+   *
+   * @param username - String user login email
+   */
+  private void logUnequalClaims(String username) {
     ApiUser user = _userRepo.findByLoginEmail(username).orElseThrow(NonexistentUserException::new);
     log.error(
         "Okta OrganizationRoleClaims do not match database OrganizationRoleClaims for User ID: {}",

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationService.java
@@ -60,6 +60,8 @@ public class LoggedInAuthorizationService implements AuthorizationService {
       String username = currentAuth.getName();
       List<OrganizationRoleClaims> dbOrgRoleClaims =
           _dbOrgRoleClaimsService.getOrganizationRoleClaims(username);
+      _dbOrgRoleClaimsService.checkOrgRoleClaimsEquality(
+          oktaOrgRoleClaims, dbOrgRoleClaims, username);
       if (_featureFlagsConfig.isOktaMigrationEnabled()) {
         return dbOrgRoleClaims;
       }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -159,7 +159,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    verify(_dbOrgRoleClaimsService, times(0)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
     assertEquals(email, userInfo.getEmail());
     roleCheck(
         userInfo,
@@ -177,7 +177,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(2)).getOrganizationRoleClaims((ApiUser) any());
     assertEquals(email, userInfo.getEmail());
     roleCheck(userInfo, EnumSet.of(OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
   }
@@ -192,7 +192,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    verify(_dbOrgRoleClaimsService, times(0)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
     assertEquals(email, userInfo.getEmail());
     roleCheck(
         userInfo,
@@ -218,7 +218,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
     UserInfo userInfo = _service.getUser(apiUser.getInternalId());
 
-    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(2)).getOrganizationRoleClaims((ApiUser) any());
     assertEquals(email, userInfo.getEmail());
     roleCheck(userInfo, EnumSet.of(OrganizationRole.USER, OrganizationRole.ALL_FACILITIES));
 
@@ -607,7 +607,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
     UserInfo userInfo = _service.getUserByLoginEmail(email);
 
-    verify(_dbOrgRoleClaimsService, times(0)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
     assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
     assertEquals(email, userInfo.getEmail());
     assertEquals(UserStatus.ACTIVE, userInfo.getUserStatus());
@@ -626,7 +626,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     ApiUser apiUser = _apiUserRepo.findByLoginEmail(email).get();
     UserInfo userInfo = _service.getUserByLoginEmail(email);
 
-    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(2)).getOrganizationRoleClaims((ApiUser) any());
 
     assertEquals(apiUser.getInternalId(), userInfo.getInternalId());
     assertEquals(email, userInfo.getEmail());
@@ -725,7 +725,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     // we should be able to retrieve user info for a user with invalid claims (no facility access)
     // without failing
     UserInfo result = _service.getUserByLoginEmail(email);
-    verify(_dbOrgRoleClaimsService, times(0)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
     assertThat(result.getFacilities()).isEmpty();
     assertEquals(List.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER), result.getRoles());
   }
@@ -740,7 +740,7 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     // we should be able to retrieve user info for a user with invalid claims (no facility access)
     // without failing
     UserInfo result = _service.getUserByLoginEmail(email);
-    verify(_dbOrgRoleClaimsService, times(1)).getOrganizationRoleClaims((ApiUser) any());
+    verify(_dbOrgRoleClaimsService, times(2)).getOrganizationRoleClaims((ApiUser) any());
     assertThat(result.getFacilities()).isEmpty();
     assertEquals(List.of(OrganizationRole.USER), result.getRoles());
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsServiceTest.java
@@ -125,9 +125,14 @@ class DbOrgRoleClaimsServiceTest extends BaseServiceTest<DbOrgRoleClaimsService>
             OrganizationRoleClaimsTestUtils.DB_ORG_EXTERNAL_ID,
             Set.of(OrganizationRole.ALL_FACILITIES, OrganizationRole.ADMIN));
 
+    String username = "fakeuser@example.com";
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(_apiUserRepoSpy.findByLoginEmail(username)).thenReturn(Optional.of(mockApiUser));
     assertTrue(
         _service.checkOrgRoleClaimsEquality(
-            List.of(secondOktaClaim, firstOktaClaim), List.of(firstDbClaim, secondDbClaim)));
+            List.of(secondOktaClaim, firstOktaClaim),
+            List.of(firstDbClaim, secondDbClaim),
+            "fakeuser@example.com"));
   }
 
   @Test
@@ -146,7 +151,10 @@ class DbOrgRoleClaimsServiceTest extends BaseServiceTest<DbOrgRoleClaimsService>
             OrganizationRoleClaimsTestUtils.OKTA_ORG_EXTERNAL_ID,
             Set.of(OrganizationRole.ALL_FACILITIES, OrganizationRole.USER));
 
-    assertTrue(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim)));
+    String username = "fakeuser@example.com";
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(_apiUserRepoSpy.findByLoginEmail(username)).thenReturn(Optional.of(mockApiUser));
+    assertTrue(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim), username));
   }
 
   @Test
@@ -164,7 +172,11 @@ class DbOrgRoleClaimsServiceTest extends BaseServiceTest<DbOrgRoleClaimsService>
 
     Mockito.reset(_apiUserRepoSpy);
 
-    assertFalse(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim)));
+    String username = "fakeuser@example.com";
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(_apiUserRepoSpy.findByLoginEmail(username)).thenReturn(Optional.of(mockApiUser));
+    assertFalse(
+        _service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(dbClaim), username));
     verify(_apiUserRepoSpy, times(1)).findByLoginEmail(any());
   }
 
@@ -176,7 +188,10 @@ class DbOrgRoleClaimsServiceTest extends BaseServiceTest<DbOrgRoleClaimsService>
             OrganizationRoleClaimsTestUtils.OKTA_FACILITY_NAMES,
             Set.of(OrganizationRole.NO_ACCESS, OrganizationRole.USER));
 
-    assertFalse(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of()));
+    String username = "fakeuser@example.com";
+    ApiUser mockApiUser = mock(ApiUser.class);
+    when(_apiUserRepoSpy.findByLoginEmail(username)).thenReturn(Optional.of(mockApiUser));
+    assertFalse(_service.checkOrgRoleClaimsEquality(List.of(oktaClaim), List.of(), username));
   }
 
   private OrganizationRoleClaims createClaimsForCreatedOrg(


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- FINALLY resolves #7598 😭 🙌 🎉 

## Changes Proposed
- Compare role claims in the DB and Okta and log an error if they are unequal for the following scenarios:
   - call `getUser` method
   - call `getUserByLoginEmail` method
   - when we set the `organizationRolesContext`

## Additional Information
- Two other issues were open related to finishing up issue #7598 
  - Adding a daily alert #8181 
  - Enabling the feature flag on certain dev envs #8180  

## Testing
- deployed on dev3 with the feature flag on
- Removed the following group in Okta for this user `cekok63012@nmaller.com` on `dev3`:
  - `SR-DEV3-TENANT:AK-Bobans-org-5145a894-3be7-45ea-a5a1-79895df0352c:ALL_FACILITIES`
  - searched the user in the "Manage users" support admin tool
  - [logged here](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/%7B%22SubscriptionId%22%3A%227d1e3999-6577-4cd5-b296-f518e5c8e677%22%2C%22ResourceGroup%22%3A%22prime-simple-report-dev%22%2C%22Name%22%3A%22prime-simple-report-dev3-insights%22%2C%22LinkedApplicationType%22%3A0%2C%22ResourceId%22%3A%22%252Fsubscriptions%252F7d1e3999-6577-4cd5-b296-f518e5c8e677%252FresourceGroups%252Fprime-simple-report-dev%252Fproviders%252FMicrosoft.Insights%252Fcomponents%252Fprime-simple-report-dev3-insights%22%2C%22ResourceType%22%3A%22microsoft.insights%252Fcomponents%22%2C%22IsAzureFirst%22%3Afalse%7D/DataModel~/%7B%22eventId%22%3A%225a28c81a-87ff-11ef-ac1d-000d3a52dd2e%22%2C%22timestamp%22%3A%222024-10-11T18%3A33%3A31.998Z%22%2C%22cacheId%22%3A%22f00a3d6a-af4c-4ca2-acf0-b57328bb6875%22%2C%22eventTable%22%3A%22traces%22%2C%22timeContext%22%3A%7B%22durationMs%22%3A86400000%2C%22endTime%22%3A%222024-10-11T18%3A34%3A01.398Z%22%7D%7D) in Azure
<img width="520" alt="Screenshot 2024-10-11 at 13 35 15" src="https://github.com/user-attachments/assets/15d7e2dd-547f-4188-8791-722c40133506">
 
 - log in as a non-site admin user on the envs above and navigate around the app

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->