### PR TITLE
Add Hepatitis-C support to test card

### DIFF
--- a/frontend/src/app/commonComponents/Checkboxes.tsx
+++ b/frontend/src/app/commonComponents/Checkboxes.tsx
@@ -89,7 +89,7 @@ const Checkboxes = (props: Props) => {
   return (
     <div
       className={classnames(
-        "usa-form-group padding-0",
+        "usa-form-group",
         validationStatus === "error" && "usa-form-group--error"
       )}
     >

--- a/frontend/src/app/commonComponents/__snapshots__/Checkboxes.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Checkboxes.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Checkboxes renders correctly 1`] = `
 <div>
   <div
-    class="usa-form-group padding-0"
+    class="usa-form-group"
   >
     <fieldset
       class="usa-fieldset prime-checkboxes"

--- a/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/frontend/src/app/signUp/Organization/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -63,7 +63,7 @@ Object {
                     You can join the waitlist to be notified when SimpleReport is available in your state, or if your organization is reporting to a SimpleReport state, you can continue.
                   </p>
                   <div
-                    class="usa-form-group padding-0"
+                    class="usa-form-group"
                   >
                     <fieldset
                       class="usa-fieldset prime-checkboxes"

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHepatitisC.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHepatitisC.ts
@@ -1,0 +1,15 @@
+const mockSupportedDiseaseTestPerformedHepatitisC = [
+  {
+    supportedDisease: {
+      internalId: "82748233-1780-4303-b5fe-05c1d3f34ab7",
+      loinc: "LP14400-3",
+      name: "Hepatitis-C",
+    },
+    testPerformedLoincCode: "80389-6",
+    equipmentUid: "HepatitisCEquipmentUid123",
+    testkitNameId: "HepatitisCTestkitNameId123",
+    testOrderedLoincCode: "80389-6",
+  },
+];
+
+export default mockSupportedDiseaseTestPerformedHepatitisC;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -12,6 +12,8 @@ import {
   fluDeviceId,
   fluDeviceName,
   generateSubmitQueueMock,
+  hepatitisCDeviceId,
+  hepatitisCDeviceName,
   hivDeviceId,
   hivDeviceName,
   multiplexDeviceId,
@@ -176,6 +178,26 @@ describe("TestCardForm", () => {
             internalId: syphilisDeviceId,
             name: syphilisDeviceName,
             model: syphilisDeviceName,
+            testLength: 15,
+          },
+        },
+      };
+
+      expect(await renderTestCardForm({ props })).toMatchSnapshot();
+    });
+
+    it("matches snapshot for hepatitis c device", async () => {
+      const props = {
+        ...testProps,
+        testOrder: {
+          ...testProps.testOrder,
+          results: [
+            { testResult: "POSITIVE", disease: { name: "HEPATITIS-C" } },
+          ],
+          deviceType: {
+            internalId: hepatitisCDeviceId,
+            name: hepatitisCDeviceName,
+            model: hepatitisCDeviceName,
             testLength: 15,
           },
         },

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -58,6 +58,7 @@ import { HIVAoEForm } from "./diseaseSpecificComponents/HIVAoEForm";
 import { stringifySymptomJsonForAoeUpdate } from "./diseaseSpecificComponents/aoeUtils";
 import { SyphilisAoEForm } from "./diseaseSpecificComponents/SyphilisAoEForm";
 import { WhereResultsAreSentModal } from "./WhereResultsAreSentModal";
+import { HepatitisCAoeForm } from "./diseaseSpecificComponents/HepatitisCAoeForm";
 
 const DEBOUNCE_TIME = 300;
 
@@ -595,6 +596,21 @@ const TestCardForm = ({
               hasAttemptedSubmit={hasAttemptedSubmit}
               onResponseChange={(responses) => {
                 setHasAttemptedSubmit(false);
+                dispatch({
+                  type: TestFormActionCase.UPDATE_AOE_RESPONSES,
+                  payload: responses,
+                });
+              }}
+            />
+          </div>
+        )}
+        {whichAoeFormOption === AOEFormOption.HEPATITIS_C && (
+          <div className="grid-row grid-gap">
+            <HepatitisCAoeForm
+              testOrder={testOrder}
+              responses={state.aoeResponses}
+              hasAttemptedSubmit={hasAttemptedSubmit}
+              onResponseChange={(responses) => {
                 dispatch({
                   type: TestFormActionCase.UPDATE_AOE_RESPONSES,
                   payload: responses,

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -64,6 +64,7 @@ const filterDiseaseFromAllDevices = (
 export function useFilteredDeviceTypes(facility: QueriedFacility) {
   const hivEnabled = useFeature("hivEnabled");
   const syphilisEnabled = useFeature("syphilisEnabled");
+  const hepatitisCEnabled = useFeature("hepatitisCEnabled");
 
   let deviceTypes = [...facility!.deviceTypes];
 
@@ -78,6 +79,12 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
     deviceTypes = filterDiseaseFromAllDevices(
       deviceTypes,
       MULTIPLEX_DISEASES.SYPHILIS
+    );
+  }
+  if (!hepatitisCEnabled) {
+    deviceTypes = filterDiseaseFromAllDevices(
+      deviceTypes,
+      MULTIPLEX_DISEASES.HEPATITIS_C
     );
   }
   return deviceTypes;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -26,6 +26,7 @@ export enum AOEFormOption {
   COVID = "COVID",
   HIV = "HIV",
   SYPHILIS = "SYPHILIS",
+  HEPATITIS_C = "HEPATITIS_C",
   NONE = "NONE",
 }
 
@@ -200,6 +201,15 @@ export const useAOEFormOption = (
     devicesMap
       .get(testFormState.deviceId)
       ?.supportedDiseaseTestPerformed.filter(
+        (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.HEPATITIS_C
+      ).length === 1
+  ) {
+    return resultHasPositive ? AOEFormOption.HEPATITIS_C : AOEFormOption.NONE;
+  }
+  if (
+    devicesMap
+      .get(testFormState.deviceId)
+      ?.supportedDiseaseTestPerformed.filter(
         (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.HIV
       ).length === 1
   ) {
@@ -240,18 +250,36 @@ export const AoeValidationErrorMessages = {
   UNKNOWN: "UNKNOWN",
 } as const;
 
+export enum AoeQuestionName {
+  PREGNANCY = "pregnancy",
+  NO_SYMPTOMS = "noSymptoms",
+  GENDER_OF_SEXUAL_PARTNERS = "genderOfSexualPartners",
+  SYPHILIS_HISTORY = "syphilisHistory",
+}
+
 export const REQUIRED_AOE_QUESTIONS_BY_DISEASE: {
   [_key in AOEFormOption]: Array<keyof AoeQuestionResponses>;
 } = {
   // AOE responses for COVID not required, but include in completion validation
   // to show "are you sure" modal if not filled
-  [AOEFormOption.COVID]: ["pregnancy", "noSymptoms"],
-  [AOEFormOption.HIV]: ["pregnancy", "genderOfSexualPartners"],
+  [AOEFormOption.COVID]: [
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.NO_SYMPTOMS,
+  ],
+  [AOEFormOption.HIV]: [
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
+  ],
   [AOEFormOption.SYPHILIS]: [
-    "pregnancy",
-    "syphilisHistory",
-    "genderOfSexualPartners",
-    "noSymptoms",
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.SYPHILIS_HISTORY,
+    AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
+    AoeQuestionName.NO_SYMPTOMS,
+  ],
+  [AOEFormOption.HEPATITIS_C]: [
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
+    AoeQuestionName.NO_SYMPTOMS,
   ],
   [AOEFormOption.NONE]: [],
 };

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -1535,6 +1535,968 @@ exports[`TestCardForm initial state matches snapshot for flu device 1`] = `
 </div>
 `;
 
+exports[`TestCardForm initial state matches snapshot for hepatitis c device 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-hidden="true"
+        class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+      >
+        <h4>
+          Submitting test data for 
+          Dixon, Althea Hedda Mclaughlin
+          ...
+        </h4>
+        <img
+          alt="submitting"
+          class="square-5"
+          src="loader.svg"
+        />
+      </div>
+      <div
+        class="grid-container sr-test-card-form-container"
+      >
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <label
+              class="usa-label margin-top-3"
+              data-testid="label"
+              for="current-date-time"
+            >
+              Test date and time
+               
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                *
+              </abbr>
+            </label>
+            <div
+              class="usa-checkbox"
+              data-testid="checkbox"
+            >
+              <input
+                checked=""
+                class="usa-checkbox__input"
+                id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="current-date-time"
+                type="checkbox"
+              />
+              <label
+                class="usa-checkbox__label"
+                for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              >
+                Current date and time
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+          data-testid="device-type-dropdown-container"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <div
+              class="usa-form-group prime-dropdown  usa-form-group--error card-dropdown"
+            >
+              <label
+                class="usa-label usa-label--error"
+                for="25"
+              >
+                <span
+                  class="usa-tooltip usa-text-with-tooltip"
+                  data-testid="tooltipWrapper"
+                >
+                  <button
+                    aria-describedby="tooltip-1000000"
+                    aria-label=""
+                    class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                    data-testid="triggerElement"
+                    position="right"
+                    tabindex="0"
+                    title=""
+                    wrapperclasses="usa-text-with-tooltip"
+                  >
+                    Test device
+                    <svg
+                      alt-text="info"
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-circle-info info-circle-icon"
+                      data-icon="circle-info"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <span
+                    aria-hidden="true"
+                    class="usa-tooltip__body"
+                    data-testid="tooltipBody"
+                    id="tooltip-1000000"
+                    role="tooltip"
+                    title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                  >
+                    Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                  </span>
+                </span>
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <div
+                class="usa-error-message"
+                id="error_25"
+                role="alert"
+              >
+                <span
+                  class="usa-sr-only"
+                >
+                  Error: 
+                </span>
+                Please select a device.
+              </div>
+              <select
+                aria-describedby="error_25"
+                aria-invalid="true"
+                aria-label="Test device"
+                aria-required="true"
+                class="usa-select usa-input--error"
+                data-testid="device-type-dropdown"
+                id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="testDevice"
+              >
+                <option
+                  aria-selected="false"
+                  value=""
+                />
+                <option
+                  aria-selected="false"
+                  value="FLU-DEVICE-ID"
+                >
+                  FLU
+                </option>
+                <option
+                  aria-selected="false"
+                  value="COVID-DEVICE-ID"
+                >
+                  LumiraDX
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-DEVICE-ID"
+                >
+                  Multiplex
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-COVID-DEVICE-ID"
+                >
+                  MultiplexAndCovidOnly
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="grid-col-auto"
+            data-testid="specimen-type-dropdown-container"
+          >
+            <div
+              class="usa-form-group prime-dropdown  card-dropdown"
+            >
+              <label
+                class="usa-label"
+                for="26"
+              >
+                Specimen type
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <select
+                aria-label="Specimen type"
+                aria-required="true"
+                class="usa-select"
+                data-testid="specimen-type-dropdown"
+                disabled=""
+                id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="specimenType"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="usa-form-group"
+            data-testid="formGroup"
+          >
+            <div
+              class="usa-alert usa-alert--error"
+              data-testid="alert"
+            >
+              <div
+                class="usa-alert__body"
+              >
+                <p
+                  class="usa-alert__text"
+                >
+                  This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col-auto"
+            id="covid-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+          >
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient pregnant?
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="false"
+                          id="27-val-77386006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="77386006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                          for="27-val-77386006"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="false"
+                          id="27-val-60001007"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="60001007"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                          for="27-val-60001007"
+                        >
+                          No
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="false"
+                          id="27-val-261665006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="261665006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                          for="27-val-261665006"
+                        >
+                          Prefer not to answer
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient currently experiencing or showing signs of symptoms?
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="false"
+                          id="28-val-YES"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="YES"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                          for="28-val-YES"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          checked=""
+                          class="usa-radio__input"
+                          data-required="false"
+                          id="28-val-NO"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="NO"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                          for="28-val-NO"
+                        >
+                          No
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-4"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <button
+              class="usa-button"
+              data-testid="button"
+              type="button"
+            >
+              Submit results
+            </button>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-1"
+        >
+          <button
+            class="usa-button usa-button--unstyled margin-top-05em"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              alt-text="info"
+              aria-hidden="true"
+              class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+              data-icon="circle-info"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                fill="currentColor"
+              />
+            </svg>
+            <strong
+              class="font-body-2xs"
+            >
+              Where results are sent
+            </strong>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="modal--basic"
+    />
+    <div
+      class="modal--basic"
+    />
+  </body>,
+  "container": <div>
+    <div
+      aria-hidden="true"
+      class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+    >
+      <h4>
+        Submitting test data for 
+        Dixon, Althea Hedda Mclaughlin
+        ...
+      </h4>
+      <img
+        alt="submitting"
+        class="square-5"
+        src="loader.svg"
+      />
+    </div>
+    <div
+      class="grid-container sr-test-card-form-container"
+    >
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <label
+            class="usa-label margin-top-3"
+            data-testid="label"
+            for="current-date-time"
+          >
+            Test date and time
+             
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+          </label>
+          <div
+            class="usa-checkbox"
+            data-testid="checkbox"
+          >
+            <input
+              checked=""
+              class="usa-checkbox__input"
+              id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="current-date-time"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+            >
+              Current date and time
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+        data-testid="device-type-dropdown-container"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <div
+            class="usa-form-group prime-dropdown  usa-form-group--error card-dropdown"
+          >
+            <label
+              class="usa-label usa-label--error"
+              for="25"
+            >
+              <span
+                class="usa-tooltip usa-text-with-tooltip"
+                data-testid="tooltipWrapper"
+              >
+                <button
+                  aria-describedby="tooltip-1000000"
+                  aria-label=""
+                  class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                  data-testid="triggerElement"
+                  position="right"
+                  tabindex="0"
+                  title=""
+                  wrapperclasses="usa-text-with-tooltip"
+                >
+                  Test device
+                  <svg
+                    alt-text="info"
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-circle-info info-circle-icon"
+                    data-icon="circle-info"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  aria-hidden="true"
+                  class="usa-tooltip__body"
+                  data-testid="tooltipBody"
+                  id="tooltip-1000000"
+                  role="tooltip"
+                  title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                >
+                  Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                </span>
+              </span>
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <div
+              class="usa-error-message"
+              id="error_25"
+              role="alert"
+            >
+              <span
+                class="usa-sr-only"
+              >
+                Error: 
+              </span>
+              Please select a device.
+            </div>
+            <select
+              aria-describedby="error_25"
+              aria-invalid="true"
+              aria-label="Test device"
+              aria-required="true"
+              class="usa-select usa-input--error"
+              data-testid="device-type-dropdown"
+              id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="testDevice"
+            >
+              <option
+                aria-selected="false"
+                value=""
+              />
+              <option
+                aria-selected="false"
+                value="FLU-DEVICE-ID"
+              >
+                FLU
+              </option>
+              <option
+                aria-selected="false"
+                value="COVID-DEVICE-ID"
+              >
+                LumiraDX
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-DEVICE-ID"
+              >
+                Multiplex
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-COVID-DEVICE-ID"
+              >
+                MultiplexAndCovidOnly
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-col-auto"
+          data-testid="specimen-type-dropdown-container"
+        >
+          <div
+            class="usa-form-group prime-dropdown  card-dropdown"
+          >
+            <label
+              class="usa-label"
+              for="26"
+            >
+              Specimen type
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <select
+              aria-label="Specimen type"
+              aria-required="true"
+              class="usa-select"
+              data-testid="specimen-type-dropdown"
+              disabled=""
+              id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="specimenType"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="usa-form-group"
+          data-testid="formGroup"
+        >
+          <div
+            class="usa-alert usa-alert--error"
+            data-testid="alert"
+          >
+            <div
+              class="usa-alert__body"
+            >
+              <p
+                class="usa-alert__text"
+              >
+                This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col-auto"
+          id="covid-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+        >
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient pregnant?
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="false"
+                        id="27-val-77386006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="77386006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                        for="27-val-77386006"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="false"
+                        id="27-val-60001007"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="60001007"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                        for="27-val-60001007"
+                      >
+                        No
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="false"
+                        id="27-val-261665006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="261665006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                        for="27-val-261665006"
+                      >
+                        Prefer not to answer
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient currently experiencing or showing signs of symptoms?
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="false"
+                        id="28-val-YES"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="YES"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                        for="28-val-YES"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        checked=""
+                        class="usa-radio__input"
+                        data-required="false"
+                        id="28-val-NO"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="NO"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                        for="28-val-NO"
+                      >
+                        No
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-4"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <button
+            class="usa-button"
+            data-testid="button"
+            type="button"
+          >
+            Submit results
+          </button>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-1"
+      >
+        <button
+          class="usa-button usa-button--unstyled margin-top-05em"
+          data-testid="button"
+          type="button"
+        >
+          <svg
+            alt-text="info"
+            aria-hidden="true"
+            class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+            data-icon="circle-info"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+              fill="currentColor"
+            />
+          </svg>
+          <strong
+            class="font-body-2xs"
+          >
+            Where results are sent
+          </strong>
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+  "user": Object {
+    "clear": [Function],
+    "click": [Function],
+    "copy": [Function],
+    "cut": [Function],
+    "dblClick": [Function],
+    "deselectOptions": [Function],
+    "hover": [Function],
+    "keyboard": [Function],
+    "paste": [Function],
+    "pointer": [Function],
+    "selectOptions": [Function],
+    "setup": [Function],
+    "tab": [Function],
+    "tripleClick": [Function],
+    "type": [Function],
+    "unhover": [Function],
+    "upload": [Function],
+  },
+}
+`;
+
 exports[`TestCardForm initial state matches snapshot for hiv device 1`] = `
 Object {
   "asFragment": [Function],

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -4768,7 +4768,7 @@ Object {
               class="grid-row"
             >
               <div
-                class="grid-col-12 desktop:grid-col-6"
+                class="grid-col-auto"
               >
                 <div
                   class="usa-form-group"
@@ -5523,7 +5523,7 @@ Object {
             class="grid-row"
           >
             <div
-              class="grid-col-12 desktop:grid-col-6"
+              class="grid-col-auto"
             >
               <div
                 class="usa-form-group"

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/CovidAoEForm.tsx
@@ -79,7 +79,12 @@ const CovidAoEForm = ({
       </div>
       {hasSymptoms === "YES" && (
         <>
-          <div className="grid-row grid-gap" data-testid="symptom-date">
+          <div
+            className={`grid-row grid-gap ${
+              showSymptomOnsetDateError ? "margin-left-0" : ""
+            }`}
+            data-testid="symptom-date"
+          >
             <TextInput
               name={`symptom-date-${testOrder.internalId}`}
               type="date"
@@ -101,11 +106,12 @@ const CovidAoEForm = ({
                   ? SYMPTOM_SUBQUESTION_ERROR
                   : undefined
               }
-              className={showSymptomOnsetDateError ? "margin-left-0" : ""}
             ></TextInput>
           </div>
           <div
-            className="grid-row grid-gap margin-left-0 "
+            className={`grid-row grid-gap ${
+              showSymptomSelectionError ? "margin-left-0" : ""
+            }`}
             data-testid={`symptom-selection-${testOrder.internalId}`}
           >
             <Checkboxes
@@ -123,7 +129,6 @@ const CovidAoEForm = ({
                   ? SYMPTOM_SUBQUESTION_ERROR
                   : undefined
               }
-              className={"padding-left-0"}
             />
           </div>
         </>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HepatitisCAoeForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HepatitisCAoeForm.tsx
@@ -51,7 +51,7 @@ export const HepatitisCAoeForm = ({
       id={`hepatitis-c-aoe-form-${testOrder.patient.internalId}`}
     >
       <div className="grid-row">
-        <div className="grid-col-12 desktop:grid-col-6">
+        <div className="grid-col-auto">
           <GenderOfSexualPartnersAoe
             testOrderId={testOrder.internalId}
             responses={responses}
@@ -73,7 +73,7 @@ export const HepatitisCAoeForm = ({
         </div>
       </div>
       <div className="grid-row">
-        <div className="grid-col-12">
+        <div className="grid-col-auto">
           <YesNoRadioGroup
             name={`has-any-symptoms-${testOrder.internalId}`}
             legend="Is the patient currently experiencing or showing signs of symptoms?"
@@ -89,7 +89,7 @@ export const HepatitisCAoeForm = ({
       </div>
       {hasSymptoms === "YES" && (
         <div className={"grid-row grid-gap width-full"}>
-          <div className={"grid-col-12 desktop:grid-col-9 padding-right-0"}>
+          <div className={"grid-col-auto"}>
             <Checkboxes
               boxes={hepatitisCSymptomDefinitions.map(({ label, value }) => ({
                 label,
@@ -108,31 +108,32 @@ export const HepatitisCAoeForm = ({
               }
             />
           </div>
-
-          <TextInput
-            data-testid="symptom-date"
-            name={`symptom-date-${testOrder.internalId}`}
-            type="date"
-            label="Date of symptom onset"
-            aria-label="Symptom onset date"
-            className={""}
-            min={formatDate(new Date("Jan 1, 2020"))}
-            max={formatDate(moment().toDate())}
-            required
-            value={
-              responses.symptomOnset
-                ? formatDate(
-                    moment(responses.symptomOnset).format("YYYY-MM-DD")
-                  )
-                : ""
-            }
-            onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
-            validationStatus={showSymptomOnsetDateError ? "error" : undefined}
-            errorMessage={
-              showSymptomOnsetDateError &&
-              "Please answer this required question."
-            }
-          ></TextInput>
+          <div className="grid-col-auto">
+            <TextInput
+              data-testid="symptom-date"
+              name={`symptom-date-${testOrder.internalId}`}
+              type="date"
+              label="Date of symptom onset"
+              aria-label="Symptom onset date"
+              className={""}
+              min={formatDate(new Date("Jan 1, 2020"))}
+              max={formatDate(moment().toDate())}
+              required
+              value={
+                responses.symptomOnset
+                  ? formatDate(
+                      moment(responses.symptomOnset).format("YYYY-MM-DD")
+                    )
+                  : ""
+              }
+              onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
+              validationStatus={showSymptomOnsetDateError ? "error" : undefined}
+              errorMessage={
+                showSymptomOnsetDateError &&
+                "Please answer this required question."
+              }
+            ></TextInput>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HepatitisCAoeForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/HepatitisCAoeForm.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import moment from "moment";
+
+import { hepatitisCSymptomDefinitions } from "../../../../patientApp/timeOfTest/constants";
+import { AoeQuestionResponses } from "../TestCardFormReducer";
+import { QueriedTestOrder } from "../types";
+import YesNoRadioGroup from "../../../commonComponents/YesNoRadioGroup";
+import Checkboxes from "../../../commonComponents/Checkboxes";
+import TextInput from "../../../commonComponents/TextInput";
+import { formatDate } from "../../../utils/date";
+
+import {
+  generateAoeListenerHooks,
+  generateSymptomAoeConstants,
+} from "./aoeUtils";
+import { PregnancyAoe } from "./aoeQuestionComponents/PregnancyAoe";
+import { GenderOfSexualPartnersAoe } from "./aoeQuestionComponents/GenderOfSexualPartnersAoe";
+
+interface HepatitisCAoeFormProps {
+  testOrder: QueriedTestOrder;
+  responses: AoeQuestionResponses;
+  hasAttemptedSubmit: boolean;
+  onResponseChange: (responses: AoeQuestionResponses) => void;
+}
+
+export const HepatitisCAoeForm = ({
+  testOrder,
+  responses,
+  hasAttemptedSubmit,
+  onResponseChange,
+}: HepatitisCAoeFormProps) => {
+  const { onHasAnySymptomsChange, onSymptomOnsetDateChange, onSymptomsChange } =
+    generateAoeListenerHooks(onResponseChange, responses);
+
+  const {
+    showSymptomsError,
+    showSymptomOnsetDateError,
+    hasSymptoms,
+    showSymptomSelectionError,
+    symptoms,
+  } = generateSymptomAoeConstants(
+    responses,
+    hasAttemptedSubmit,
+    hepatitisCSymptomDefinitions
+  );
+
+  const CHECKBOX_COLS_TO_DISPLAY = 3;
+  return (
+    <div
+      className="grid-col"
+      id={`hepatitis-c-aoe-form-${testOrder.patient.internalId}`}
+    >
+      <div className="grid-row">
+        <div className="grid-col-12 desktop:grid-col-6">
+          <GenderOfSexualPartnersAoe
+            testOrderId={testOrder.internalId}
+            responses={responses}
+            hasAttemptedSubmit={hasAttemptedSubmit}
+            onResponseChange={onResponseChange}
+            required
+          />
+        </div>
+      </div>
+      <div className="grid-row">
+        <div className="grid-col-auto">
+          <PregnancyAoe
+            testOrderId={testOrder.internalId}
+            responses={responses}
+            hasAttemptedSubmit={hasAttemptedSubmit}
+            onResponseChange={onResponseChange}
+            required
+          />
+        </div>
+      </div>
+      <div className="grid-row">
+        <div className="grid-col-12">
+          <YesNoRadioGroup
+            name={`has-any-symptoms-${testOrder.internalId}`}
+            legend="Is the patient currently experiencing or showing signs of symptoms?"
+            value={hasSymptoms}
+            onChange={onHasAnySymptomsChange}
+            required
+            validationStatus={showSymptomsError ? "error" : undefined}
+            errorMessage={
+              showSymptomsError && "Please answer this required question."
+            }
+          />
+        </div>
+      </div>
+      {hasSymptoms === "YES" && (
+        <div className={"grid-row grid-gap width-full"}>
+          <div className={"grid-col-12 desktop:grid-col-9 padding-right-0"}>
+            <Checkboxes
+              boxes={hepatitisCSymptomDefinitions.map(({ label, value }) => ({
+                label,
+                value,
+                checked: symptoms[value],
+              }))}
+              legend="Select any symptoms the patient is experiencing"
+              name={`symptoms-${testOrder.internalId}`}
+              onChange={(e) => onSymptomsChange(e, symptoms)}
+              numColumnsToDisplay={CHECKBOX_COLS_TO_DISPLAY}
+              validationStatus={showSymptomSelectionError ? "error" : undefined}
+              errorMessage={
+                showSymptomSelectionError
+                  ? "Please answer this required question."
+                  : ""
+              }
+            />
+          </div>
+
+          <TextInput
+            data-testid="symptom-date"
+            name={`symptom-date-${testOrder.internalId}`}
+            type="date"
+            label="Date of symptom onset"
+            aria-label="Symptom onset date"
+            className={""}
+            min={formatDate(new Date("Jan 1, 2020"))}
+            max={formatDate(moment().toDate())}
+            required
+            value={
+              responses.symptomOnset
+                ? formatDate(
+                    moment(responses.symptomOnset).format("YYYY-MM-DD")
+                  )
+                : ""
+            }
+            onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
+            validationStatus={showSymptomOnsetDateError ? "error" : undefined}
+            errorMessage={
+              showSymptomOnsetDateError &&
+              "Please answer this required question."
+            }
+          ></TextInput>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/SyphilisAoEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/SyphilisAoEForm.tsx
@@ -75,7 +75,7 @@ export const SyphilisAoEForm = ({
       id={`syphillis-aoe-form-${testOrder.patient.internalId}`}
     >
       <div className="grid-row">
-        <div className="grid-col-12 desktop:grid-col-6">
+        <div className="grid-col-auto">
           <MultiSelect
             name={`sexual-partner-gender-${testOrder.internalId}`}
             options={GENDER_IDENTITY_VALUES}
@@ -149,7 +149,7 @@ export const SyphilisAoEForm = ({
       </div>
       {hasSymptoms === "YES" && (
         <div className={"grid-row grid-gap width-full"}>
-          <div className={"grid-col-12 desktop:grid-col-9 padding-right-0"}>
+          <div className={"grid-col-auto"}>
             <Checkboxes
               boxes={syphilisSymptomDefinitions.map(({ label, value }) => ({
                 label,
@@ -168,31 +168,32 @@ export const SyphilisAoEForm = ({
               }
             />
           </div>
-
-          <TextInput
-            data-testid="symptom-date"
-            name={`symptom-date-${testOrder.internalId}`}
-            type="date"
-            required
-            label="Date of symptom onset"
-            aria-label="Symptom onset date"
-            className={""}
-            min={formatDate(new Date("Jan 1, 2020"))}
-            max={formatDate(moment().toDate())}
-            value={
-              responses.symptomOnset
-                ? formatDate(
-                    moment(responses.symptomOnset).format("YYYY-MM-DD")
-                  )
-                : ""
-            }
-            onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
-            validationStatus={showSymptomOnsetDateError ? "error" : undefined}
-            errorMessage={
-              showSymptomOnsetDateError &&
-              "Please answer this required question."
-            }
-          ></TextInput>
+          <div className="grid-col-auto">
+            <TextInput
+              data-testid="symptom-date"
+              name={`symptom-date-${testOrder.internalId}`}
+              type="date"
+              required
+              label="Date of symptom onset"
+              aria-label="Symptom onset date"
+              className={""}
+              min={formatDate(new Date("Jan 1, 2020"))}
+              max={formatDate(moment().toDate())}
+              value={
+                responses.symptomOnset
+                  ? formatDate(
+                      moment(responses.symptomOnset).format("YYYY-MM-DD")
+                    )
+                  : ""
+              }
+              onChange={(e) => onSymptomOnsetDateChange(e.target.value)}
+              validationStatus={showSymptomOnsetDateError ? "error" : undefined}
+              errorMessage={
+                showSymptomOnsetDateError &&
+                "Please answer this required question."
+              }
+            ></TextInput>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeQuestionComponents/GenderOfSexualPartnersAoe.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeQuestionComponents/GenderOfSexualPartnersAoe.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import { SensitiveTopicsTooltipModal } from "../SensitiveTopicsTooltipModal";
+import MultiSelect from "../../../../commonComponents/MultiSelect/MultiSelect";
+import { GENDER_IDENTITY_VALUES } from "../../../../constants";
+import { AoeQuestionProps } from "../aoeUtils";
+
+export const GenderOfSexualPartnersAoe = ({
+  testOrderId,
+  responses,
+  hasAttemptedSubmit,
+  onResponseChange,
+  required = false,
+}: AoeQuestionProps) => {
+  const onSexualPartnerGenderChange = (selectedItems: string[]) => {
+    onResponseChange({
+      ...responses,
+      genderOfSexualPartners: selectedItems,
+    });
+  };
+  const selectedGenders: string[] = [];
+  responses.genderOfSexualPartners?.forEach((g) => {
+    if (g) {
+      selectedGenders.push(g);
+    }
+  });
+  const isGenderOfSexualPartnersAnswered =
+    !!responses.genderOfSexualPartners &&
+    responses.genderOfSexualPartners.length > 0;
+  const showGenderOfSexualPartnersError =
+    hasAttemptedSubmit && !isGenderOfSexualPartnersAnswered;
+
+  return (
+    <MultiSelect
+      name={`sexual-partner-gender-${testOrderId}`}
+      options={GENDER_IDENTITY_VALUES}
+      onChange={onSexualPartnerGenderChange}
+      initialSelectedValues={selectedGenders}
+      label={
+        <>
+          What is the gender of their sexual partners?{" "}
+          <span className={"text-base-dark"}>(Select all that apply.)</span>
+        </>
+      }
+      required={required}
+      hintText={<SensitiveTopicsTooltipModal showSyphilis={false} />}
+      hintTextClassName={""}
+      validationStatus={showGenderOfSexualPartnersError ? "error" : undefined}
+      errorMessage={
+        showGenderOfSexualPartnersError &&
+        "Please answer this required question."
+      }
+    />
+  );
+};

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeQuestionComponents/PregnancyAoe.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeQuestionComponents/PregnancyAoe.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+import RadioGroup from "../../../../commonComponents/RadioGroup";
+import {
+  getPregnancyResponses,
+  PregnancyCode,
+} from "../../../../../patientApp/timeOfTest/constants";
+import { AoeQuestionProps } from "../aoeUtils";
+
+const pregnancyResponses = getPregnancyResponses();
+
+export const PregnancyAoe = ({
+  testOrderId,
+  responses,
+  hasAttemptedSubmit,
+  onResponseChange,
+  required = false,
+}: AoeQuestionProps) => {
+  const onPregnancyChange = (pregnancyCode: PregnancyCode) => {
+    onResponseChange({ ...responses, pregnancy: pregnancyCode });
+  };
+  const isPregnancyFilled = !!responses.pregnancy;
+  const showPregnancyError = hasAttemptedSubmit && !isPregnancyFilled;
+
+  return (
+    <RadioGroup
+      legend="Is the patient pregnant?"
+      name={`pregnancy-${testOrderId}`}
+      onChange={onPregnancyChange}
+      buttons={pregnancyResponses}
+      selectedRadio={responses.pregnancy}
+      required={required}
+      validationStatus={showPregnancyError ? "error" : undefined}
+      errorMessage={
+        showPregnancyError && "Please answer this required question."
+      }
+    />
+  );
+};

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
@@ -1,4 +1,6 @@
 import {
+  hepatitisCSymptomDefinitions,
+  hepatitisCSymptomOrder,
   respiratorySymptomDefinitions,
   respiratorySymptomOrder,
 } from "../../../../patientApp/timeOfTest/constants";
@@ -14,6 +16,17 @@ describe("mapSymptomBoolLiteralsToBool", () => {
       respiratorySymptomDefinitions
     );
     respiratorySymptomOrder.forEach((symptomKey) => {
+      expect(parsedPayload[symptomKey]).toEqual(false);
+    });
+  });
+  it("takes a JSON payload of {'Hepatitis C symptom SNOMEDS' : boolean strings} and parses the strings into booleans", () => {
+    const hepatitisCSymptomPayload =
+      '{"225549006":false,"110292000":false,"249497008":false,"271681002":false,"386661006":false,"39575007":false,"271863002":false,"57676002":false,"224960004":false}\n';
+    const parsedPayload = mapSymptomBoolLiteralsToBool(
+      hepatitisCSymptomPayload,
+      hepatitisCSymptomDefinitions
+    );
+    hepatitisCSymptomOrder.forEach((symptomKey) => {
       expect(parsedPayload[symptomKey]).toEqual(false);
     });
   });

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -4,6 +4,8 @@ import _ from "lodash";
 
 import { AoeQuestionResponses } from "../TestCardFormReducer";
 import {
+  hepatitisCSymptomDefinitions,
+  hepatitisCSymptomsMap,
   PregnancyCode,
   respiratorySymptomDefinitions,
   respiratorySymptomsMap,
@@ -13,6 +15,14 @@ import {
   syphilisSymptomsMap,
 } from "../../../../patientApp/timeOfTest/constants";
 import { AOEFormOption } from "../TestCardForm.utils";
+
+export interface AoeQuestionProps {
+  testOrderId: string;
+  responses: AoeQuestionResponses;
+  onResponseChange: (responses: AoeQuestionResponses) => void;
+  hasAttemptedSubmit: boolean;
+  required?: boolean;
+}
 
 export function generateAoeListenerHooks(
   onResponseChange: (responses: AoeQuestionResponses) => void,
@@ -167,6 +177,11 @@ export function stringifySymptomJsonForAoeUpdate(
       mapSymptomBoolLiteralsToBool(symptomJson, syphilisSymptomDefinitions)
     );
   }
+  if (_.isEqual(symptomKeys, Object.keys(hepatitisCSymptomsMap))) {
+    symptomPayload = JSON.stringify(
+      mapSymptomBoolLiteralsToBool(symptomJson, hepatitisCSymptomDefinitions)
+    );
+  }
   return symptomPayload;
 }
 
@@ -180,6 +195,9 @@ export function mapSpecifiedSymptomBoolLiteralsToBool(
   }
   if (disease === AOEFormOption.SYPHILIS) {
     symptomDefinitionToParse = syphilisSymptomDefinitions;
+  }
+  if (disease === AOEFormOption.HEPATITIS_C) {
+    symptomDefinitionToParse = hepatitisCSymptomDefinitions;
   }
   // there are no symptoms for that test card, so return true
   if (!symptomDefinitionToParse) return { shouldReturn: true };

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -652,7 +652,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap"
+                        class="grid-row grid-gap "
                         data-testid="symptom-date"
                       >
                         <div
@@ -678,14 +678,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap margin-left-0 "
+                        class="grid-row grid-gap "
                         data-testid="symptom-selection-abc"
                       >
                         <div
                           class="usa-form-group"
                         >
                           <fieldset
-                            class="usa-fieldset prime-checkboxes padding-left-0"
+                            class="usa-fieldset prime-checkboxes"
                           >
                             <legend
                               class="usa-legend"
@@ -1672,7 +1672,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap"
+                        class="grid-row grid-gap "
                         data-testid="symptom-date"
                       >
                         <div
@@ -1698,14 +1698,14 @@ exports[`TestQueue should render the test queue 1`] = `
                         </div>
                       </div>
                       <div
-                        class="grid-row grid-gap margin-left-0 "
+                        class="grid-row grid-gap "
                         data-testid="symptom-selection-def"
                       >
                         <div
                           class="usa-form-group"
                         >
                           <fieldset
-                            class="usa-fieldset prime-checkboxes padding-left-0"
+                            class="usa-fieldset prime-checkboxes"
                           >
                             <legend
                               class="usa-legend"

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -682,7 +682,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         data-testid="symptom-selection-abc"
                       >
                         <div
-                          class="usa-form-group padding-0"
+                          class="usa-form-group"
                         >
                           <fieldset
                             class="usa-fieldset prime-checkboxes padding-left-0"
@@ -1702,7 +1702,7 @@ exports[`TestQueue should render the test queue 1`] = `
                         data-testid="symptom-selection-def"
                       >
                         <div
-                          class="usa-form-group padding-0"
+                          class="usa-form-group"
                         >
                           <fieldset
                             class="usa-fieldset prime-checkboxes padding-left-0"

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -44,6 +44,7 @@ export const device5Name = "MultiplexAndCovidOnly";
 export const device6Name = "FluOnly";
 export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
+export const device9Name = "Hepatitis-C device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -53,6 +54,7 @@ export const device5Id = "DEVICE-5-ID";
 export const device6Id = "DEVICE-6-ID";
 export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
+export const device9Id = "DEVICE-9-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -30,6 +30,8 @@ export const hivDeviceId = "HIV-DEVICE-ID";
 export const FACILITY_INFO_TEST_ID = "f02cfff5-1921-4293-beff-e2a5d03e1fda";
 export const syphilisDeviceName = "SYPHILIS";
 export const syphilisDeviceId = "SYPHILIS-DEVICE-ID";
+export const hepatitisCDeviceName = "HEPATITIS-C";
+export const hepatitisCDeviceId = "HEPATITIS-C-DEVICE-ID";
 
 // 6 instead of 7 because HIV devices are filtered out when HIV feature flag is disabled
 export const DEFAULT_DEVICE_OPTIONS_LENGTH = 6;

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -497,7 +497,7 @@ export const updateAoeMocks = [
 ];
 
 // Syphilis card
-const baseSyphilisAoeUpdateMock = (
+export const baseStiAoeUpdateMock = (
   variableOverrides?: Partial<UpdateAoeMutationVariables>
 ) => {
   return {
@@ -509,13 +509,13 @@ const baseSyphilisAoeUpdateMock = (
   };
 };
 const yesSyphilisHistoryMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...SYPHILIS_HISTORY_OVERRIDE,
   }),
 };
 
 const yesSyphilisHistoryPregnancyMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...SYPHILIS_HISTORY_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
   }),
@@ -523,7 +523,7 @@ const yesSyphilisHistoryPregnancyMock = {
 };
 
 const yesSyphilisHistoryPregnancyFemaleSexPartnerMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...SYPHILIS_HISTORY_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...GENDER_SEXUAL_PARTNERS_FEMALE_OVERRIDE,
@@ -532,7 +532,7 @@ const yesSyphilisHistoryPregnancyFemaleSexPartnerMock = {
 };
 
 const falseNoSymptomOnsetDateBlankSymptomsAndYesSyphilisAoeMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...NO_SYMPTOMS_FALSE_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...SYPHILIS_HISTORY_OVERRIDE,
@@ -542,7 +542,7 @@ const falseNoSymptomOnsetDateBlankSymptomsAndYesSyphilisAoeMock = {
 };
 
 const falseNoSymptomBlurredVisionMockAndYesSyphilisAoeMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...NO_SYMPTOMS_FALSE_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...SYPHILIS_HISTORY_OVERRIDE,
@@ -553,7 +553,7 @@ const falseNoSymptomBlurredVisionMockAndYesSyphilisAoeMock = {
 };
 
 const falseNoSymptomBlurredVisionOnsetDateAndYesSyphilisAoeMock = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...NO_SYMPTOMS_FALSE_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...SYPHILIS_HISTORY_OVERRIDE,
@@ -565,7 +565,7 @@ const falseNoSymptomBlurredVisionOnsetDateAndYesSyphilisAoeMock = {
 };
 
 const noSymptomsTrueSymptomsBlankSyphilisHistory = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...NO_SYMPTOMS_TRUE_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...SYPHILIS_HISTORY_OVERRIDE,
@@ -574,7 +574,7 @@ const noSymptomsTrueSymptomsBlankSyphilisHistory = {
 };
 
 const noSymptomsTrueSymptomsBlankSyphilisFemaleHistory = {
-  ...baseSyphilisAoeUpdateMock({
+  ...baseStiAoeUpdateMock({
     ...NO_SYMPTOMS_TRUE_OVERRIDE,
     ...PREGNANCY_OVERRIDE,
     ...SYPHILIS_HISTORY_OVERRIDE,
@@ -609,6 +609,49 @@ export const updateSyphilisAoeMocks = [
   falseNoSymptomOnsetDateBlankSymptomsAndYesSyphilisAoeMock,
   noSymptomsTrueSymptomsBlankSyphilisHistory,
   noSymptomsTrueSymptomsBlankSyphilisFemaleHistory,
+];
+
+export const updateHepCAoeMocks = [
+  blankUpdateAoeEventMock,
+  generateEditQueueMock(MULTIPLEX_DISEASES.HEPATITIS_C, TEST_RESULTS.POSITIVE, {
+    device: {
+      deviceId: "DEVICE-9-ID",
+    },
+    specimen: {
+      specimenId: "SPECIMEN-3-ID",
+    },
+  }),
+  generateSubmitQueueMock(
+    MULTIPLEX_DISEASES.HEPATITIS_C,
+    TEST_RESULTS.POSITIVE,
+    {
+      device: {
+        deviceId: "DEVICE-9-ID",
+      },
+      specimen: {
+        specimenId: "SPECIMEN-3-ID",
+      },
+    }
+  ),
+  {
+    ...baseStiAoeUpdateMock({ ...PREGNANCY_OVERRIDE }),
+    ...mutationResponse,
+  },
+  {
+    ...baseStiAoeUpdateMock({
+      ...NO_SYMPTOMS_TRUE_OVERRIDE,
+      ...PREGNANCY_OVERRIDE,
+    }),
+    ...mutationResponse,
+  },
+  {
+    ...baseStiAoeUpdateMock({
+      ...GENDER_SEXUAL_PARTNERS_FEMALE_OVERRIDE,
+      ...NO_SYMPTOMS_TRUE_OVERRIDE,
+      ...PREGNANCY_OVERRIDE,
+    }),
+    ...mutationResponse,
+  },
 ];
 
 type EditQueueMockParams = {

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -6,6 +6,7 @@ export enum MULTIPLEX_DISEASES {
   HIV = "HIV",
   SYPHILIS = "Syphilis",
   FLU_A_AND_B = "Flu A and B",
+  HEPATITIS_C = "Hepatitis-C",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -12,6 +12,12 @@ export const useSupportedDiseaseList = () => {
   if (!syphilisEnabled) {
     allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.SYPHILIS);
   }
+  const hepatitisCEnabled = Boolean(useFeature("hepatitisCEnabled"));
+  if (!hepatitisCEnabled) {
+    allDiseases = allDiseases.filter(
+      (d) => d !== MULTIPLEX_DISEASES.HEPATITIS_C
+    );
+  }
   return allDiseases;
 };
 

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -132,14 +132,43 @@ export const syphilisSymptomDefinitions: SymptomDefinitionMap[] =
     label: syphilisSymptomsMap[value],
   }));
 
+export const hepatitisCSymptomsMap = {
+  "225549006": "Yellow skin or eyes",
+  "110292000": "Not wanting to eat",
+  "249497008": "Throwing up",
+  "271681002": "Stomach pain or upset stomach",
+  "386661006": "Fever",
+  "39575007": "Dark urine",
+  "271863002": "Light-colored stool",
+  "57676002": "Joint pain",
+  "224960004": "Feeling tired",
+} as const;
+
+export type HepatitisCSymptoms = typeof hepatitisCSymptomsMap;
+export type HepatitisCSymptomCode = keyof HepatitisCSymptoms;
+export type HepatitisCSymptomName = HepatitisCSymptoms[HepatitisCSymptomCode];
+
+const hepatitisCSymptomOrder: HepatitisCSymptomCode[] =
+  alphabetizeSymptomKeysFromMapValues(hepatitisCSymptomsMap);
+
+export const hepatitisCSymptomDefinitions: SymptomDefinitionMap[] =
+  hepatitisCSymptomOrder.map((value) => ({
+    value,
+    label: hepatitisCSymptomsMap[value],
+  }));
+
 export const SYMPTOM_SUBQUESTION_ERROR =
   "This question is required if the patient has symptoms.";
 export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";
 
 export type AllSymptomsCode = keyof RespiratorySymptoms &
-  keyof SyphilisSymptoms;
-export type AllSymptomsName = RespiratorySymptomName & SyphilisSymptomName;
+  keyof SyphilisSymptoms &
+  keyof HepatitisCSymptoms;
+export type AllSymptomsName = RespiratorySymptomName &
+  SyphilisSymptomName &
+  HepatitisCSymptomName;
 export const allSymptomsMap = {
   ...syphilisSymptomsMap,
   ...respiratorySymptomsMap,
+  ...hepatitisCSymptomsMap,
 };

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -148,7 +148,7 @@ export type HepatitisCSymptoms = typeof hepatitisCSymptomsMap;
 export type HepatitisCSymptomCode = keyof HepatitisCSymptoms;
 export type HepatitisCSymptomName = HepatitisCSymptoms[HepatitisCSymptomCode];
 
-const hepatitisCSymptomOrder: HepatitisCSymptomCode[] =
+export const hepatitisCSymptomOrder: HepatitisCSymptomCode[] =
   alphabetizeSymptomKeysFromMapValues(hepatitisCSymptomsMap);
 
 export const hepatitisCSymptomDefinitions: SymptomDefinitionMap[] =


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7433 

## Changes Proposed

- Adds support for Hepatitis-C to test card
- AOE questions become required for positive results
- Creates reusable AOE components like a common `PregnancyAoe` question component or `GenderOfSexualPartnersAoe` question component, so that future diseases (and previous diseases if we'd like) can have their own disease specific AOE forms more easily composed with existing AOE questions

## Additional Information

- Follow up PR will add sample data once accurate data can be confirmed
- Follow up PR will clean up how we use the SensitiveTopicsTooltipModal so it can be configured on the disease AOE form level
- Should be merged after #8223 
- [x] Approved by design
- [x] Approved by product

## Testing

- Deployed on dev4
- Hepatitis C device added for org `1679607649-Blanda - Stanton` and facility `KY Test renamed`

## Screenshots / Demos

![Screenshot 2024-10-23 120117](https://github.com/user-attachments/assets/e3455140-2563-48b4-8be5-fbc91fe15e9d)
![Screenshot 2024-10-23 120123](https://github.com/user-attachments/assets/50188926-c1f1-46d7-8500-c0ea38488ce8)