### PR TITLE
Support timezones for Puerto Rico

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.service;
 
 import static gov.cdc.usds.simplereport.api.Translators.parseState;
 import static gov.cdc.usds.simplereport.api.Translators.parseString;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.commonNameZoneIdMap;
 
 import com.smartystreets.api.ClientBuilder;
 import com.smartystreets.api.exceptions.SmartyException;
@@ -16,7 +17,6 @@ import gov.cdc.usds.simplereport.service.errors.InvalidAddressException;
 import gov.cdc.usds.simplereport.service.model.TimezoneInfo;
 import java.io.IOException;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -145,7 +145,12 @@ public class AddressValidationService {
       return null;
     }
 
-    ZoneOffset zoneOffset = ZoneOffset.of(String.valueOf(timezoneInfo.utcOffset));
-    return ZoneId.of(zoneOffset.getId());
+    String timezoneCommonName = timezoneInfo.timezoneCommonName.toLowerCase();
+    if (commonNameZoneIdMap.containsKey(timezoneCommonName)) {
+      return commonNameZoneIdMap.get(timezoneCommonName);
+    } else {
+      log.error("Unsupported timezone common name: {}", timezoneCommonName);
+      return null;
+    }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/AddressValidationService.java
@@ -16,6 +16,7 @@ import gov.cdc.usds.simplereport.service.errors.InvalidAddressException;
 import gov.cdc.usds.simplereport.service.model.TimezoneInfo;
 import java.io.IOException;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -144,6 +145,7 @@ public class AddressValidationService {
       return null;
     }
 
