### PR TITLE
Map single entry symptom responses to FHIR

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/Translators.java
@@ -378,6 +378,51 @@ public class Translators {
     throw IllegalGraphqlArgumentException.invalidInput(s, "state");
   }
 
+  private static final Map<String, String> RESPIRATORY_SYMPTOMS =
+      Map.ofEntries(
+          Map.entry("426000000", "Fever over 100.4F"),
+          Map.entry("103001002", "Feeling feverish"),
+          Map.entry("43724002", "Chills"),
+          Map.entry("49727002", "Cough"),
+          Map.entry("267036007", "Shortness of breath"),
+          Map.entry("230145002", "Difficulty breathing"),
+          Map.entry("84229001", "Fatigue"),
+          Map.entry("68962001", "Muscle or body aches"),
+          Map.entry("25064002", "Headache"),
+          Map.entry("36955009", "New loss of taste"),
+          Map.entry("44169009", "New loss of smell"),
+          Map.entry("162397003", "Sore throat"),
+          Map.entry("68235000", "Nasal congestion"),
+          Map.entry("64531003", "Runny nose"),
+          Map.entry("422587007", "Nausea"),
+          Map.entry("422400008", "Vomiting"),
+          Map.entry("62315008", "Diarrhea"),
+          Map.entry("261665006", "Other symptom not listed"));
+
+  private static final Map<String, String> SYPHILIS_SYMPTOMS =
+      Map.ofEntries(
+          Map.entry("724386005", "Genital sore/lesion"),
+          Map.entry("195469007", "Anal sore/lesion"),
+          Map.entry("26284000", "Sore(s) in mouth/lips"),
+          Map.entry("266128007", "Body Rash"),
+          Map.entry("56940005", "Palmar (hand)/plantar (foot) rash"),
+          Map.entry("91554004", "Flat white warts"),
+          Map.entry("15188001", "Hearing loss"),
+          Map.entry("246636008", "Blurred vision"),
+          Map.entry("56317004", "Alopecia"));
+
+  private static Map<String, String> getSupportedSymptoms() {
+    Map<String, String> supportedSymptoms = new HashMap<>();
+    supportedSymptoms.putAll(RESPIRATORY_SYMPTOMS);
+    supportedSymptoms.putAll(SYPHILIS_SYMPTOMS);
+    return supportedSymptoms;
+  }
+
+  public static String getSymptomName(String snomedCode) {
+    Map<String, String> supportedSymptoms = getSupportedSymptoms();
+    return supportedSymptoms.get(snomedCode);
+  }
+
   public static Map<String, Boolean> parseSymptoms(String symptoms) {
     if (symptoms == null) {
       return Collections.emptyMap();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConstants.java
@@ -51,6 +51,8 @@ public class FhirConstants {
 
   public static final String LOINC_AOE_IDENTIFIER = "81959-9";
   public static final String LOINC_AOE_SYMPTOMATIC = "95419-8";
+  public static final String LOINC_SYMPTOM_TIMING_PANEL = "99582-9";
+  public static final String LOINC_SYMPTOM = "75325-1";
   public static final String LOINC_AOE_SYMPTOM_ONSET = "11368-8";
   public static final String LOINC_AOE_PREGNANCY_STATUS = "82810-3";
   public static final String LOINC_AOE_EMPLOYED_IN_HEALTHCARE = "95418-0";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1005,8 +1005,8 @@ public class FhirConverter {
     } else if (surveyData.getSymptoms() != null
         && surveyData.getSymptoms().containsValue(Boolean.TRUE)) {
       symptomatic = true;
-      List<String> trueSymptoms = getFilteredTrueSymptoms(surveyData.getSymptoms());
-      observations.addAll(convertToSymptomsObservations(trueSymptoms));
+      List<String> symptomsPresent = getFilteredSymptomsPresent(surveyData.getSymptoms());
+      observations.addAll(convertToSymptomsObservations(symptomsPresent));
     } // implied else: AoE form was not completed. Symptomatic set to null
 
     var symptomOnsetDate = surveyData.getSymptomOnsetDate();
@@ -1651,7 +1651,7 @@ public class FhirConverter {
     return patient;
   }
 
-  private List<String> getFilteredTrueSymptoms(Map<String, Boolean> symptomsMap) {
+  private List<String> getFilteredSymptomsPresent(Map<String, Boolean> symptomsMap) {
     return symptomsMap.entrySet().stream()
         .filter(symptom -> Boolean.TRUE.equals(symptom.getValue()))
         .map(Entry::getKey)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1005,8 +1005,8 @@ public class FhirConverter {
     } else if (surveyData.getSymptoms() != null
         && surveyData.getSymptoms().containsValue(Boolean.TRUE)) {
       symptomatic = true;
-      List<String> positiveSymptoms = getPositiveSymptoms(surveyData.getSymptoms());
-      observations.addAll(convertToSymptomsObservations(positiveSymptoms));
+      List<String> trueSymptoms = getFilteredTrueSymptoms(surveyData.getSymptoms());
+      observations.addAll(convertToSymptomsObservations(trueSymptoms));
     } // implied else: AoE form was not completed. Symptomatic set to null
 
     var symptomOnsetDate = surveyData.getSymptomOnsetDate();
@@ -1651,7 +1651,7 @@ public class FhirConverter {
     return patient;
   }
 
-  private List<String> getPositiveSymptoms(Map<String, Boolean> symptomsMap) {
+  private List<String> getFilteredTrueSymptoms(Map<String, Boolean> symptomsMap) {
     return symptomsMap.entrySet().stream()
         .filter(symptom -> Boolean.TRUE.equals(symptom.getValue()))
         .map(Entry::getKey)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -10,6 +10,7 @@ import static gov.cdc.usds.simplereport.api.Translators.OTHER;
 import static gov.cdc.usds.simplereport.api.Translators.REFUSED;
 import static gov.cdc.usds.simplereport.api.Translators.TRANS_MAN;
 import static gov.cdc.usds.simplereport.api.Translators.TRANS_WOMAN;
+import static gov.cdc.usds.simplereport.api.Translators.getSymptomName;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAGS_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_ABNORMAL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.ABNORMAL_FLAG_NORMAL;
@@ -34,6 +35,8 @@ import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SY
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_AOE_SYMPTOM_ONSET;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_CODE_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_GENDER_IDENTITY;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_SYMPTOM;
+import static gov.cdc.usds.simplereport.api.converter.FhirConstants.LOINC_SYMPTOM_TIMING_PANEL;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM_CODE;
 import static gov.cdc.usds.simplereport.api.converter.FhirConstants.NOTE_TYPE_CODING_SYSTEM_CODE_INDEX_EXTENSION_URL;
@@ -114,12 +117,15 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -802,7 +808,7 @@ public class FhirConverter {
     }
   }
 
-  public Set<Observation> convertToAOESymptomObservation(
+  public Set<Observation> convertToAOESymptomaticObservation(
       String eventId, Boolean symptomatic, LocalDate symptomOnsetDate) {
     var observations = new LinkedHashSet<Observation>();
     var symptomaticCode =
@@ -824,6 +830,33 @@ public class FhirConverter {
                   "Illness or injury onset date and time"),
               new DateTimeType(symptomOnsetDate.toString())));
     }
+    return observations;
+  }
+
+  public Observation createSymptomObservation(CodeableConcept code, Type value) {
+    Observation observation =
+        new Observation().setStatus(ObservationStatus.FINAL).setCode(code).setValue(value);
+    observation.setId(uuidGenerator.randomUUID().toString());
+    observation
+        .addIdentifier()
+        .setUse(IdentifierUse.OFFICIAL)
+        .setType(createLoincConcept(LOINC_SYMPTOM_TIMING_PANEL, "Symptom and timing panel", null));
+    return observation;
+  }
+
+  public Set<Observation> convertToSymptomsObservations(List<String> symptoms) {
+    HashSet<Observation> observations = new HashSet<>();
+
+    CodeableConcept symptomStatusCode = createLoincConcept(LOINC_SYMPTOM, "Symptom", "Symptom");
+
+    symptoms.forEach(
+        symptom -> {
+          String symptomName = getSymptomName(symptom);
+          if (symptomName != null && !symptomName.isBlank()) {
+            CodeableConcept symptomValueCode = createSNOMEDConcept(symptom, symptomName, null);
+            observations.add(createSymptomObservation(symptomStatusCode, symptomValueCode));
+          }
+        });
     return observations;
   }
 
@@ -972,10 +1005,12 @@ public class FhirConverter {
     } else if (surveyData.getSymptoms() != null
         && surveyData.getSymptoms().containsValue(Boolean.TRUE)) {
       symptomatic = true;
+      List<String> positiveSymptoms = getPositiveSymptoms(surveyData.getSymptoms());
+      observations.addAll(convertToSymptomsObservations(positiveSymptoms));
     } // implied else: AoE form was not completed. Symptomatic set to null
 
     var symptomOnsetDate = surveyData.getSymptomOnsetDate();
-    observations.addAll(convertToAOESymptomObservation(eventId, symptomatic, symptomOnsetDate));
+    observations.addAll(convertToAOESymptomaticObservation(eventId, symptomatic, symptomOnsetDate));
 
     String pregnancyStatus = surveyData.getPregnancy();
     if (pregnancyStatus != null && pregnancyStatusSnomedMap.values().contains(pregnancyStatus)) {
@@ -1614,6 +1649,13 @@ public class FhirConverter {
                   .setValue(new CodeableConcept().addCoding().setCode(absentReason)));
     }
     return patient;
+  }
+
+  private List<String> getPositiveSymptoms(Map<String, Boolean> symptomsMap) {
+    return symptomsMap.entrySet().stream()
+        .filter(symptom -> Boolean.TRUE.equals(symptom.getValue()))
+        .map(Entry::getKey)
+        .collect(Collectors.toList());
   }
 
   public Bundle createFhirBundle(ConditionAgnosticCreateFhirBundleProps props) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -458,7 +458,8 @@ public class BulkUploadResultsToFhir {
     }
 
     aoeObservations.addAll(
-        fhirConverter.convertToAOESymptomObservation(testEventId, symptomatic, symptomOnsetDate));
+        fhirConverter.convertToAOESymptomaticObservation(
+            testEventId, symptomatic, symptomOnsetDate));
 
     String pregnancyValue = row.getPregnant().getValue();
     if (StringUtils.isNotBlank(pregnancyValue)) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1026,7 +1026,7 @@ class FhirConverterTest {
         AskOnEntrySurvey.builder()
             .pregnancy(null)
             .syphilisHistory(null)
-            .symptoms(Map.of("fake", false))
+            .symptoms(Map.of("195469007", true))
             .noSymptoms(true)
             .symptomOnsetDate(null)
             .genderOfSexualPartners(null)
@@ -1271,13 +1271,42 @@ class FhirConverterTest {
   }
 
   @Test
+  void convertToAoeObservation_symptoms_matchesJson() throws IOException {
+    AskOnEntrySurvey answers =
+        AskOnEntrySurvey.builder()
+            .pregnancy(null)
+            .syphilisHistory(null)
+            .symptoms(
+                Map.of("36955009", true, "261665006", false, "68962001", true, "195469007", true))
+            .genderOfSexualPartners(null)
+            .symptomOnsetDate(null)
+            .noSymptoms(false)
+            .build();
+
+    String testId = "fakeId";
+
+    Set<Observation> actual =
+        fhirConverter.convertToAOEObservations(
+            testId, answers, new Person("first", "last", "middle", "suffix", null));
+
+    String actualSerialized =
+        actual.stream().map(parser::encodeResourceToString).collect(Collectors.toSet()).toString();
+    String expectedSerialized =
+        IOUtils.toString(
+            Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream("fhir/observationSymptom.json")),
+            StandardCharsets.UTF_8);
+    JSONAssert.assertEquals(expectedSerialized, actualSerialized, true);
+  }
+
+  @Test
   void convertToAoeObservation_allAOE_matchesJson() throws IOException {
     List<String> sexualPartners = List.of("male", "female");
     AskOnEntrySurvey answers =
         AskOnEntrySurvey.builder()
             .pregnancy(PREGNANT_UNKNOWN_SNOMED)
             .syphilisHistory(NO_SYPHILIS_HISTORY_SNOMED)
-            .symptoms(Map.of("fake", true))
+            .symptoms(Map.of("36955009", true))
             .symptomOnsetDate(LocalDate.of(2023, 3, 4))
             .genderOfSexualPartners(sexualPartners)
             .noSymptoms(false)

--- a/backend/src/test/resources/fhir/bundle-integration-testing.json
+++ b/backend/src/test/resources/fhir/bundle-integration-testing.json
@@ -381,6 +381,9 @@
           },
           {
             "reference": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          },
+          {
+            "reference": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
           }
         ],
         "note": [
@@ -885,6 +888,50 @@
               "system": "http://snomed.info/sct",
               "code": "446151000124109",
               "display": "Male gender identity"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "Observation/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "identifier": [
+          {
+            "use": "official",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "99582-9",
+                  "display": "Symptom and timing panel"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "75325-1",
+              "display": "Symptom"
+            }
+          ],
+          "text": "Symptom"
+        },
+        "subject": {
+          "reference": "Patient/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "84229001",
+              "display": "Fatigue"
             }
           ]
         }

