### PR TITLE
Add Hepatitis C support for bulk upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -502,6 +502,18 @@ public class TestResultRow implements FileRow {
                 equipmentModelName.getValue(), testPerformedCode.getValue()));
   }
 
+  private boolean isHepatitisCResult() {
+    if (equipmentModelName.getValue() == null || testPerformedCode.getValue() == null) {
+      return false;
+    }
+
+    return resultsUploaderCachingService
+        .getHepatitisCEquipmentModelAndTestPerformedCodeSet()
+        .contains(
+            ResultsUploaderCachingService.getKey(
+                equipmentModelName.getValue(), testPerformedCode.getValue()));
+  }
+
   private List<FeedbackMessage> generateInvalidDataErrorMessages() {
     String errorMessage =
         "Invalid " + EQUIPMENT_MODEL_NAME + " and " + TEST_PERFORMED_CODE + " combination";
@@ -625,6 +637,14 @@ public class TestResultRow implements FileRow {
               testResult,
               DiseaseService.SYPHILIS_NAME,
               List.of(gendersOfSexualPartners, pregnant, syphilisHistory, symptomaticForDisease)));
+    }
+
+    if (isHepatitisCResult()) {
+      errors.addAll(
+          validateRequiredFieldsForPositiveResult(
+              testResult,
+              DiseaseService.HEPATITIS_C_NAME,
+              List.of(gendersOfSexualPartners, pregnant, symptomaticForDisease)));
     }
 
     return errors;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -12,6 +12,8 @@ public class CachingConfig {
 
   public static final String COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "covidEquipmentModelAndTestPerformedCodeSet";
+  public static final String HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
+      "hepatitisCEquipmentModelAndTestPerformedCodeSet";
   public static final String HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "hivEquipmentModelAndTestPerformedCodeSet";
   public static final String SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
@@ -27,6 +29,7 @@ public class CachingConfig {
   public CacheManager cacheManager() {
     return new ConcurrentMapCacheManager(
         COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+        HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -21,6 +21,7 @@ public class DiseaseService {
   public static final String FLU_B_NAME = "Flu B";
   public static final String FLU_A_AND_B_NAME = "Flu A and B";
   public static final String FLU_RNA_NAME = "Flu RNA";
+  public static final String HEPATITIS_C_NAME = "Hepatitis C";
   public static final String RSV_NAME = "RSV";
   public static final String HIV_NAME = "HIV";
   public static final String SYPHILIS_NAME = "Syphilis";
@@ -58,6 +59,10 @@ public class DiseaseService {
 
   public SupportedDisease fluB() {
     return getDiseaseByName(FLU_B_NAME);
+  }
+
+  public SupportedDisease hepatitisC() {
+    return getDiseaseByName(HEPATITIS_C_NAME);
   }
 
   public SupportedDisease rsv() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import static gov.cdc.usds.simplereport.config.CachingConfig.ADDRESS_TIMEZONE_LOOKUP_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP;
+import static gov.cdc.usds.simplereport.config.CachingConfig.HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SNOMED_TO_SPECIMEN_NAME_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SPECIMEN_NAME_TO_SNOMED_MAP;
@@ -163,6 +164,12 @@ public class ResultsUploaderCachingService {
     return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.COVID19_NAME);
   }
 
+  @Cacheable(HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getHepatitisCEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating hepatitisCEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.HEPATITIS_C_NAME);
+  }
+
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
   @Caching(
       evict = {
@@ -181,6 +188,18 @@ public class ResultsUploaderCachingService {
   public void cacheHivEquipmentModelAndTestPerformedCodeSet() {
     log.info("clear and generate hivEquipmentModelAndTestPerformedCodeSet cache");
     getHivEquipmentModelAndTestPerformedCodeSet();
+  }
+
+  @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
+  @Caching(
+      evict = {
+        @CacheEvict(
+            value = HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+            allEntries = true)
+      })
+  public void cacheHepatitisCEquipmentModelAndTestPerformedCodeSet() {
+    log.info("clear and generate hepatitisCEquipmentModelAndTestPerformedCodeSet cache");
+    getHepatitisCEquipmentModelAndTestPerformedCodeSet();
   }
 
   @Cacheable(SNOMED_TO_SPECIMEN_NAME_MAP)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -59,6 +59,13 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
   }
 
   @Test
+  void getHepatitisC_successful() {
+    SupportedDisease hepC = _service.hepatitisC();
+    assertNotNull(hepC);
+    assertEquals(DiseaseService.HEPATITIS_C_NAME, hepC.getName());
+  }
+
+  @Test
   void getByName_successful() {
     SupportedDisease covidByName = _service.getDiseaseByName(COVID19_NAME);
     SupportedDisease covidFromRepo = repo.findByName(COVID19_NAME).orElse(null);
@@ -77,7 +84,9 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
         .containsEntry(_service.covid().getInternalId(), _service.covid())
         .containsEntry(_service.fluA().getInternalId(), _service.fluA())
         .containsEntry(_service.fluB().getInternalId(), _service.fluB())
-        .containsEntry(_service.rsv().getInternalId(), _service.rsv());
+        .containsEntry(_service.rsv().getInternalId(), _service.rsv())
+        .containsEntry(_service.hiv().getInternalId(), _service.hiv())
+        .containsEntry(_service.hepatitisC().getInternalId(), _service.hepatitisC());
   }
 
   @Test
@@ -90,6 +99,8 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
         .contains(_service.covid())
         .contains(_service.fluA())
         .contains(_service.fluB())
-        .contains(_service.rsv());
+        .contains(_service.rsv())
+        .contains(_service.hiv())
+        .contains(_service.hepatitisC());
   }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7449

## Changes Proposed

- Supports the bulk upload of Hepatitis C test results
- Throws a validation error if user tries to upload a positive Hepatitis C result without the required AOE columns (`pregnancy`, `gender_of_sexual_partners`, `symptomatic_for_disease`)

## Additional Information
- N/A

## Testing
- deployed on dev3
- perform a bulk upload of Hepatitis C results
   - `equipment_model_name` - Hep C Model
   - `test_performed_code` - 40726-2
- [test_results_example_10-3-2022.csv](https://github.com/user-attachments/files/17653866/test_results_example_10-3-2022.csv)

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
