### PR TITLE
Add no op support escalation service

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/SimpleReportApplication.java
@@ -10,6 +10,7 @@ import gov.cdc.usds.simplereport.properties.ExperianProperties;
 import gov.cdc.usds.simplereport.properties.OrderingProviderProperties;
 import gov.cdc.usds.simplereport.properties.SendGridProperties;
 import gov.cdc.usds.simplereport.properties.SmartyStreetsProperties;
+import gov.cdc.usds.simplereport.properties.SupportEscalationProperties;
 import gov.cdc.usds.simplereport.service.DiseaseService;
 import gov.cdc.usds.simplereport.service.OrganizationInitializingService;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +41,8 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
   SendGridProperties.class,
   OrderingProviderProperties.class,
   CorsProperties.class,
-  AzureStorageQueueReportingProperties.class
+  AzureStorageQueueReportingProperties.class,
+  SupportEscalationProperties.class
 })
 @EnableAsync
 @EnableScheduling

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/supportescalation/SupportEscalationMutationResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/supportescalation/SupportEscalationMutationResolver.java
@@ -1,7 +1,7 @@
 package gov.cdc.usds.simplereport.api.supportescalation;
 
 import gov.cdc.usds.simplereport.api.model.errors.GenericGraphqlException;
-import gov.cdc.usds.simplereport.service.supportescalation.SlackWebhookService;
+import gov.cdc.usds.simplereport.service.supportescalation.SupportEscalationService;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,19 +12,19 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 @Slf4j
 public class SupportEscalationMutationResolver {
-  private final SlackWebhookService slackClient;
+  private final SupportEscalationService supportEscalationService;
 
   @MutationMapping
   public boolean sendSupportEscalation() throws GenericGraphqlException {
 
     try {
-      boolean escalationSuccessful = slackClient.sendSlackEscalationMessage();
+      boolean escalationSuccessful = supportEscalationService.sendEscalationMessage();
       if (escalationSuccessful) {
         return true;
       }
       throw new IOException("Escalation didn't return success");
     } catch (IOException e) {
-      log.error("Slack escalation failed");
+      log.error("Support escalation failed");
       throw new GenericGraphqlException();
     }
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/properties/SupportEscalationProperties.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/properties/SupportEscalationProperties.java
@@ -1,0 +1,12 @@
+package gov.cdc.usds.simplereport.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "simple-report.support-escalation")
+public class SupportEscalationProperties {
+  private final String enabled;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/NoOpSupportEscalationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/NoOpSupportEscalationService.java
@@ -1,0 +1,21 @@
+package gov.cdc.usds.simplereport.service.supportescalation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnMissingBean(name = "slackWebhookService")
+@Slf4j
+public class NoOpSupportEscalationService implements SupportEscalationService {
+
+  public NoOpSupportEscalationService() {
+    log.info("Configured for no-op support escalation");
+  }
+
+  @Override
+  public boolean sendEscalationMessage() {
+    log.info("No op support escalation message successful");
+    return true;
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SlackWebhookService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SlackWebhookService.java
@@ -2,16 +2,19 @@ package gov.cdc.usds.simplereport.service.supportescalation;
 
 import gov.cdc.usds.simplereport.config.AuthorizationConfiguration;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 @Service
+@ConditionalOnProperty(value = "simple-report.support-escalation.enabled", havingValue = "true")
 @AllArgsConstructor
-public class SlackWebhookService {
-
+@Slf4j
+public class SlackWebhookService implements SupportEscalationService {
   private SlackConfigService slackConfigService;
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
-  public boolean sendSlackEscalationMessage() {
+  public boolean sendEscalationMessage() {
     return slackConfigService.makeEscalationRequest();
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SlackWebhookService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SlackWebhookService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class SlackWebhookService implements SupportEscalationService {
   private SlackConfigService slackConfigService;
 
+  @Override
   @AuthorizationConfiguration.RequireGlobalAdminUser
   public boolean sendEscalationMessage() {
     return slackConfigService.makeEscalationRequest();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SupportEscalationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/supportescalation/SupportEscalationService.java
@@ -1,0 +1,5 @@
+package gov.cdc.usds.simplereport.service.supportescalation;
+
+public interface SupportEscalationService {
+  boolean sendEscalationMessage();
+}

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -17,6 +17,8 @@ simple-report:
       - https://simplereport.gov
   experian:
     enabled: true
+  support-escalation:
+    enabled: true
 twilio:
   enabled: true
   from-number: "+14045312484"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -157,6 +157,8 @@ simple-report:
       - POST
   batch-size: 1000
   fhir-reporting-enabled: true
+  support-escalation:
+    enabled: false
 twilio:
   messaging-service-sid: ${TWILIO_MESSAGING_SID}
 logging:

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/supportadmin/SupportEscalationMutationResolverTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/supportadmin/SupportEscalationMutationResolverTest.java
@@ -7,33 +7,28 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.api.model.errors.GenericGraphqlException;
 import gov.cdc.usds.simplereport.api.supportescalation.SupportEscalationMutationResolver;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
-import gov.cdc.usds.simplereport.service.supportescalation.SlackWebhookService;
+import gov.cdc.usds.simplereport.service.supportescalation.SupportEscalationService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
-import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 @SliceTestConfiguration.WithSimpleReportOrgAdminUser
-class SlackEscalationMutationResolverTest extends BaseServiceTest<SlackWebhookService> {
-  @Mock SlackWebhookService service;
+class SupportEscalationMutationResolverTest extends BaseServiceTest<SupportEscalationService> {
+  @Mock SupportEscalationService service;
 
   @InjectMocks SupportEscalationMutationResolver resolver;
 
   @Test
-  void escalation_success() throws IOException {
-    when(service.sendSlackEscalationMessage()).thenReturn(true);
+  void escalation_success() {
+    when(service.sendEscalationMessage()).thenReturn(true);
     boolean escalationCompleted = resolver.sendSupportEscalation();
     assertThat(escalationCompleted).isTrue();
   }
 
   @Test
-  void escalation_throws_if_fails() throws IOException {
-    when(service.sendSlackEscalationMessage()).thenReturn(false);
-    assertThrows(
-        GenericGraphqlException.class,
-        () -> {
-          resolver.sendSupportEscalation();
-        });
+  void escalation_throws_if_fails() {
+    when(service.sendEscalationMessage()).thenReturn(false);
+    assertThrows(GenericGraphqlException.class, () -> resolver.sendSupportEscalation());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/NoOpSupportEscalationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/NoOpSupportEscalationServiceTest.java
@@ -1,0 +1,18 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.cdc.usds.simplereport.service.supportescalation.SupportEscalationService;
+import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import org.junit.jupiter.api.Test;
+
+@SliceTestConfiguration.WithSimpleReportOrgAdminUser
+public class NoOpSupportEscalationServiceTest extends BaseServiceTest<SupportEscalationService> {
+
+  @Test
+  @SliceTestConfiguration.WithSimpleReportSiteAdminUser
+  void noOpSupportEscalationSuccess() {
+    boolean escalationWasOk = _service.sendEscalationMessage();
+    assertThat(escalationWasOk).isTrue();
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/SlackWebhookServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/SlackWebhookServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,15 +9,19 @@ import static org.mockito.Mockito.when;
 import gov.cdc.usds.simplereport.service.supportescalation.SlackConfigService;
 import gov.cdc.usds.simplereport.service.supportescalation.SlackWebhookService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-class SlackWebhookServiceTest extends BaseServiceTest<SlackWebhookService> {
+class SlackWebhookServiceTest {
 
-  @Autowired private SlackWebhookService service;
+  private SlackWebhookService service;
+  private static SlackConfigService config;
 
-  @Autowired @MockBean private SlackConfigService config;
+  @BeforeEach
+  void setup() {
+    config = mock(SlackConfigService.class);
+    service = new SlackWebhookService(config);
+  }
 
   @Test
   @SliceTestConfiguration.WithSimpleReportSiteAdminUser
@@ -25,7 +30,7 @@ class SlackWebhookServiceTest extends BaseServiceTest<SlackWebhookService> {
     when(config.makeEscalationRequest()).thenReturn(true);
 
     // WHEN
-    boolean escalationWasOk = service.sendSlackEscalationMessage();
+    boolean escalationWasOk = service.sendEscalationMessage();
 
     // THEN
     verify(config, times(1)).makeEscalationRequest();

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/SliceTestConfiguration.java
@@ -21,6 +21,7 @@ import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration.DemoUser;
 import gov.cdc.usds.simplereport.db.repository.BaseRepositoryTest;
 import gov.cdc.usds.simplereport.idp.repository.DemoOktaRepository;
+import gov.cdc.usds.simplereport.properties.SupportEscalationProperties;
 import gov.cdc.usds.simplereport.service.ApiUserService;
 import gov.cdc.usds.simplereport.service.AuthorizationService;
 import gov.cdc.usds.simplereport.service.BaseServiceTest;
@@ -35,6 +36,7 @@ import gov.cdc.usds.simplereport.service.ResultService;
 import gov.cdc.usds.simplereport.service.TenantDataAccessService;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
+import gov.cdc.usds.simplereport.service.supportescalation.NoOpSupportEscalationService;
 import gov.cdc.usds.simplereport.validators.OrderingProviderRequiredValidator;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -113,9 +115,14 @@ import org.springframework.security.test.context.support.WithMockUser;
   OktaHealthIndicator.class,
   EmailService.class,
   SendGridDisabledConfiguration.class,
-  FeatureFlagsConfig.class
+  FeatureFlagsConfig.class,
+  NoOpSupportEscalationService.class
 })
-@EnableConfigurationProperties({InitialSetupProperties.class, AuthorizationProperties.class})
+@EnableConfigurationProperties({
+  InitialSetupProperties.class,
+  AuthorizationProperties.class,
+  SupportEscalationProperties.class
+})
 public class SliceTestConfiguration {
 
   private static final String DEFAULT_ROLE_PREFIX =


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7883

## Changes Proposed

- Creates a no op support escalation service to be used by all non-prod environments
- Bean configuration is conditional based on whether the configuration property is enabled in the spring profile

## Testing

- Deployed to dev5
- On the support admin dashboard, click "Escalate to engineering" and then "Submit escalation" and verify that it shows a success.
- Can also check the logs on dev5 for "No op support escalation message successful"