### PR TITLE
Rename Hepatitis-C to Hepatitis C

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5662,3 +5662,22 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Hepatitis-C';
+
+  - changeSet:
+      id: update-hepatitis-c-naming-in-supported-disease-table
+      author: ggs2@cdc.gov
+      comment: Changes Hepatitis-C to Hepatitis C without a dash
+      changes:
+        - tagDatabase:
+            tag: update-hepatitis-c-naming-in-supported-disease-table
+        - sql:
+            sql: |
+              UPDATE ${database.defaultSchemaName}.supported_disease
+              SET name = 'Hepatitis C'
+              WHERE name = 'Hepatitis-C' AND loinc = 'LP14400-3'
+      rollback:
+        - sql:
+            sql: |
+              UPDATE ${database.defaultSchemaName}.supported_disease
+              SET name = 'Hepatitis-C'
+              WHERE name = 'Hepatitis C' AND loinc = 'LP14400-3'

--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.test.tsx
@@ -5,9 +5,9 @@ import "../../../i18n";
 import HepatitisCResultGuidance from "./HepatitisCResultGuidance";
 
 describe("HepatitisCResultGuidance", () => {
-  it("displays guidance for a Hepatitis-C result", () => {
+  it("displays guidance for a Hepatitis C result", () => {
     const { container } = render(<HepatitisCResultGuidance />);
-    expect(screen.getByText("For Hepatitis-C:")).toBeInTheDocument();
+    expect(screen.getByText("For Hepatitis C:")).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });

--- a/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/HepatitisCResultGuidance.tsx
@@ -20,7 +20,7 @@ const HepatitisCResultGuidance = () => {
             rel="noopener noreferrer"
             key="hepatitis-c-treatment-link"
           >
-            hepatitis-c treatment link
+            hepatitis c treatment link
           </a>,
         ]}
       />

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/HepatitisCResultGuidance.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HepatitisCResultGuidance displays guidance for a Hepatitis-C result 1`] = `
+exports[`HepatitisCResultGuidance displays guidance for a Hepatitis C result 1`] = `
 <div>
   <p
     class="text-bold sr-guidance-heading"
   >
-    For Hepatitis-C:
+    For Hepatitis C:
   </p>
   <p>
     If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.
@@ -16,7 +16,7 @@ exports[`HepatitisCResultGuidance displays guidance for a Hepatitis-C result 1`]
       rel="noopener noreferrer"
       target="_blank"
     >
-      Visit the CDC website to learn more about a positive Hepatitis-C result
+      Visit the CDC website to learn more about a positive Hepatitis C result
     </a>
      (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).
   </p>

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHepatitisC.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHepatitisC.ts
@@ -3,7 +3,7 @@ const mockSupportedDiseaseTestPerformedHepatitisC = [
     supportedDisease: {
       internalId: "82748233-1780-4303-b5fe-05c1d3f34ab7",
       loinc: "LP14400-3",
-      name: "Hepatitis-C",
+      name: "Hepatitis C",
     },
     testPerformedLoincCode: "80389-6",
     equipmentUid: "HepatitisCEquipmentUid123",

--- a/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
+++ b/frontend/src/app/testQueue/TestCard/TestCard.test.tsx
@@ -1329,15 +1329,15 @@ describe("TestCard", () => {
       ];
 
       const { user } = await renderQueueItem({ mocks });
-      expect(screen.queryByText("Hepatitis-C result")).not.toBeInTheDocument();
+      expect(screen.queryByText("Hepatitis C result")).not.toBeInTheDocument();
 
       const deviceDropdown = await getDeviceTypeDropdown();
 
       await user.selectOptions(deviceDropdown, device9Name);
-      expect(screen.getByText("Hepatitis-C result")).toBeInTheDocument();
+      expect(screen.getByText("Hepatitis C result")).toBeInTheDocument();
     });
 
-    it("shows required Hepatitis-C AOE questions when a positive Hepatitis-C result is present", async function () {
+    it("shows required Hepatitis C AOE questions when a positive Hepatitis C result is present", async function () {
       mockDiseaseEnabledFlag("hepatitisC");
 
       const mocks = [
@@ -1361,7 +1361,7 @@ describe("TestCard", () => {
       );
 
       await user.selectOptions(deviceDropdown, device9Name);
-      expect(screen.getByText("Hepatitis-C result")).toBeInTheDocument();
+      expect(screen.getByText("Hepatitis C result")).toBeInTheDocument();
 
       await user.click(
         screen.getByLabelText("Positive", {
@@ -1389,7 +1389,7 @@ describe("TestCard", () => {
       ).toBeInTheDocument();
     });
 
-    it("hides AOE questions when there is no positive Hepatitis-C result", async function () {
+    it("hides AOE questions when there is no positive Hepatitis C result", async function () {
       mockDiseaseEnabledFlag("hepatitisC");
 
       const mocks = [
@@ -1404,7 +1404,7 @@ describe("TestCard", () => {
       const deviceDropdown = await getDeviceTypeDropdown();
 
       await user.selectOptions(deviceDropdown, device9Name);
-      expect(screen.getByText("Hepatitis-C result")).toBeInTheDocument();
+      expect(screen.getByText("Hepatitis C result")).toBeInTheDocument();
       expect(
         screen.queryByText("Is the patient pregnant?")
       ).not.toBeInTheDocument();

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -192,7 +192,7 @@ describe("TestCardForm", () => {
         testOrder: {
           ...testProps.testOrder,
           results: [
-            { testResult: "POSITIVE", disease: { name: "HEPATITIS-C" } },
+            { testResult: "POSITIVE", disease: { name: "HEPATITIS C" } },
           ],
           deviceType: {
             internalId: hepatitisCDeviceId,

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -30,8 +30,8 @@ export const hivDeviceId = "HIV-DEVICE-ID";
 export const FACILITY_INFO_TEST_ID = "f02cfff5-1921-4293-beff-e2a5d03e1fda";
 export const syphilisDeviceName = "SYPHILIS";
 export const syphilisDeviceId = "SYPHILIS-DEVICE-ID";
-export const hepatitisCDeviceName = "HEPATITIS-C";
-export const hepatitisCDeviceId = "HEPATITIS-C-DEVICE-ID";
+export const hepatitisCDeviceName = "HEPATITIS C";
+export const hepatitisCDeviceId = "HEPATITIS C-DEVICE-ID";
 
 // 6 instead of 7 because HIV devices are filtered out when HIV feature flag is disabled
 export const DEFAULT_DEVICE_OPTIONS_LENGTH = 6;
@@ -44,7 +44,7 @@ export const device5Name = "MultiplexAndCovidOnly";
 export const device6Name = "FluOnly";
 export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
-export const device9Name = "Hepatitis-C device";
+export const device9Name = "Hepatitis C device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -6,7 +6,7 @@ export enum MULTIPLEX_DISEASES {
   HIV = "HIV",
   SYPHILIS = "Syphilis",
   FLU_A_AND_B = "Flu A and B",
-  HEPATITIS_C = "Hepatitis-C",
+  HEPATITIS_C = "Hepatitis C",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -40,7 +40,7 @@ export const en = {
         RSV: "RSV",
         HIV: "HIV",
         SYPHILIS: "Syphilis",
-        HEPATITIS_C: "Hepatitis-C",
+        HEPATITIS_C: "Hepatitis C",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 result",
@@ -50,7 +50,7 @@ export const en = {
         RSV: "RSV result",
         HIV: "HIV result",
         SYPHILIS: "Syphilis result",
-        HEPATITIS_C: "Hepatitis-C result",
+        HEPATITIS_C: "Hepatitis C result",
       },
       role: {
         STAFF: "Staff",
@@ -423,10 +423,10 @@ export const en = {
         },
       },
       hepatitisCNotes: {
-        h1: "For Hepatitis-C:",
+        h1: "For Hepatitis C:",
         positive: {
           p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
-          p1: "<0>Visit the CDC website to learn more about a positive Hepatitis-C result</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
+          p1: "<0>Visit the CDC website to learn more about a positive Hepatitis C result</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
           treatmentLink:
             "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
         },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -53,7 +53,7 @@ export const es: LanguageConfig = {
         RSV: "RSV resultado",
         HIV: "Resultado de la prueba del VIH",
         SYPHILIS: "Sífilis resultado",
-        HEPATITIS_C: "Hepatitis-C resultado",
+        HEPATITIS_C: "Hepatitis C resultado",
       },
       role: {
         STAFF: "Personal",
@@ -446,7 +446,7 @@ export const es: LanguageConfig = {
         },
       },
       hepatitisCNotes: {
-        h1: "Para Hepatitis-C:",
+        h1: "Para Hepatitis C:",
         positive: {
           p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
           p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo en la prueba del hepatitis C.</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",


### PR DESCRIPTION
# BACKEND AND FRONTEND PULL REQUEST

## Changes Proposed

- Changes the naming of Hepatitis-C to Hepatitis C (without a dash) to match CDC usage.

## Additional Information

- Review after #8249 

## Testing

- Deployed on dev4, some screenshots below of the rename


![image](https://github.com/user-attachments/assets/8cb80167-558a-4704-9d61-90957f6fee18)
![image](https://github.com/user-attachments/assets/4ff02db1-e32e-47c8-97b6-ff53c732b16d)