-    return ZoneId.of("US/" + timezoneInfo.timezoneCommonName);
+    ZoneOffset zoneOffset = ZoneOffset.of(String.valueOf(timezoneInfo.utcOffset));
+    return ZoneId.of(zoneOffset.getId());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -39,7 +39,31 @@ public class DateTimeUtils {
   private static final ZoneId samoaTimeZoneId = ZoneId.of("US/Samoa");
   private static final ZoneId puertoRicoTimeZoneId = ZoneId.of("America/Puerto_Rico");
 
-  public static final Map<String, ZoneId> validTimeZoneIdMap =
+  /**
+   * Map of common name `time_zone` values returned from SmartyStreets and their corresponding
+   * ZoneId https://www.smarty.com/docs/cloud/us-street-api
+   */
+  public static final Map<String, ZoneId> commonNameZoneIdMap =
+      Map.ofEntries(
+          Map.entry("Alaska".toLowerCase(), alaskaTimeZoneId),
+          Map.entry("Atlantic".toLowerCase(), puertoRicoTimeZoneId),
+          Map.entry("Central".toLowerCase(), centralTimeZoneId),
+          Map.entry("Eastern".toLowerCase(), easternTimeZoneId),
+          Map.entry("Hawaii".toLowerCase(), hawaiiTimeZoneId),
+          Map.entry("Mountain".toLowerCase(), mountainTimeZoneId),
+          Map.entry("None".toLowerCase(), FALLBACK_TIMEZONE_ID),
+          Map.entry("Pacific".toLowerCase(), pacificTimeZoneId),
+          Map.entry("Samoa".toLowerCase(), samoaTimeZoneId),
+          Map.entry("UTC+9".toLowerCase(), ZoneId.of("+9")),
+          Map.entry("UTC+10".toLowerCase(), ZoneId.of("+10")),
+          Map.entry("UTC+11".toLowerCase(), ZoneId.of("+11")),
+          Map.entry("UTC+12".toLowerCase(), ZoneId.of("+12")));
+
+  /**
+   * Map of abbreviated timezones and their corresponding ZoneId Used for bulk upload timestamp
+   * validations and when converting user-supplied timezones to a ZoneId
+   */
+  public static final Map<String, ZoneId> timezoneAbbreviationZoneIdMap =
       Map.ofEntries(
           Map.entry("UTC", ZoneOffset.UTC),
           Map.entry("UT", ZoneOffset.UTC),
@@ -63,6 +87,8 @@ public class DateTimeUtils {
           Map.entry("HI", hawaiiTimeZoneId),
           Map.entry("HST", hawaiiTimeZoneId),
           Map.entry("HDT", aleutianTimeZoneId),
+          Map.entry("AS", samoaTimeZoneId),
+          Map.entry("ASM", samoaTimeZoneId),
           Map.entry("SST", samoaTimeZoneId),
           Map.entry("ADT", puertoRicoTimeZoneId),
           Map.entry("AST", puertoRicoTimeZoneId));
@@ -112,8 +138,8 @@ public class DateTimeUtils {
   }
 
   public static ZoneId parseZoneId(String timezoneCode) {
-    if (validTimeZoneIdMap.containsKey(timezoneCode.toUpperCase())) {
-      return validTimeZoneIdMap.get(timezoneCode.toUpperCase());
+    if (timezoneAbbreviationZoneIdMap.containsKey(timezoneCode.toUpperCase())) {
+      return timezoneAbbreviationZoneIdMap.get(timezoneCode.toUpperCase());
     }
     return ZoneId.of(timezoneCode);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -37,6 +37,7 @@ public class DateTimeUtils {
   private static final ZoneId hawaiiTimeZoneId = ZoneId.of("US/Hawaii");
   private static final ZoneId aleutianTimeZoneId = ZoneId.of("US/Aleutian");
   private static final ZoneId samoaTimeZoneId = ZoneId.of("US/Samoa");
+  private static final ZoneId puertoRicoTimeZoneId = ZoneId.of("America/Puerto_Rico");
 
   public static final Map<String, ZoneId> validTimeZoneIdMap =
       Map.ofEntries(
@@ -62,9 +63,9 @@ public class DateTimeUtils {
           Map.entry("HI", hawaiiTimeZoneId),
           Map.entry("HST", hawaiiTimeZoneId),
           Map.entry("HDT", aleutianTimeZoneId),
-          Map.entry("AS", samoaTimeZoneId),
-          Map.entry("ASM", samoaTimeZoneId),
-          Map.entry("SST", samoaTimeZoneId));
+          Map.entry("SST", samoaTimeZoneId),
+          Map.entry("ADT", puertoRicoTimeZoneId),
+          Map.entry("AST", puertoRicoTimeZoneId));
 
   public static ZonedDateTime convertToZonedDateTime(
       String dateString,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -45,7 +45,7 @@ import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_LI
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_SNOMED;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getGenderIdentityAbbreviationMap;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.TIMEZONE_SUFFIX_REGEX;
-import static gov.cdc.usds.simplereport.utils.DateTimeUtils.validTimeZoneIdMap;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.timezoneAbbreviationZoneIdMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 
@@ -462,7 +462,7 @@ public class CsvValidatorUtils {
     String value = input.getValue();
     String timezoneCode = value.substring(value.lastIndexOf(' ')).trim();
     if (!ZoneId.getAvailableZoneIds().contains(timezoneCode)
-        && !validTimeZoneIdMap.containsKey(timezoneCode.toUpperCase())) {
+        && !timezoneAbbreviationZoneIdMap.containsKey(timezoneCode.toUpperCase())) {
       errors.add(
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AddressValidationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AddressValidationServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
@@ -69,15 +70,39 @@ class AddressValidationServiceTest {
   }
 
   @Test
-  void returnsCorrectZoneIdByLookup() {
+  void withSupportedTimezoneCommonName_returnsCorrectZoneIdByLookup() {
     ArrayList<Candidate> results = new ArrayList<Candidate>();
-    results.add(getMockTimeZoneInfoResult());
+    results.add(getMockTimeZoneInfoResult("Central", -5.0));
     Lookup lookup = mock(Lookup.class);
     when(lookup.getResult()).thenReturn(results);
 
     ZoneId zoneId = s.getZoneIdByLookup(lookup);
 
-    assertEquals(zoneId, ZoneId.of("-05:00"));
+    assertEquals(ZoneId.of("US/Central"), zoneId);
+  }
+
+  @Test
+  void withSupportedUtcOffsetTimezone_returnsCorrectZoneIdByLookup() {
+    ArrayList<Candidate> results = new ArrayList<Candidate>();
+    results.add(getMockTimeZoneInfoResult("UTC+9", +9.0));
+    Lookup lookup = mock(Lookup.class);
+    when(lookup.getResult()).thenReturn(results);
+
+    ZoneId zoneId = s.getZoneIdByLookup(lookup);
+
+    assertEquals(ZoneId.of("+9"), zoneId);
+  }
+
+  @Test
+  void withUnsupportedTimezoneCommonName_returnsNull() {
+    ArrayList<Candidate> results = new ArrayList<Candidate>();
+    results.add(getMockTimeZoneInfoResult("FakeZoneId", -25.0));
+    Lookup lookup = mock(Lookup.class);
+    when(lookup.getResult()).thenReturn(results);
+
+    ZoneId zoneId = s.getZoneIdByLookup(lookup);
+
+    assertNull(zoneId);
   }
 
   @Test
@@ -103,10 +128,10 @@ class AddressValidationServiceTest {
     assertThrows(InvalidAddressException.class, () -> s.getTimezoneInfoByLookup(lookup));
   }
 
-  private Candidate getMockTimeZoneInfoResult() {
+  private Candidate getMockTimeZoneInfoResult(String commonName, Double utcOffset) {
     Metadata metadata = mock(Metadata.class);
-    when(metadata.getTimeZone()).thenReturn("Central");
-    when(metadata.getUtcOffset()).thenReturn(-5.0);
+    when(metadata.getTimeZone()).thenReturn(commonName);
+    when(metadata.getUtcOffset()).thenReturn(utcOffset);
     when(metadata.obeysDst()).thenReturn(true);
 
     Candidate result = mock(Candidate.class);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/AddressValidationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/AddressValidationServiceTest.java
@@ -77,7 +77,7 @@ class AddressValidationServiceTest {
 
     ZoneId zoneId = s.getZoneIdByLookup(lookup);
 
-    assertEquals(zoneId, ZoneId.of("US/Central"));
+    assertEquals(zoneId, ZoneId.of("-05:00"));
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #8203 

## Changes Proposed

- Fixes a bug in our CSV bulk uploader where we were generating a timezone for date values in the following columns:
`order_test_date`, `specimen_collection_date`, `testing_lab_specimen_received_date`, `test_result_date`, `date_result_released`
  - this bug occurred for any valid ordering provider address in Puerto Rico **AND** when the above columns had only a date value OR date and time value without a timezone (e.g. `10/18/2024` or `10/18/2024 12:00` and NOT `10/18/2024 12:00 ET`)
- Added the timezone abbreviations for Puerto Rico (`AST` and `ADT`) so that these timezones can be used in dates for our bulk uploader and pass validation

## Additional Information
- N/A

## Testing
- example CSV with a **VALID** Puerto Rico ordering provider and no timestamps - [pr_ordering_provider_ex.csv](https://github.com/user-attachments/files/17527334/pr_ordering_provider_ex.csv)
  - should fail silently on `main`
  - should succeed on `dev3`
  - editing the file and adding `AST` or `ADT` to any date timestamps should also pass the validations

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
