### PR TITLE
Use original test event id for FHIR bundle corrections

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1202,11 +1202,11 @@ public class FhirConverter {
         break;
       case CORRECTED:
         status = (DiagnosticReportStatus.CORRECTED);
-        id = testEvent.getTestOrder().getTestEvent().getInternalId().toString();
+        id = testEvent.getPriorCorrectedTestEventId().toString();
         break;
       case REMOVED:
         status = (DiagnosticReportStatus.ENTEREDINERROR);
-        id = testEvent.getTestOrder().getTestEvent().getInternalId().toString();
+        id = testEvent.getPriorCorrectedTestEventId().toString();
         break;
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -1195,15 +1195,18 @@ public class FhirConverter {
    */
   public DiagnosticReport convertToDiagnosticReport(TestEvent testEvent, Date currentDate) {
     DiagnosticReportStatus status = null;
+    String id = Objects.toString(testEvent.getInternalId(), "");
     switch (testEvent.getCorrectionStatus()) {
       case ORIGINAL:
         status = (DiagnosticReportStatus.FINAL);
         break;
       case CORRECTED:
         status = (DiagnosticReportStatus.CORRECTED);
+        id = testEvent.getTestOrder().getTestEvent().getInternalId().toString();
         break;
       case REMOVED:
         status = (DiagnosticReportStatus.ENTEREDINERROR);
+        id = testEvent.getTestOrder().getTestEvent().getInternalId().toString();
         break;
     }
 
@@ -1241,12 +1244,7 @@ public class FhirConverter {
       dateIssued = ZonedDateTime.ofInstant(currentDate.toInstant(), ZoneOffset.UTC);
 
     return convertToDiagnosticReport(
-        status,
-        testOrderLoinc,
-        testOrderLoincLongName,
-        Objects.toString(testEvent.getInternalId(), ""),
-        dateTested,
-        dateIssued);
+        status, testOrderLoinc, testOrderLoincLongName, id, dateTested, dateIssued);
   }
 
   /**

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1373,12 +1373,16 @@ class FhirConverterTest {
         new TestEvent(invalidTestEvent, TestCorrectionStatus.CORRECTED, "typo");
 
     String priorCorrectedTestEventId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
-    ReflectionTestUtils.setField(correctedTestEvent, "priorCorrectedTestEventId", UUID.fromString(priorCorrectedTestEventId));
+    ReflectionTestUtils.setField(
+        correctedTestEvent,
+        "priorCorrectedTestEventId",
+        UUID.fromString(priorCorrectedTestEventId));
 
     var actual = fhirConverter.convertToDiagnosticReport(correctedTestEvent, new Date());
 
     assertThat(actual.getStatus()).isEqualTo(DiagnosticReportStatus.CORRECTED);
-    assertThat(actual.getId()).isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
+    assertThat(actual.getId())
+        .isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
   }
 
   @Test
@@ -1388,12 +1392,16 @@ class FhirConverterTest {
         new TestEvent(invalidTestEvent, TestCorrectionStatus.REMOVED, "wrong person");
 
     String priorCorrectedTestEventId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
-    ReflectionTestUtils.setField(correctedTestEvent, "priorCorrectedTestEventId", UUID.fromString(priorCorrectedTestEventId));
+    ReflectionTestUtils.setField(
+        correctedTestEvent,
+        "priorCorrectedTestEventId",
+        UUID.fromString(priorCorrectedTestEventId));
 
     var actual = fhirConverter.convertToDiagnosticReport(correctedTestEvent, new Date());
 
     assertThat(actual.getStatus()).isEqualTo(DiagnosticReportStatus.ENTEREDINERROR);
-    assertThat(actual.getId()).isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
+    assertThat(actual.getId())
+        .isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -1367,24 +1367,33 @@ class FhirConverterTest {
 
   @Test
   void convertToDiagnosticReport_TestEvent_correctedTestEvent() {
-    var invalidTestEvent = TestDataBuilder.createEmptyTestEvent();
+    var invalidTestEvent = TestDataBuilder.createMultiplexTestEvent();
+
     var correctedTestEvent =
         new TestEvent(invalidTestEvent, TestCorrectionStatus.CORRECTED, "typo");
+
+    String priorCorrectedTestEventId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
+    ReflectionTestUtils.setField(correctedTestEvent, "priorCorrectedTestEventId", UUID.fromString(priorCorrectedTestEventId));
 
     var actual = fhirConverter.convertToDiagnosticReport(correctedTestEvent, new Date());
 
     assertThat(actual.getStatus()).isEqualTo(DiagnosticReportStatus.CORRECTED);
+    assertThat(actual.getId()).isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
   }
 
   @Test
   void convertToDiagnosticReport_TestEvent_removedTestEvent() {
-    var invalidTestEvent = TestDataBuilder.createEmptyTestEvent();
+    var invalidTestEvent = TestDataBuilder.createMultiplexTestEvent();
     var correctedTestEvent =
         new TestEvent(invalidTestEvent, TestCorrectionStatus.REMOVED, "wrong person");
+
+    String priorCorrectedTestEventId = "3c9c7370-e2e3-49ad-bb7a-f6005f41cf29";
+    ReflectionTestUtils.setField(correctedTestEvent, "priorCorrectedTestEventId", UUID.fromString(priorCorrectedTestEventId));
 
     var actual = fhirConverter.convertToDiagnosticReport(correctedTestEvent, new Date());
 
     assertThat(actual.getStatus()).isEqualTo(DiagnosticReportStatus.ENTEREDINERROR);
+    assertThat(actual.getId()).isEqualTo(correctedTestEvent.getPriorCorrectedTestEventId().toString());
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #8084 

## Changes Proposed

- When processing corrections, the FHIR converter now sets the diagnostic report id as the prior corrected test event id.

## Additional Information

- ReportStream [confirmed that this fix is working as expected after submitting test events from dev5 to RS staging](https://skylight-hq.slack.com/archives/C0411VC78DN/p1729177410882259?thread_ts=1728399361.625019&cid=C0411VC78DN)

## Testing

- For local testing, your app backend should already default to printing out the FHIR bundle in the backend logs via the `NoOpFHIRReportingService`.
- Submit a test event and use search in your logs to find `"DiagnosticReport","id":`. The UUID after this is the test event id. Now go to results page and start a correction for that same result. Make whatever changes you'd like on the correction and then submit it. Now check your logs for the latest case of `"DiagnosticReport","id":` which should contain the same test event id as the original.