### PR TITLE
Results page and PXP support for Hepatitis C

### DIFF
--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
@@ -1,40 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { cloneDeep } from "lodash";
 
 import "../../../i18n";
-
-import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 
 import HepatitisCResultGuidance from "./HepatitisCResultGuidance";
 
 describe("HepatitisCResultGuidance", () => {
-  const mockResultTemplate = {
-    disease: {
-      name: MULTIPLEX_DISEASES.HEPATITIS_C,
-    },
-    testResult: TEST_RESULTS.POSITIVE,
-  } as MultiplexResult;
-
-  it("displays guidance for a positive Hepatitis-C result", () => {
-    const { container } = render(
-      <HepatitisCResultGuidance result={mockResultTemplate} />
-    );
+  it("displays guidance for a Hepatitis-C result", () => {
+    const { container } = render(<HepatitisCResultGuidance />);
+    expect(screen.getByText("For Hepatitis-C:")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
-
-  const nonPositiveCases = [
-    TEST_RESULTS.NEGATIVE,
-    TEST_RESULTS.UNDETERMINED,
-    TEST_RESULTS.UNKNOWN,
-  ];
-
-  test.each(nonPositiveCases)(
-    "displays no Hepatitis-C guidance for %p result",
-    (testResult) => {
-      const mockResult = cloneDeep(mockResultTemplate);
-      mockResult.testResult = testResult;
-      render(<HepatitisCResultGuidance result={mockResult} />);
-      expect(screen.queryByText("For Hepatitis-C:")).not.toBeInTheDocument();
-    }
-  );
 });

--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { cloneDeep } from "lodash";
+
+import "../../../i18n";
+
+import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
+
+import HepatitisCResultGuidance from "./HepatitisCResultGuidance";
+
+describe("HepatitisCResultGuidance", () => {
+  const mockResultTemplate = {
+    disease: {
+      name: MULTIPLEX_DISEASES.HEPATITIS_C,
+    },
+    testResult: TEST_RESULTS.POSITIVE,
+  } as MultiplexResult;
+
+  it("displays guidance for a positive Hepatitis-C result", () => {
+    const { container } = render(
+      <HepatitisCResultGuidance result={mockResultTemplate} />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  const nonPositiveCases = [
+    TEST_RESULTS.NEGATIVE,
+    TEST_RESULTS.UNDETERMINED,
+    TEST_RESULTS.UNKNOWN,
+  ];
+
+  test.each(nonPositiveCases)(
+    "displays no Hepatitis-C guidance for %p result",
+    (testResult) => {
+      const mockResult = cloneDeep(mockResultTemplate);
+      mockResult.testResult = testResult;
+      render(<HepatitisCResultGuidance result={mockResult} />);
+      expect(screen.queryByText("For Hepatitis-C:")).not.toBeInTheDocument();
+    }
+  );
+});

--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 
-import { TEST_RESULTS } from "../../testResults/constants";
-
-import { ResultGuidanceProps } from "./ResultsGuidance";
-
-const PositiveHepatitisCResultInfo = () => {
+const HepatitisCResultGuidance = () => {
   const { t } = useTranslation();
 
   return (
@@ -30,12 +26,6 @@ const PositiveHepatitisCResultInfo = () => {
       />
     </>
   );
-};
-
-const HepatitisCResultGuidance = ({ result }: ResultGuidanceProps) => {
-  const hasPositiveHepatitisCResult =
-    result.testResult === TEST_RESULTS.POSITIVE;
-  return <>{hasPositiveHepatitisCResult && <PositiveHepatitisCResultInfo />}</>;
 };
 
 export default HepatitisCResultGuidance;

--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+
+import { TEST_RESULTS } from "../../testResults/constants";
+
+import { ResultGuidanceProps } from "./ResultsGuidance";
+
+const PositiveHepatitisCResultInfo = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p className="text-bold sr-guidance-heading">
+        {t("testResult.hepatitisCNotes.h1")}
+      </p>
+      <p>{t("testResult.hepatitisCNotes.positive.p0")}</p>
+      <Trans
+        parent="p"
+        i18nKey="testResult.hepatitisCNotes.positive.p1"
+        components={[
+          <a
+            href={t("testResult.hepatitisCNotes.positive.treatmentLink")}
+            target="_blank"
+            rel="noopener noreferrer"
+            key="hepatitis-c-treatment-link"
+          >
+            hepatitis-c treatment link
+          </a>,
+        ]}
+      />
+    </>
+  );
+};
+
+const HepatitisCResultGuidance = ({ result }: ResultGuidanceProps) => {
+  const hasPositiveHepatitisCResult =
+    result.testResult === TEST_RESULTS.POSITIVE;
+  return <>{hasPositiveHepatitisCResult && <PositiveHepatitisCResultInfo />}</>;
+};
+
+export default HepatitisCResultGuidance;

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HepatitisCResultGuidance displays guidance for a positive Hepatitis-C result 1`] = `
+exports[`HepatitisCResultGuidance displays guidance for a Hepatitis-C result 1`] = `
 <div>
   <p
     class="text-bold sr-guidance-heading"

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`HepatitisCResultGuidance displays guidance for a Hepatitis-C result 1`]
       rel="noopener noreferrer"
       target="_blank"
     >
-      Visit the CDC website to learn more about a positive Hepatitis-C result.
+      Visit the CDC website to learn more about a positive Hepatitis-C result
     </a>
      (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).
   </p>

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HepatitisCResultGuidance displays guidance for a positive Hepatitis-C result 1`] = `
+<div>
+  <p
+    class="text-bold sr-guidance-heading"
+  >
+    For Hepatitis-C:
+  </p>
+  <p>
+    If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.
+  </p>
+  <p>
+    <a
+      href="https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Visit the CDC website to learn more about a positive Hepatitis-C result.
+    </a>
+     (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).
+  </p>
+</div>
+`;

--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -50,6 +50,10 @@ const setDiseaseResultKey = (diseaseName: MultiplexDisease, isPxp: boolean) => {
       return isPxp
         ? "constants.diseaseResultTitle.SYPHILIS"
         : "constants.disease.SYPHILIS";
+    case MULTIPLEX_DISEASES.HEPATITIS_C:
+      return isPxp
+        ? "constants.diseaseResultTitle.HEPATITIS_C"
+        : "constants.disease.HEPATITIS_C";
     default:
       return null;
   }

--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -8,55 +8,41 @@ interface TestResultsListProps {
   results: MultiplexResults;
   isPatientApp: boolean;
 }
+
 const setDiseaseResultTitle = (
-  diseaseName: MultiplexDisease,
+  diseaseName: MULTIPLEX_DISEASES,
   t: translateFn,
   isPxp: boolean
 ) => {
-  const translationKey = setDiseaseResultKey(diseaseName, isPxp);
+  const translationKey = isPxp
+    ? diseaseResultTitlePxpMap[diseaseName]
+    : diseaseResultReportingAppMap[diseaseName];
   if (translationKey) {
     return t(translationKey);
   }
   return "";
 };
 
-const setDiseaseResultKey = (diseaseName: MultiplexDisease, isPxp: boolean) => {
-  switch (diseaseName) {
-    case MULTIPLEX_DISEASES.COVID_19:
-      return isPxp
-        ? "constants.diseaseResultTitle.COVID19"
-        : "constants.disease.COVID19";
-    case MULTIPLEX_DISEASES.FLU_A:
-      return isPxp
-        ? "constants.diseaseResultTitle.FLUA"
-        : "constants.disease.FLUA";
-    case MULTIPLEX_DISEASES.FLU_B:
-      return isPxp
-        ? "constants.diseaseResultTitle.FLUB"
-        : "constants.disease.FLUB";
-    case MULTIPLEX_DISEASES.FLU_A_AND_B:
-      return isPxp
-        ? "constants.diseaseResultTitle.FLUAB"
-        : "constants.disease.FLUAB";
-    case MULTIPLEX_DISEASES.HIV:
-      return isPxp
-        ? "constants.diseaseResultTitle.HIV"
-        : "constants.disease.HIV";
-    case MULTIPLEX_DISEASES.RSV:
-      return isPxp
-        ? "constants.diseaseResultTitle.RSV"
-        : "constants.disease.RSV";
-    case MULTIPLEX_DISEASES.SYPHILIS:
-      return isPxp
-        ? "constants.diseaseResultTitle.SYPHILIS"
-        : "constants.disease.SYPHILIS";
-    case MULTIPLEX_DISEASES.HEPATITIS_C:
-      return isPxp
-        ? "constants.diseaseResultTitle.HEPATITIS_C"
-        : "constants.disease.HEPATITIS_C";
-    default:
-      return null;
-  }
+const diseaseResultTitlePxpMap: Record<MULTIPLEX_DISEASES, string> = {
+  [MULTIPLEX_DISEASES.COVID_19]: "constants.diseaseResultTitle.COVID19",
+  [MULTIPLEX_DISEASES.FLU_A]: "constants.diseaseResultTitle.FLUA",
+  [MULTIPLEX_DISEASES.FLU_B]: "constants.diseaseResultTitle.FLUB",
+  [MULTIPLEX_DISEASES.FLU_A_AND_B]: "constants.diseaseResultTitle.FLUAB",
+  [MULTIPLEX_DISEASES.HIV]: "constants.diseaseResultTitle.HIV",
+  [MULTIPLEX_DISEASES.RSV]: "constants.diseaseResultTitle.RSV",
+  [MULTIPLEX_DISEASES.SYPHILIS]: "constants.diseaseResultTitle.SYPHILIS",
+  [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.diseaseResultTitle.HEPATITIS_C",
+};
+
+const diseaseResultReportingAppMap: Record<MULTIPLEX_DISEASES, string> = {
+  [MULTIPLEX_DISEASES.COVID_19]: "constants.disease.COVID19",
+  [MULTIPLEX_DISEASES.FLU_A]: "constants.disease.FLUA",
+  [MULTIPLEX_DISEASES.FLU_B]: "constants.disease.FLUB",
+  [MULTIPLEX_DISEASES.FLU_A_AND_B]: "constants.disease.FLUAB",
+  [MULTIPLEX_DISEASES.HIV]: "constants.disease.HIV",
+  [MULTIPLEX_DISEASES.RSV]: "constants.disease.RSV",
+  [MULTIPLEX_DISEASES.SYPHILIS]: "constants.disease.SYPHILIS",
+  [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.disease.HEPATITIS_C",
 };
 
 const setResult = (result: string, t: translateFn) => {
@@ -82,7 +68,7 @@ const setResultSymbol = (result: string, t: translateFn) => {
 };
 
 const reportingAppResultListItem = (
-  diseaseName: MultiplexDisease,
+  diseaseName: MULTIPLEX_DISEASES,
   result: TestResult,
   t: translateFn
 ) => {
@@ -103,7 +89,7 @@ const reportingAppResultListItem = (
 };
 
 const pxpAppResultListItem = (
-  diseaseName: MultiplexDisease,
+  diseaseName: MULTIPLEX_DISEASES,
   result: TestResult,
   t: translateFn
 ) => {

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -85,18 +85,11 @@ jest.mock("../../TelemetryService", () => ({
   getAppInsights: jest.fn(),
 }));
 
-const mockDiseaseEnabledFlag = (
-  diseaseName: string,
-  skipLowercase: boolean = false
-) =>
+const mockDiseaseEnabledFlag = (diseaseName: string) =>
   jest
     .spyOn(flaggedMock, "useFeature")
     .mockImplementation((flagName: string) => {
-      // to handle casing of Hepatitis-C as hepatitisC
-      if (skipLowercase) {
-        return flagName === `${diseaseName}Enabled`;
-      }
-      return flagName === `${diseaseName.toLowerCase()}Enabled`;
+      return flagName === `${diseaseName}Enabled`;
     });
 
 const mockNavigate = jest.fn();
@@ -1132,7 +1125,7 @@ describe("TestCard", () => {
     });
 
     it("shows radio buttons for HIV when an HIV device is chosen", async function () {
-      mockDiseaseEnabledFlag("HIV");
+      mockDiseaseEnabledFlag("hiv");
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.POSITIVE),
@@ -1152,7 +1145,7 @@ describe("TestCard", () => {
     });
 
     it("shows required HIV AOE questions when a positive HIV result is present", async function () {
-      mockDiseaseEnabledFlag("HIV");
+      mockDiseaseEnabledFlag("hiv");
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.POSITIVE),
@@ -1182,7 +1175,7 @@ describe("TestCard", () => {
     });
 
     it("hides AOE questions when there is no positive HIV result", async function () {
-      mockDiseaseEnabledFlag("HIV");
+      mockDiseaseEnabledFlag("hiv");
 
       const mocks = [
         generateEditQueueMock(MULTIPLEX_DISEASES.HIV, TEST_RESULTS.UNKNOWN),
@@ -1209,7 +1202,7 @@ describe("TestCard", () => {
     });
 
     it("shows radio buttons for Syphilis when a syphilis device is chosen", async function () {
-      mockDiseaseEnabledFlag("Syphilis");
+      mockDiseaseEnabledFlag("syphilis");
 
       const mocks = [
         generateEditQueueMock(
@@ -1229,7 +1222,7 @@ describe("TestCard", () => {
     });
 
     it("shows required syphilis AOE questions when a positive syphilis result is present", async function () {
-      mockDiseaseEnabledFlag("Syphilis");
+      mockDiseaseEnabledFlag("syphilis");
 
       const mocks = [
         generateEditQueueMock(
@@ -1269,7 +1262,7 @@ describe("TestCard", () => {
     });
 
     it("hides AOE questions when there is no positive syphilis result", async function () {
-      mockDiseaseEnabledFlag("Syphilis");
+      mockDiseaseEnabledFlag("syphilis");
 
       const mocks = [
         generateEditQueueMock(
@@ -1325,7 +1318,7 @@ describe("TestCard", () => {
     });
 
     it("shows radio buttons for Hepatitis C when a hepatitis c device is chosen", async function () {
-      mockDiseaseEnabledFlag("hepatitisC", true);
+      mockDiseaseEnabledFlag("hepatitisC");
 
       const mocks = [
         generateEditQueueMock(
@@ -1345,7 +1338,7 @@ describe("TestCard", () => {
     });
 
     it("shows required Hepatitis-C AOE questions when a positive Hepatitis-C result is present", async function () {
-      mockDiseaseEnabledFlag("hepatitisC", true);
+      mockDiseaseEnabledFlag("hepatitisC");
 
       const mocks = [
         generateEditQueueMock(
@@ -1397,7 +1390,7 @@ describe("TestCard", () => {
     });
 
     it("hides AOE questions when there is no positive Hepatitis-C result", async function () {
-      mockDiseaseEnabledFlag("hepatitisC", true);
+      mockDiseaseEnabledFlag("hepatitisC");
 
       const mocks = [
         generateEditQueueMock(
@@ -1443,7 +1436,7 @@ describe("TestCard", () => {
     });
 
     it("checks that Hep C submission only works if AOE questions are valid", async function () {
-      mockDiseaseEnabledFlag("hepatitisC", true);
+      mockDiseaseEnabledFlag("hepatitisC");
 
       const { user } = await renderQueueItem({ mocks: updateHepCAoeMocks });
       const deviceDropdown = await getDeviceTypeDropdown();
@@ -1494,7 +1487,7 @@ describe("TestCard", () => {
     });
 
     it("checks that submission only works if AOE questions are valid", async function () {
-      mockDiseaseEnabledFlag("Syphilis");
+      mockDiseaseEnabledFlag("syphilis");
 
       const { user } = await renderQueueItem({ mocks: updateSyphilisAoeMocks });
       const deviceDropdown = await getDeviceTypeDropdown();
@@ -1556,7 +1549,7 @@ describe("TestCard", () => {
     });
 
     it("checks that checking has symptom requires onset date and selection", async () => {
-      mockDiseaseEnabledFlag("Syphilis");
+      mockDiseaseEnabledFlag("syphilis");
       const mocks = [...updateSyphilisAoeMocks];
 
       const { user } = await renderQueueItem({ mocks });

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
@@ -57,6 +57,12 @@ export const DetachedTestResultDetailsModal = ({
     data?.testResult.results,
     MULTIPLEX_DISEASES.SYPHILIS
   );
+  const isHepatitisCResult = !!getResultForDisease(
+    data?.testResult.results,
+    MULTIPLEX_DISEASES.HEPATITIS_C
+  );
+  const showGenderOfSexualPartners =
+    isHIVResult || isSyphilisResult || isHepatitisCResult;
 
   const dateTested = data?.testResult.dateTested;
 
@@ -188,7 +194,7 @@ export const DetachedTestResultDetailsModal = ({
             removed={removed}
             aria-describedby="result-detail-title"
           />
-          {(isHIVResult || isSyphilisResult) && (
+          {showGenderOfSexualPartners && (
             <DetailsRow
               label="Gender of sexual partners"
               value={formatGenderOfSexualPartnersForDisplay(

--- a/frontend/src/app/utils/testResults.tsx
+++ b/frontend/src/app/utils/testResults.tsx
@@ -5,6 +5,7 @@ import FluResultGuidance from "../commonComponents/TestResultGuidance/FluResultG
 import HivResultGuidance from "../commonComponents/TestResultGuidance/HivResultGuidance";
 import RsvResultGuidance from "../commonComponents/TestResultGuidance/RsvResultGuidance";
 import SyphilisResultGuidance from "../commonComponents/TestResultGuidance/SyphilisResultGuidance";
+import HepatitisCResultGuidance from "../commonComponents/TestResultGuidance/HepatitisCResultGuidance";
 
 export function getResultByDiseaseName(
   results: MultiplexResults,
@@ -98,6 +99,11 @@ export const getGuidanceForResults = (
   match = getResultForDisease(results, MULTIPLEX_DISEASES.SYPHILIS, true);
   if (match) {
     guidance.push(<SyphilisResultGuidance result={match} />);
+  }
+
+  match = getResultForDisease(results, MULTIPLEX_DISEASES.HEPATITIS_C);
+  if (match) {
+    guidance.push(<HepatitisCResultGuidance result={match} />);
   }
 
   return guidance;

--- a/frontend/src/app/utils/testResults.tsx
+++ b/frontend/src/app/utils/testResults.tsx
@@ -103,7 +103,7 @@ export const getGuidanceForResults = (
 
   match = getResultForDisease(results, MULTIPLEX_DISEASES.HEPATITIS_C);
   if (match) {
-    guidance.push(<HepatitisCResultGuidance result={match} />);
+    guidance.push(<HepatitisCResultGuidance />);
   }
 
   return guidance;

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -40,6 +40,7 @@ export const en = {
         RSV: "RSV",
         HIV: "HIV",
         SYPHILIS: "Syphilis",
+        HEPATITIS_C: "Hepatitis-C",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 result",
@@ -49,6 +50,7 @@ export const en = {
         RSV: "RSV result",
         HIV: "HIV result",
         SYPHILIS: "Syphilis result",
+        HEPATITIS_C: "Hepatitis-C result",
       },
       role: {
         STAFF: "Staff",
@@ -418,6 +420,15 @@ export const en = {
           p1: "<0>Visit the CDC website to learn more about a positive Syphilis result</0> (cdc.gov/std/treatment-guidelines/syphilis.htm).",
           treatmentLink:
             "https://www.cdc.gov/std/treatment-guidelines/syphilis.htm",
+        },
+      },
+      hepatitisCNotes: {
+        h1: "For Hepatitis-C:",
+        positive: {
+          p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
+          p1: "<0>Visit the CDC website to learn more about a positive Hepatitis-C result.</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
+          treatmentLink:
+            "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
         },
       },
       tos: {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -426,7 +426,7 @@ export const en = {
         h1: "For Hepatitis-C:",
         positive: {
           p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
-          p1: "<0>Visit the CDC website to learn more about a positive Hepatitis-C result.</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
+          p1: "<0>Visit the CDC website to learn more about a positive Hepatitis-C result</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
           treatmentLink:
             "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
         },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -43,6 +43,7 @@ export const es: LanguageConfig = {
         RSV: "VRS",
         HIV: "VIH",
         SYPHILIS: "Sífilis",
+        HEPATITIS_C: "Hepatitis C",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 resultado",
@@ -52,6 +53,7 @@ export const es: LanguageConfig = {
         RSV: "RSV resultado",
         HIV: "Resultado de la prueba del VIH",
         SYPHILIS: "Sífilis resultado",
+        HEPATITIS_C: "Hepatitis-C resultado",
       },
       role: {
         STAFF: "Personal",
@@ -441,6 +443,15 @@ export const es: LanguageConfig = {
           p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo en la prueba del sífilis</0> (cdc.gov/std/treatment-guidelines/syphilis.htm).",
           treatmentLink:
             "https://www.cdc.gov/std/treatment-guidelines/syphilis.htm",
+        },
+      },
+      hepatitisCNotes: {
+        h1: "Para Hepatitis-C:",
+        positive: {
+          p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
+          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo en la prueba del hepatitis C.</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
+          treatmentLink:
+            "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
         },
       },
       tos: {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7437 and #7441 

## Changes Proposed

- Adds translation constants for showing Hepatitis-C result on Print Details and PXP View Result
- Both English and Spanish translations
- Adds gender of sexual partners response on Hepatitis-C View Details modal

## Additional Information

- Result guidance is shown for **any** Hep C result, not just positives
- Review and merge **after** #8226 

## Testing

- Will be deployed on dev4

## Screenshots / Demos

- Hepatitis-C already available as a selectable condition on Results page
![Screenshot 2024-10-29 105549](https://github.com/user-attachments/assets/e15dc214-f1d2-4ca2-a8dc-3a9270b6e7f5)

- Hepatitis-C already available as a condition in the Download Results spreadsheet
![Screenshot 2024-10-29 105620](https://github.com/user-attachments/assets/b53bca5e-03ef-4de4-ad5d-cb4f56f4cb12)

- Hepatitis-C on Print Details modal
![Screenshot 2024-10-29 105255](https://github.com/user-attachments/assets/5624d42d-11ff-460c-8bf5-20f68715ce03)

- Spanish translations for Hepatitis-C on Print Details modal
![Screenshot 2024-10-29 105302](https://github.com/user-attachments/assets/94fbb05f-c60e-476a-9e96-586e21f6e117)

- Hepatitis-C and AOE responses on View Details modal
![Screenshot 2024-10-29 105448](https://github.com/user-attachments/assets/559428a9-fe82-42dc-a884-75db6dcd6d99)

- Hepatitis-C result on the PXP View Result
![Screenshot 2024-10-29 105232](https://github.com/user-attachments/assets/b3c61525-cdfa-4829-9300-9cbb44f76281)

- Spanish translations for Hepatitis-C result on the PXP View Result
![Screenshot 2024-10-29 105237](https://github.com/user-attachments/assets/75c48fe9-7046-49e5-8a32-eed3f43cc67b)

- Negative Hepatitis-C result with result guidance still shown
![image](https://github.com/user-attachments/assets/4d8a34c5-b29f-4e52-a0f5-d43775b67978)