--- a/backend/src/test/resources/fhir/observationAllAoe.json
+++ b/backend/src/test/resources/fhir/observationAllAoe.json
@@ -1,6 +1,44 @@
 [
   {
     "resourceType": "Observation",
+    "id": "5db534ea-5e97-4861-ba18-d74acc46db15",
+    "identifier": [
+      {
+        "use": "official",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99582-9",
+              "display": "Symptom and timing panel"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "75325-1",
+          "display": "Symptom"
+        }
+      ],
+      "text": "Symptom"
+    },
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "36955009",
+          "display": "New loss of taste"
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "Observation",
     "id": "8526bd3b-42e4-3a6f-88ff-3fc43b69dc20",
     "identifier": [
       {

--- a/backend/src/test/resources/fhir/observationSymptom.json
+++ b/backend/src/test/resources/fhir/observationSymptom.json
@@ -1,0 +1,154 @@
+[
+  {
+    "resourceType": "Observation",
+    "id": "5db534ea-5e97-4861-ba18-d74acc46db15",
+    "identifier": [
+      {
+        "use": "official",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99582-9",
+              "display": "Symptom and timing panel"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "75325-1",
+          "display": "Symptom"
+        }
+      ],
+      "text": "Symptom"
+    },
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "36955009",
+          "display": "New loss of taste"
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "Observation",
+    "id": "5f3026ea-845b-3649-8b62-d3dbfd3e7b62",
+    "identifier": [
+      {
+        "use": "official",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "81959-9",
+              "display": "Public health laboratory ask at order entry panel"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "95419-8",
+          "display": "Has symptoms related to condition of interest"
+        }
+      ],
+      "text": "Has symptoms related to condition of interest"
+    },
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/ValueSet/v2-0136",
+          "code": "Y",
+          "display": "Yes"
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "Observation",
+    "id": "5db534ea-5e97-4861-ba18-d74acc46db15",
+    "identifier": [
+      {
+        "use": "official",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99582-9",
+              "display": "Symptom and timing panel"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "75325-1",
+          "display": "Symptom"
+        }
+      ],
+      "text": "Symptom"
+    },
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "68962001",
+          "display": "Muscle or body aches"
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "Observation",
+    "id": "5db534ea-5e97-4861-ba18-d74acc46db15",
+    "identifier": [
+      {
+        "use": "official",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "99582-9",
+              "display": "Symptom and timing panel"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "75325-1",
+          "display": "Symptom"
+        }
+      ],
+      "text": "Symptom"
+    },
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "195469007",
+          "display": "Anal sore/lesion"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #6609 

## Changes Proposed

- Maps single entry symptom responses to FHIR to match the format described [here](https://skylight-hq.slack.com/archives/C0411VC78DN/p1715709220645269?thread_ts=1715704188.705729&cid=C0411VC78DN)

```
{
    "fullUrl": "Observation/12345",
    "resource": {
        "resourceType": "Observation",
        "id": "12345",
        "identifier": [
            {
                "use": "official",
                "type": {
                    "coding": [
                        {
                            "system": "http://loinc.org/",
                            "code": "99582-9",
                            "display": "Symptom and timing panel"
                        }
                    ]
                }
            }
        ],
        "status": "final",
        "code": {
            "coding": [
                {
                    "system": "http://loinc.org/",
                    "code": "75325-1",
                    "display": "Symptom"
                }
            ],
            "text": "Symptom"
        },
        "subject": {
            "reference": "Patient/12345"
        },
        "valueCodeableConcept": {
            "coding": [
                {
                    "system": "http://snomed.info/sct",
                    "code": "111516008",
                    "display": "Blurred vision"
                }
            ]
        }
    }
}
```

## Additional Information
- N/A

## Testing
- [`elisa/log-6609-symptoms-fhir-single-entry` branch](https://github.com/CDCgov/prime-simplereport/compare/elisa/log-6609-symptoms-fhir-single-entry?expand=1#diff-0f13a6fdf468bcfcc079f96410fbd7204be5fded4c21df796d259163c3ea62c5R864) has been pushed so you can see a log in your backend console with the symptoms mapped to FHIR

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->