### PR TITLE
Remove mock resets

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -596,7 +595,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
   private void sendOrgAdminEmailCSVAsyncTest() throws ExecutionException, InterruptedException {
     setupDataByFacility();
     String type = "facilities";
-    reset(emailService);
     when(oktaRepository.getOktaRateLimitSleepMs()).thenReturn(0);
     when(oktaRepository.getOktaOrgsLimit()).thenReturn(1);
 
@@ -607,7 +605,6 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
         List.of("mn-orgBadmin1@example.com", "mn-orgBadmin2@example.com");
     verify(emailService, times(1)).sendWithCSVAttachment(expectedMnEmails, "MN", type);
     assertThat(mnEmails).isEqualTo(expectedMnEmails);
-    reset(emailService);
 
     String njExternalId = "d6b3951b-6698-4ee7-9d63-aaadee85bac0";
     UUID njId = organizationRepository.findByExternalId(njExternalId).get().getInternalId();
@@ -615,13 +612,11 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     List<String> expectedNjEmails = List.of("nj-orgAadmin1@example.com");
     verify(emailService, times(1)).sendWithCSVAttachment(expectedNjEmails, "NJ", type);
     assertThat(njEmails).isEqualTo(expectedNjEmails);
-    reset(emailService);
 
     List<String> nonExistentOrgEmails =
         _service.sendOrgAdminEmailCSVAsync(List.of(), type, "PA").get();
     verify(emailService, times(1)).sendWithCSVAttachment(nonExistentOrgEmails, "PA", type);
     assertThat(nonExistentOrgEmails).isEmpty();
-    reset(emailService);
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Hopefully resolves the flaky backend test (noted [here](https://skylight-hq.slack.com/archives/C064P7MHM47/p1728582684271359?thread_ts=1728520671.559249&cid=C064P7MHM47), and [here](https://github.com/CDCgov/prime-simplereport/actions/runs/11541682979/job/32123973353?pr=8238), and probably a lot of other failures to be linked 😅)
- Thank you @mpbrown for your help! 😸 

## Changes Proposed

- Removes calling [a reset on the `EmailService` mock](https://github.com/CDCgov/prime-simplereport/blob/c65128e7d89d1f848c3d687e4be44ccf1da3ec64/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java#L599) in that test that was failing randomly

## Additional Information

@mpbrown helpfully pointed out this in the [Mockito docs](https://javadoc.io/doc/org.mockito/mockito-core/2.2.17/org/mockito/Mockito.html#resetting_mocks) 😅 👃 

> Don't harm yourself. reset() in the middle of the test method is a code smell (you're probably testing too much).

## Testing
- Reran the ["backend tests" workflow](https://github.com/CDCgov/prime-simplereport/actions/runs/11580565431/job/32241387696) 6 times and they passed 😎 🙏 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
