### PR TITLE
Update how we save and log org claims on whoami calls

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/LoggedInAuthorizationService.java
@@ -56,15 +56,9 @@ public class LoggedInAuthorizationService implements AuthorizationService {
     List<OrganizationRoleClaims> oktaOrgRoleClaims =
         _extractor.convert(currentAuth.getAuthorities());
 
-    if (!isSiteAdmin()) {
+    if (!isSiteAdmin() && _featureFlagsConfig.isOktaMigrationEnabled()) {
       String username = currentAuth.getName();
-      List<OrganizationRoleClaims> dbOrgRoleClaims =
-          _dbOrgRoleClaimsService.getOrganizationRoleClaims(username);
-      _dbOrgRoleClaimsService.checkOrgRoleClaimsEquality(
-          oktaOrgRoleClaims, dbOrgRoleClaims, username);
-      if (_featureFlagsConfig.isOktaMigrationEnabled()) {
-        return dbOrgRoleClaims;
-      }
+      return _dbOrgRoleClaimsService.getOrganizationRoleClaims(username);
     }
     return oktaOrgRoleClaims;
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Fix bug introduced in #8182 
  - Before this fix, users that were not migrated over before the logging was introduced would log the user as having mismatched Okta and DB org roles

## Changes Proposed
- Move the check to the level of the `getCurrentUserInfoForWhoAmI` method
- Remove check happening at the `LoggedInAuthorizationService` level

## Additional Information


## Testing
- deployed on dev3
  - find a user that you can log in as that is not a site admin
  - use this mutation to clear that user's roles and facilities
  
  ```
  mutation ($username: String!) {
    clearUserRolesAndFacilities (
        username: $username
    ) {
        id
        nameInfo {
            firstName
            lastName
        }
        email
    }
  }
  ```

  - log in as that user (check what time you logged in at)
  - check that their roles and facilities have populated
  - do a transaction search in Azure app insights for dev3 with the string (below) and make sure your user's ID does not appear as a log message during that timeframe
 
> Okta OrganizationRoleClaims do not match database OrganizationRoleClaims for User ID:
 
<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->