### PR TITLE
Add Hepatitis-C to SupportedDiseases

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5634,7 +5634,7 @@ databaseChangeLog:
         - addColumn:
             tableName: test_order
             columns:
-              - column:
+            - column:
                   name: timer_started_at
                   type: text
                   constraints:
@@ -5643,3 +5643,22 @@ databaseChangeLog:
         - dropColumn:
             tableName: test_order
             columnName: timer_started_at
+
+  - changeSet:
+      id: add-hepatitis-c-to-supported_disease-table
+      author: ggs2@cdc.gov
+      comment: Add Hepatitis-C to the supported_disease table.
+      changes:
+        - tagDatabase:
+            tag: add-hepatitis-c-to-supported_disease-table
+        - sql:
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.supported_disease (
+                   internal_id,
+                   name,
+                   loinc)
+              VALUES
+                   (gen_random_uuid(), 'Hepatitis-C', 'LP14400-3')
+      rollback:
+        - sql:
+            sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Hepatitis-C';


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #7433 
- Will be followed up with PR for adding full Hep C support on the test card

## Changes Proposed

- Adds Hepatitis-C to the SupportedDiseases table

## Additional Information

- Wondering whether we should be filtering diseases based on feature flag for the `GetSupportedDiseases` query which is used in the DeviceForm where support admins can add a new device. Without a filter, then once all the pieces of this ticket go in, support admins would be able to add Hepatitis C devices even though users would not be able to use those devices yet with the feature flag off. Currently, facilities would also be able to add any available Hep C devices even if the feature flag is turned off (which shouldn't exist unless support adds it anyway so kind of an edge case here, but flagging it for consideration)

## Testing

- [Branch with the Hep C feature flag disabled](https://github.com/CDCgov/prime-simplereport/tree/refs/heads/mike/7433-hep-c-supported-disease-db-dev2-flag) was deployed to dev2