### PR TITLE
Add Gonorrhea to SupportedDiseases

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5681,3 +5681,23 @@ databaseChangeLog:
               UPDATE ${database.defaultSchemaName}.supported_disease
               SET name = 'Hepatitis-C'
               WHERE name = 'Hepatitis C' AND loinc = 'LP14400-3'
+
+  - changeSet:
+        id: add-gonorrhea-to-supported_disease-table
+        author: ggs2@cdc.gov
+        comment: Add Gonorrhea to the supported_disease table.
+        changes:
+          - tagDatabase:
+              tag: add-gonorrhea-to-supported_disease-table
+          - sql:
+              sql: |
+                INSERT INTO ${database.defaultSchemaName}.supported_disease (
+                     internal_id,
+                     name,
+                     loinc)
+                VALUES
+                     (gen_random_uuid(), 'Gonorrhea', 'LP14316-1')
+        rollback:
+          - sql:
+              sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Gonorrhea';
+


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part of #7434 
- Will be followed up with PR for adding full Gonorrhea support on the test card

## Changes Proposed

- Adds Gonorrhea to the SupportedDiseases table

## Testing

- Deployed to dev5
- Gonorrhea is available as an option for support admins adding a new test device (note that this support admin device form is not hidden behind a feature flag for gonorrhea)
![image](https://github.com/user-attachments/assets/1e0ba162-4cd1-4120-bee9-f671bfbbe71e)
