### PR TITLE
Add Gonorrhea Support For Bulk Upload

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -529,6 +529,18 @@ public class TestResultRow implements FileRow {
                 equipmentModelName.getValue(), testPerformedCode.getValue()));
   }
 
+  private boolean isGonorrheaResult() {
+    if (equipmentModelName.getValue() == null || testPerformedCode.getValue() == null) {
+      return false;
+    }
+
+    return resultsUploaderCachingService
+        .getGonorrheaEquipmentModelAndTestPerformedCodeSet()
+        .contains(
+            ResultsUploaderCachingService.getKey(
+                equipmentModelName.getValue(), testPerformedCode.getValue()));
+  }
+
   private List<FeedbackMessage> generateInvalidDataErrorMessages() {
     String errorMessage =
         "Invalid " + EQUIPMENT_MODEL_NAME + " and " + TEST_PERFORMED_CODE + " combination";
@@ -661,6 +673,14 @@ public class TestResultRow implements FileRow {
           validateRequiredFieldsForPositiveResult(
               testResult,
               DiseaseService.HEPATITIS_C_NAME,
+              List.of(gendersOfSexualPartners, pregnant, symptomaticForDisease)));
+    }
+
+    if (isGonorrheaResult()) {
+      errors.addAll(
+          validateRequiredFieldsForPositiveResult(
+              testResult,
+              DiseaseService.GONORRHEA_NAME,
               List.of(gendersOfSexualPartners, pregnant, symptomaticForDisease)));
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -14,6 +14,9 @@ public class CachingConfig {
       "covidEquipmentModelAndTestPerformedCodeSet";
   public static final String HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "hepatitisCEquipmentModelAndTestPerformedCodeSet";
+
+  public static final String GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
+      "gonorrheaEquipmentModelAndTestPerformedCodeSet";
   public static final String HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "hivEquipmentModelAndTestPerformedCodeSet";
   public static final String SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
@@ -30,6 +33,7 @@ public class CachingConfig {
     return new ConcurrentMapCacheManager(
         COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+        GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -25,6 +25,7 @@ public class DiseaseService {
   public static final String RSV_NAME = "RSV";
   public static final String HIV_NAME = "HIV";
   public static final String SYPHILIS_NAME = "Syphilis";
+  public static final String GONORRHEA_NAME = "Gonorrhea";
 
   private final DiseaseCacheService diseaseCacheService;
 
@@ -63,6 +64,10 @@ public class DiseaseService {
 
   public SupportedDisease hepatitisC() {
     return getDiseaseByName(HEPATITIS_C_NAME);
+  }
+
+  public SupportedDisease gonorrhea() {
+    return getDiseaseByName(GONORRHEA_NAME);
   }
 
   public SupportedDisease rsv() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -3,6 +3,7 @@ package gov.cdc.usds.simplereport.service;
 import static gov.cdc.usds.simplereport.config.CachingConfig.ADDRESS_TIMEZONE_LOOKUP_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP;
+import static gov.cdc.usds.simplereport.config.CachingConfig.GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.HEPATITIS_C_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.SNOMED_TO_SPECIMEN_NAME_MAP;
@@ -170,6 +171,12 @@ public class ResultsUploaderCachingService {
     return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.HEPATITIS_C_NAME);
   }
 
+  @Cacheable(GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getGonorrheaEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating gonorrheaEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.GONORRHEA_NAME);
+  }
+
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
   @Caching(
       evict = {
@@ -200,6 +207,18 @@ public class ResultsUploaderCachingService {
   public void cacheHepatitisCEquipmentModelAndTestPerformedCodeSet() {
     log.info("clear and generate hepatitisCEquipmentModelAndTestPerformedCodeSet cache");
     getHepatitisCEquipmentModelAndTestPerformedCodeSet();
+  }
+
+  @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
+  @Caching(
+      evict = {
+        @CacheEvict(
+            value = GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+            allEntries = true)
+      })
+  public void cacheGonorrheaEquipmentModelAndTestPerformedCodeSet() {
+    log.info("clear and generate gonorrheaEquipmentModelAndTestPerformedCodeSet cache");
+    getGonorrheaEquipmentModelAndTestPerformedCodeSet();
   }
 
   @Cacheable(SNOMED_TO_SPECIMEN_NAME_MAP)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DiseaseServiceTest.java
@@ -66,6 +66,13 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
   }
 
   @Test
+  void getGonorrhea_successful() {
+    SupportedDisease gonorrhea = _service.gonorrhea();
+    assertNotNull(gonorrhea);
+    assertEquals(DiseaseService.GONORRHEA_NAME, gonorrhea.getName());
+  }
+
+  @Test
   void getByName_successful() {
     SupportedDisease covidByName = _service.getDiseaseByName(COVID19_NAME);
     SupportedDisease covidFromRepo = repo.findByName(COVID19_NAME).orElse(null);
@@ -86,7 +93,8 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
         .containsEntry(_service.fluB().getInternalId(), _service.fluB())
         .containsEntry(_service.rsv().getInternalId(), _service.rsv())
         .containsEntry(_service.hiv().getInternalId(), _service.hiv())
-        .containsEntry(_service.hepatitisC().getInternalId(), _service.hepatitisC());
+        .containsEntry(_service.hepatitisC().getInternalId(), _service.hepatitisC())
+        .containsEntry(_service.gonorrhea().getInternalId(), _service.gonorrhea());
   }
 
   @Test
@@ -101,6 +109,7 @@ class DiseaseServiceTest extends BaseServiceTest<DiseaseService> {
         .contains(_service.fluB())
         .contains(_service.rsv())
         .contains(_service.hiv())
+        .contains(_service.gonorrhea())
         .contains(_service.hepatitisC());
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
@@ -527,6 +527,37 @@ class TestResultRowTest {
                     "This is required because the row contains a positive Hepatitis C test result."));
   }
 
+  @Test
+  void validatePositiveGonorrheaRequiredAoeFields() {
+    Map<String, String> missingGonorrheaRequiredAoeFields =
+        getPositiveResultRowMap("Gonorrhea Model", "5028-6");
+    missingGonorrheaRequiredAoeFields.put("pregnant", "");
+    missingGonorrheaRequiredAoeFields.put("genders_of_sexual_partners", "");
+    missingGonorrheaRequiredAoeFields.put("symptomatic_for_disease", "");
+
+    ResultsUploaderCachingService resultsUploaderCachingService =
+        mock(ResultsUploaderCachingService.class);
+    when(resultsUploaderCachingService.getModelAndTestPerformedCodeToDeviceMap())
+        .thenReturn(Map.of("gonorrhea model|5028-6", TestDataBuilder.createDeviceType()));
+    when(resultsUploaderCachingService.getHepatitisCEquipmentModelAndTestPerformedCodeSet())
+        .thenReturn(Set.of("gonorrhea model|5028-6"));
+
+    TestResultRow testResultRow =
+        new TestResultRow(
+            missingGonorrheaRequiredAoeFields,
+            resultsUploaderCachingService,
+            mock(FeatureFlagsConfig.class));
+
+    List<FeedbackMessage> actual = testResultRow.validateIndividualValues();
+
+    assertThat(actual).hasSize(3);
+    actual.forEach(
+        message ->
+            assertThat(message.getMessage())
+                .contains(
+                    "This is required because the row contains a positive Gonorrhea test result."));
+  }
+
   @NotNull
   private Map<String, String> getPositiveResultRowMap(
       String deviceModelName, String testPerformedCode) {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
@@ -539,7 +539,7 @@ class TestResultRowTest {
         mock(ResultsUploaderCachingService.class);
     when(resultsUploaderCachingService.getModelAndTestPerformedCodeToDeviceMap())
         .thenReturn(Map.of("gonorrhea model|5028-6", TestDataBuilder.createDeviceType()));
-    when(resultsUploaderCachingService.getHepatitisCEquipmentModelAndTestPerformedCodeSet())
+    when(resultsUploaderCachingService.getGonorrheaEquipmentModelAndTestPerformedCodeSet())
         .thenReturn(Set.of("gonorrhea model|5028-6"));
 
     TestResultRow testResultRow =


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7450 

## Changes Proposed

- Bulk upload throws a validation error if user tries to upload a positive Gonorrhea result without the required AOE columns (`pregnancy`, `gender_of_sexual_partners`, `symptomatic_for_disease`)

## Testing
- Live for testing on `Dev 6`
-  Under the org Peter Rabbit there is a `Gonorrhea Device` with the corresponding test code `5028-6`
- Spreadsheet template with above device and code: 
[test_results_example_10-3-2022.csv](https://github.com/user-attachments/files/17926261/test_results_example_10-3-2022.csv)
