### PR TITLE
Add Gonorrhea support to test card

### DIFF
--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -32,6 +32,7 @@ const diseaseResultTitlePxpMap: Record<MULTIPLEX_DISEASES, string> = {
   [MULTIPLEX_DISEASES.RSV]: "constants.diseaseResultTitle.RSV",
   [MULTIPLEX_DISEASES.SYPHILIS]: "constants.diseaseResultTitle.SYPHILIS",
   [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.diseaseResultTitle.HEPATITIS_C",
+  [MULTIPLEX_DISEASES.GONORRHEA]: "constants.diseaseResultTitle.GONORRHEA",
 };
 
 const diseaseResultReportingAppMap: Record<MULTIPLEX_DISEASES, string> = {
@@ -43,6 +44,7 @@ const diseaseResultReportingAppMap: Record<MULTIPLEX_DISEASES, string> = {
   [MULTIPLEX_DISEASES.RSV]: "constants.disease.RSV",
   [MULTIPLEX_DISEASES.SYPHILIS]: "constants.disease.SYPHILIS",
   [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.disease.HEPATITIS_C",
+  [MULTIPLEX_DISEASES.GONORRHEA]: "constants.disease.GONORRHEA",
 };
 
 const setResult = (result: string, t: translateFn) => {

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedGonorrhea.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedGonorrhea.ts
@@ -1,0 +1,15 @@
+const mockSupportedDiseaseTestPerformedGonorrhea = [
+  {
+    supportedDisease: {
+      internalId: "18948648-1780-4303-b5fe-05c1d3f34ab7",
+      loinc: "LP14316-1",
+      name: "Gonorrhea",
+    },
+    testPerformedLoincCode: "80123-6",
+    equipmentUid: "GonorrheaEquipmentUid123",
+    testkitNameId: "GonorrheaTestkitNameId123",
+    testOrderedLoincCode: "80123-6",
+  },
+];
+
+export default mockSupportedDiseaseTestPerformedGonorrhea;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -12,6 +12,8 @@ import {
   fluDeviceId,
   fluDeviceName,
   generateSubmitQueueMock,
+  gonorrheaDeviceId,
+  gonorrheaDeviceName,
   hepatitisCDeviceId,
   hepatitisCDeviceName,
   hivDeviceId,
@@ -198,6 +200,24 @@ describe("TestCardForm", () => {
             internalId: hepatitisCDeviceId,
             name: hepatitisCDeviceName,
             model: hepatitisCDeviceName,
+            testLength: 15,
+          },
+        },
+      };
+
+      expect(await renderTestCardForm({ props })).toMatchSnapshot();
+    });
+
+    it("matches snapshot for gonorrhea device", async () => {
+      const props = {
+        ...testProps,
+        testOrder: {
+          ...testProps.testOrder,
+          results: [{ testResult: "POSITIVE", disease: { name: "GONORRHEA" } }],
+          deviceType: {
+            internalId: gonorrheaDeviceId,
+            name: gonorrheaDeviceName,
+            model: gonorrheaDeviceName,
             testLength: 15,
           },
         },

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -27,6 +27,8 @@ import {
   TestCorrectionReasons,
 } from "../../testResults/viewResults/actionMenuModals/TestResultCorrectionModal";
 import {
+  gonorrheaSymptomDefinitions,
+  hepatitisCSymptomDefinitions,
   PregnancyCode,
   SyphilisHistoryCode,
 } from "../../../patientApp/timeOfTest/constants";
@@ -58,7 +60,7 @@ import { HIVAoEForm } from "./diseaseSpecificComponents/HIVAoEForm";
 import { stringifySymptomJsonForAoeUpdate } from "./diseaseSpecificComponents/aoeUtils";
 import { SyphilisAoEForm } from "./diseaseSpecificComponents/SyphilisAoEForm";
 import { WhereResultsAreSentModal } from "./WhereResultsAreSentModal";
-import { HepatitisCAoeForm } from "./diseaseSpecificComponents/HepatitisCAoeForm";
+import { STIGenericAOEForm } from "./diseaseSpecificComponents/STIGenericAOEForm";
 
 const DEBOUNCE_TIME = 300;
 
@@ -606,7 +608,7 @@ const TestCardForm = ({
         )}
         {whichAoeFormOption === AOEFormOption.HEPATITIS_C && (
           <div className="grid-row grid-gap">
-            <HepatitisCAoeForm
+            <STIGenericAOEForm
               testOrder={testOrder}
               responses={state.aoeResponses}
               hasAttemptedSubmit={hasAttemptedSubmit}
@@ -616,6 +618,25 @@ const TestCardForm = ({
                   payload: responses,
                 });
               }}
+              diseaseSymptomDefinitions={hepatitisCSymptomDefinitions}
+              diseaseNameForFormIds={"hepatitis-c"}
+            />
+          </div>
+        )}
+        {whichAoeFormOption === AOEFormOption.GONORRHEA && (
+          <div className="grid-row grid-gap">
+            <STIGenericAOEForm
+              testOrder={testOrder}
+              responses={state.aoeResponses}
+              hasAttemptedSubmit={hasAttemptedSubmit}
+              onResponseChange={(responses) => {
+                dispatch({
+                  type: TestFormActionCase.UPDATE_AOE_RESPONSES,
+                  payload: responses,
+                });
+              }}
+              diseaseSymptomDefinitions={gonorrheaSymptomDefinitions}
+              diseaseNameForFormIds={"gonorrhea"}
             />
           </div>
         )}

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.test.tsx
@@ -122,5 +122,28 @@ describe("TestCardForm.utils", () => {
         )
       ).toEqual(AoeValidationErrorMessages.COMPLETE);
     });
+
+    it("should return false if Gonorrhea questions are unanswered", () => {
+      const positive: TestFormState = {
+        ...incompleteState,
+      };
+      expect(
+        generateAoeValidationState(positive, AOEFormOption.GONORRHEA)
+      ).toEqual(AoeValidationErrorMessages.INCOMPLETE);
+    });
+
+    it("should return true when Gonorrhea positive is selected and questions are answered", () => {
+      const positiveGonorrheaStateCompleteAOE: TestFormState = {
+        ...completeStateWithSymptoms,
+      };
+      positiveGonorrheaStateCompleteAOE.aoeResponses.symptoms =
+        '{"49650001":true,"289560001":false,"399131003":false,"249661007":false,"90446007":false,"71393004":false,"131148009":false,"225595004":false}';
+      expect(
+        generateAoeValidationState(
+          positiveGonorrheaStateCompleteAOE,
+          AOEFormOption.GONORRHEA
+        )
+      ).toEqual(AoeValidationErrorMessages.COMPLETE);
+    });
   });
 });

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -27,6 +27,7 @@ export enum AOEFormOption {
   HIV = "HIV",
   SYPHILIS = "SYPHILIS",
   HEPATITIS_C = "HEPATITIS_C",
+  GONORRHEA = "GONORRHEA",
   NONE = "NONE",
 }
 
@@ -65,6 +66,7 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
   const hivEnabled = useFeature("hivEnabled");
   const syphilisEnabled = useFeature("syphilisEnabled");
   const hepatitisCEnabled = useFeature("hepatitisCEnabled");
+  const gonorrheaEnabled = useFeature("gonorrheaEnabled");
 
   let deviceTypes = [...facility!.deviceTypes];
 
@@ -74,7 +76,6 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
       MULTIPLEX_DISEASES.HIV
     );
   }
-
   if (!syphilisEnabled) {
     deviceTypes = filterDiseaseFromAllDevices(
       deviceTypes,
@@ -85,6 +86,12 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
     deviceTypes = filterDiseaseFromAllDevices(
       deviceTypes,
       MULTIPLEX_DISEASES.HEPATITIS_C
+    );
+  }
+  if (!gonorrheaEnabled) {
+    deviceTypes = filterDiseaseFromAllDevices(
+      deviceTypes,
+      MULTIPLEX_DISEASES.GONORRHEA
     );
   }
   return deviceTypes;
@@ -208,6 +215,15 @@ export const useAOEFormOption = (
     devicesMap
       .get(testFormState.deviceId)
       ?.supportedDiseaseTestPerformed.filter(
+        (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.GONORRHEA
+      ).length === 1
+  ) {
+    return resultHasPositive ? AOEFormOption.GONORRHEA : AOEFormOption.NONE;
+  }
+  if (
+    devicesMap
+      .get(testFormState.deviceId)
+      ?.supportedDiseaseTestPerformed.filter(
         (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.HEPATITIS_C
       ).length === 1
   ) {
@@ -284,6 +300,11 @@ export const REQUIRED_AOE_QUESTIONS_BY_DISEASE: {
     AoeQuestionName.NO_SYMPTOMS,
   ],
   [AOEFormOption.HEPATITIS_C]: [
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
+    AoeQuestionName.NO_SYMPTOMS,
+  ],
+  [AOEFormOption.GONORRHEA]: [
     AoeQuestionName.PREGNANCY,
     AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
     AoeQuestionName.NO_SYMPTOMS,

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -1535,6 +1535,1409 @@ exports[`TestCardForm initial state matches snapshot for flu device 1`] = `
 </div>
 `;
 
+exports[`TestCardForm initial state matches snapshot for gonorrhea device 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-hidden="true"
+        class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+      >
+        <h4>
+          Submitting test data for 
+          Dixon, Althea Hedda Mclaughlin
+          ...
+        </h4>
+        <img
+          alt="submitting"
+          class="square-5"
+          src="loader.svg"
+        />
+      </div>
+      <div
+        class="grid-container sr-test-card-form-container"
+      >
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <label
+              class="usa-label margin-top-3"
+              data-testid="label"
+              for="current-date-time"
+            >
+              Test date and time
+               
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                *
+              </abbr>
+            </label>
+            <div
+              class="usa-checkbox"
+              data-testid="checkbox"
+            >
+              <input
+                checked=""
+                class="usa-checkbox__input"
+                id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="current-date-time"
+                type="checkbox"
+              />
+              <label
+                class="usa-checkbox__label"
+                for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              >
+                Current date and time
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+          data-testid="device-type-dropdown-container"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <div
+              class="usa-form-group prime-dropdown  card-dropdown"
+            >
+              <label
+                class="usa-label"
+                for="29"
+              >
+                <span
+                  class="usa-tooltip usa-text-with-tooltip"
+                  data-testid="tooltipWrapper"
+                >
+                  <button
+                    aria-describedby="tooltip-1000000"
+                    aria-label=""
+                    class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                    data-testid="triggerElement"
+                    position="right"
+                    tabindex="0"
+                    title=""
+                    wrapperclasses="usa-text-with-tooltip"
+                  >
+                    Test device
+                    <svg
+                      alt-text="info"
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-circle-info info-circle-icon"
+                      data-icon="circle-info"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <span
+                    aria-hidden="true"
+                    class="usa-tooltip__body"
+                    data-testid="tooltipBody"
+                    id="tooltip-1000000"
+                    role="tooltip"
+                    title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                  >
+                    Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                  </span>
+                </span>
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <select
+                aria-label="Test device"
+                aria-required="true"
+                class="usa-select"
+                data-testid="device-type-dropdown"
+                id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="testDevice"
+              >
+                <option
+                  aria-selected="false"
+                  value="FLU-DEVICE-ID"
+                >
+                  FLU
+                </option>
+                <option
+                  aria-selected="false"
+                  value="COVID-DEVICE-ID"
+                >
+                  LumiraDX
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-DEVICE-ID"
+                >
+                  Multiplex
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-COVID-DEVICE-ID"
+                >
+                  MultiplexAndCovidOnly
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="grid-col-auto"
+            data-testid="specimen-type-dropdown-container"
+          >
+            <div
+              class="usa-form-group prime-dropdown  card-dropdown"
+            >
+              <label
+                class="usa-label"
+                for="30"
+              >
+                Specimen type
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <select
+                aria-label="Specimen type"
+                aria-required="true"
+                class="usa-select"
+                data-testid="specimen-type-dropdown"
+                id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="specimenType"
+              >
+                <option
+                  aria-selected="true"
+                  value="SPECIMEN-1-ID"
+                >
+                  Swab of internal nose
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="usa-form-group"
+            data-testid="formGroup"
+          >
+            <div
+              class="usa-alert usa-alert--error"
+              data-testid="alert"
+            >
+              <div
+                class="usa-alert__body"
+              >
+                <p
+                  class="usa-alert__text"
+                >
+                  This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col"
+            id="gonorrhea-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+          >
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <label
+                    class="usa-label"
+                    for="31"
+                    id="label-for-31"
+                  >
+                    What is the gender of their sexual partners?
+                     
+                    <span
+                      class="text-base-dark"
+                    >
+                      (Select all that apply.)
+                    </span>
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </label>
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled margin-top-05em"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        alt-text="info"
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+                        data-icon="circle-info"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <strong
+                        class="font-body-2xs"
+                      >
+                        Why SimpleReport asks about sensitive topics like this
+                      </strong>
+                    </button>
+                  </span>
+                  <div
+                    class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
+                    data-testid="multi-select"
+                    id="31"
+                  >
+                    <input
+                      aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      aria-labelledby="label-for-31"
+                      aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      aria-required="true"
+                      autocapitalize="off"
+                      autocomplete="off"
+                      class="usa-combo-box__input"
+                      data-testid="multi-select-input"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <span
+                      class="usa-combo-box__input-button-separator"
+                    >
+                       
+                    </span>
+                    <span
+                      class="usa-combo-box__toggle-list__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-hidden="true"
+                        class="usa-combo-box__toggle-list"
+                        data-testid="multi-select-toggle"
+                        tabindex="-1"
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <ul
+                      class="usa-combo-box__list"
+                      data-testid="multi-select-option-list"
+                      hidden=""
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      role="listbox"
+                      tabindex="-1"
+                    >
+                      <li
+                        aria-posinset="1"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-female"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-0"
+                        role="option"
+                        tabindex="-1"
+                        value="female"
+                      >
+                        Female
+                      </li>
+                      <li
+                        aria-posinset="2"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-other"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-1"
+                        role="option"
+                        tabindex="-1"
+                        value="other"
+                      >
+                        Gender identity not listed here
+                      </li>
+                      <li
+                        aria-posinset="3"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-male"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-2"
+                        role="option"
+                        tabindex="-1"
+                        value="male"
+                      >
+                        Male
+                      </li>
+                      <li
+                        aria-posinset="4"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-nonbinary"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-3"
+                        role="option"
+                        tabindex="-1"
+                        value="nonbinary"
+                      >
+                        Nonbinary or gender non-conforming
+                      </li>
+                      <li
+                        aria-posinset="5"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-refused"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-4"
+                        role="option"
+                        tabindex="-1"
+                        value="refused"
+                      >
+                        Prefer not to answer
+                      </li>
+                      <li
+                        aria-posinset="6"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-transman"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-5"
+                        role="option"
+                        tabindex="-1"
+                        value="transman"
+                      >
+                        Transman
+                      </li>
+                      <li
+                        aria-posinset="7"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-transwoman"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-6"
+                        role="option"
+                        tabindex="-1"
+                        value="transwoman"
+                      >
+                        Transwoman
+                      </li>
+                    </ul>
+                    <div
+                      class="usa-combo-box__status usa-sr-only"
+                      role="status"
+                    />
+                  </div>
+                  <fieldset
+                    class="fieldset--unstyled pill-container pill-container--hidden"
+                    data-testid="pill-container"
+                  >
+                    <legend
+                      class="usa-sr-only"
+                    >
+                      Selected [object Object]
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient pregnant?
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="32-val-77386006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="77386006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                          for="32-val-77386006"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="32-val-60001007"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="60001007"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                          for="32-val-60001007"
+                        >
+                          No
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="32-val-261665006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="261665006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                          for="32-val-261665006"
+                        >
+                          Prefer not to answer
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient currently experiencing or showing signs of symptoms?
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="33-val-YES"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="YES"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                          for="33-val-YES"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          checked=""
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="33-val-NO"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="NO"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                          for="33-val-NO"
+                        >
+                          No
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-4"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <button
+              class="usa-button"
+              data-testid="button"
+              type="button"
+            >
+              Submit results
+            </button>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-1"
+        >
+          <button
+            class="usa-button usa-button--unstyled margin-top-05em"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              alt-text="info"
+              aria-hidden="true"
+              class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+              data-icon="circle-info"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                fill="currentColor"
+              />
+            </svg>
+            <strong
+              class="font-body-2xs"
+            >
+              Where results are sent
+            </strong>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="modal--basic"
+    />
+    <div
+      class="modal--basic"
+    />
+    <div
+      class="modal--basic"
+    />
+  </body>,
+  "container": <div>
+    <div
+      aria-hidden="true"
+      class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+    >
+      <h4>
+        Submitting test data for 
+        Dixon, Althea Hedda Mclaughlin
+        ...
+      </h4>
+      <img
+        alt="submitting"
+        class="square-5"
+        src="loader.svg"
+      />
+    </div>
+    <div
+      class="grid-container sr-test-card-form-container"
+    >
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <label
+            class="usa-label margin-top-3"
+            data-testid="label"
+            for="current-date-time"
+          >
+            Test date and time
+             
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+          </label>
+          <div
+            class="usa-checkbox"
+            data-testid="checkbox"
+          >
+            <input
+              checked=""
+              class="usa-checkbox__input"
+              id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="current-date-time"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+            >
+              Current date and time
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+        data-testid="device-type-dropdown-container"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <div
+            class="usa-form-group prime-dropdown  card-dropdown"
+          >
+            <label
+              class="usa-label"
+              for="29"
+            >
+              <span
+                class="usa-tooltip usa-text-with-tooltip"
+                data-testid="tooltipWrapper"
+              >
+                <button
+                  aria-describedby="tooltip-1000000"
+                  aria-label=""
+                  class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                  data-testid="triggerElement"
+                  position="right"
+                  tabindex="0"
+                  title=""
+                  wrapperclasses="usa-text-with-tooltip"
+                >
+                  Test device
+                  <svg
+                    alt-text="info"
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-circle-info info-circle-icon"
+                    data-icon="circle-info"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  aria-hidden="true"
+                  class="usa-tooltip__body"
+                  data-testid="tooltipBody"
+                  id="tooltip-1000000"
+                  role="tooltip"
+                  title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                >
+                  Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                </span>
+              </span>
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <select
+              aria-label="Test device"
+              aria-required="true"
+              class="usa-select"
+              data-testid="device-type-dropdown"
+              id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="testDevice"
+            >
+              <option
+                aria-selected="false"
+                value="FLU-DEVICE-ID"
+              >
+                FLU
+              </option>
+              <option
+                aria-selected="false"
+                value="COVID-DEVICE-ID"
+              >
+                LumiraDX
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-DEVICE-ID"
+              >
+                Multiplex
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-COVID-DEVICE-ID"
+              >
+                MultiplexAndCovidOnly
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-col-auto"
+          data-testid="specimen-type-dropdown-container"
+        >
+          <div
+            class="usa-form-group prime-dropdown  card-dropdown"
+          >
+            <label
+              class="usa-label"
+              for="30"
+            >
+              Specimen type
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <select
+              aria-label="Specimen type"
+              aria-required="true"
+              class="usa-select"
+              data-testid="specimen-type-dropdown"
+              id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="specimenType"
+            >
+              <option
+                aria-selected="true"
+                value="SPECIMEN-1-ID"
+              >
+                Swab of internal nose
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="usa-form-group"
+          data-testid="formGroup"
+        >
+          <div
+            class="usa-alert usa-alert--error"
+            data-testid="alert"
+          >
+            <div
+              class="usa-alert__body"
+            >
+              <p
+                class="usa-alert__text"
+              >
+                This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col"
+          id="gonorrhea-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+        >
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <label
+                  class="usa-label"
+                  for="31"
+                  id="label-for-31"
+                >
+                  What is the gender of their sexual partners?
+                   
+                  <span
+                    class="text-base-dark"
+                  >
+                    (Select all that apply.)
+                  </span>
+                  <abbr
+                    class="usa-hint usa-hint--required"
+                    title="required"
+                  >
+                     
+                    *
+                  </abbr>
+                </label>
+                <span
+                  class=""
+                >
+                  <button
+                    class="usa-button usa-button--unstyled margin-top-05em"
+                    data-testid="button"
+                    type="button"
+                  >
+                    <svg
+                      alt-text="info"
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+                      data-icon="circle-info"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <strong
+                      class="font-body-2xs"
+                    >
+                      Why SimpleReport asks about sensitive topics like this
+                    </strong>
+                  </button>
+                </span>
+                <div
+                  class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
+                  data-testid="multi-select"
+                  id="31"
+                >
+                  <input
+                    aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    aria-labelledby="label-for-31"
+                    aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    aria-required="true"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    class="usa-combo-box__input"
+                    data-testid="multi-select-input"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
+                  <span
+                    class="usa-combo-box__input-button-separator"
+                  >
+                     
+                  </span>
+                  <span
+                    class="usa-combo-box__toggle-list__wrapper"
+                    tabindex="-1"
+                  >
+                    <button
+                      aria-hidden="true"
+                      class="usa-combo-box__toggle-list"
+                      data-testid="multi-select-toggle"
+                      tabindex="-1"
+                      type="button"
+                    >
+                       
+                    </button>
+                  </span>
+                  <ul
+                    class="usa-combo-box__list"
+                    data-testid="multi-select-option-list"
+                    hidden=""
+                    id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    role="listbox"
+                    tabindex="-1"
+                  >
+                    <li
+                      aria-posinset="1"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-female"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-0"
+                      role="option"
+                      tabindex="-1"
+                      value="female"
+                    >
+                      Female
+                    </li>
+                    <li
+                      aria-posinset="2"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-other"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-1"
+                      role="option"
+                      tabindex="-1"
+                      value="other"
+                    >
+                      Gender identity not listed here
+                    </li>
+                    <li
+                      aria-posinset="3"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-male"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-2"
+                      role="option"
+                      tabindex="-1"
+                      value="male"
+                    >
+                      Male
+                    </li>
+                    <li
+                      aria-posinset="4"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-nonbinary"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-3"
+                      role="option"
+                      tabindex="-1"
+                      value="nonbinary"
+                    >
+                      Nonbinary or gender non-conforming
+                    </li>
+                    <li
+                      aria-posinset="5"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-refused"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-4"
+                      role="option"
+                      tabindex="-1"
+                      value="refused"
+                    >
+                      Prefer not to answer
+                    </li>
+                    <li
+                      aria-posinset="6"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-transman"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-5"
+                      role="option"
+                      tabindex="-1"
+                      value="transman"
+                    >
+                      Transman
+                    </li>
+                    <li
+                      aria-posinset="7"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-transwoman"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-6"
+                      role="option"
+                      tabindex="-1"
+                      value="transwoman"
+                    >
+                      Transwoman
+                    </li>
+                  </ul>
+                  <div
+                    class="usa-combo-box__status usa-sr-only"
+                    role="status"
+                  />
+                </div>
+                <fieldset
+                  class="fieldset--unstyled pill-container pill-container--hidden"
+                  data-testid="pill-container"
+                >
+                  <legend
+                    class="usa-sr-only"
+                  >
+                    Selected [object Object]
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient pregnant?
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="32-val-77386006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="77386006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                        for="32-val-77386006"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="32-val-60001007"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="60001007"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                        for="32-val-60001007"
+                      >
+                        No
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="32-val-261665006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="261665006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                        for="32-val-261665006"
+                      >
+                        Prefer not to answer
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient currently experiencing or showing signs of symptoms?
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="33-val-YES"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="YES"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                        for="33-val-YES"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        checked=""
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="33-val-NO"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="NO"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                        for="33-val-NO"
+                      >
+                        No
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-4"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <button
+            class="usa-button"
+            data-testid="button"
+            type="button"
+          >
+            Submit results
+          </button>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-1"
+      >
+        <button
+          class="usa-button usa-button--unstyled margin-top-05em"
+          data-testid="button"
+          type="button"
+        >
+          <svg
+            alt-text="info"
+            aria-hidden="true"
+            class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+            data-icon="circle-info"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+              fill="currentColor"
+            />
+          </svg>
+          <strong
+            class="font-body-2xs"
+          >
+            Where results are sent
+          </strong>
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+  "user": Object {
+    "clear": [Function],
+    "click": [Function],
+    "copy": [Function],
+    "cut": [Function],
+    "dblClick": [Function],
+    "deselectOptions": [Function],
+    "hover": [Function],
+    "keyboard": [Function],
+    "paste": [Function],
+    "pointer": [Function],
+    "selectOptions": [Function],
+    "setup": [Function],
+    "tab": [Function],
+    "tripleClick": [Function],
+    "type": [Function],
+    "unhover": [Function],
+    "upload": [Function],
+  },
+}
+`;
+
 exports[`TestCardForm initial state matches snapshot for hepatitis c device 1`] = `
 Object {
   "asFragment": [Function],

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/STIGenericAOEForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/STIGenericAOEForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import moment from "moment";
 
-import { hepatitisCSymptomDefinitions } from "../../../../patientApp/timeOfTest/constants";
+import { SymptomDefinitionMap } from "../../../../patientApp/timeOfTest/constants";
 import { AoeQuestionResponses } from "../TestCardFormReducer";
 import { QueriedTestOrder } from "../types";
 import YesNoRadioGroup from "../../../commonComponents/YesNoRadioGroup";
@@ -18,19 +18,26 @@ import { PregnancyAoe } from "./aoeQuestionComponents/PregnancyAoe";
 import { GenderOfSexualPartnersAoe } from "./aoeQuestionComponents/GenderOfSexualPartnersAoe";
 import { SensitiveTopicsTooltipModal } from "./SensitiveTopicsTooltipModal";
 
-interface HepatitisCAoeFormProps {
+interface STIGenericAoeFormProps {
   testOrder: QueriedTestOrder;
   responses: AoeQuestionResponses;
   hasAttemptedSubmit: boolean;
   onResponseChange: (responses: AoeQuestionResponses) => void;
+  diseaseSymptomDefinitions: SymptomDefinitionMap[];
+  /**
+   * This is used for div ids
+   */
+  diseaseNameForFormIds: string;
 }
 
-export const HepatitisCAoeForm = ({
+export const STIGenericAOEForm = ({
   testOrder,
   responses,
   hasAttemptedSubmit,
   onResponseChange,
-}: HepatitisCAoeFormProps) => {
+  diseaseSymptomDefinitions,
+  diseaseNameForFormIds,
+}: STIGenericAoeFormProps) => {
   const { onHasAnySymptomsChange, onSymptomOnsetDateChange, onSymptomsChange } =
     generateAoeListenerHooks(onResponseChange, responses);
 
@@ -43,14 +50,14 @@ export const HepatitisCAoeForm = ({
   } = generateSymptomAoeConstants(
     responses,
     hasAttemptedSubmit,
-    hepatitisCSymptomDefinitions
+    diseaseSymptomDefinitions
   );
 
   const CHECKBOX_COLS_TO_DISPLAY = 3;
   return (
     <div
       className="grid-col"
-      id={`hepatitis-c-aoe-form-${testOrder.patient.internalId}`}
+      id={`${diseaseNameForFormIds}-aoe-form-${testOrder.patient.internalId}`}
     >
       <div className="grid-row">
         <div className="grid-col-auto">
@@ -101,7 +108,7 @@ export const HepatitisCAoeForm = ({
         <div className={"grid-row grid-gap width-full"}>
           <div className={"grid-col-auto"}>
             <Checkboxes
-              boxes={hepatitisCSymptomDefinitions.map(({ label, value }) => ({
+              boxes={diseaseSymptomDefinitions.map(({ label, value }) => ({
                 label,
                 value,
                 checked: symptoms[value],

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
@@ -1,4 +1,6 @@
 import {
+  gonorrheaSymptomDefinitions,
+  gonorrheaSymptomOrder,
   hepatitisCSymptomDefinitions,
   hepatitisCSymptomOrder,
   respiratorySymptomDefinitions,
@@ -27,6 +29,17 @@ describe("mapSymptomBoolLiteralsToBool", () => {
       hepatitisCSymptomDefinitions
     );
     hepatitisCSymptomOrder.forEach((symptomKey) => {
+      expect(parsedPayload[symptomKey]).toEqual(false);
+    });
+  });
+  it("takes a JSON payload of {'Gonorrhea symptom SNOMEDS' : boolean strings} and parses the strings into booleans", () => {
+    const gonorrheaSymptomPayload =
+      '{"49650001":false,"289560001":false,"399131003":false,"249661007":false,"90446007":false,"71393004":false,"131148009":false,"225595004":false}\n';
+    const parsedPayload = mapSymptomBoolLiteralsToBool(
+      gonorrheaSymptomPayload,
+      gonorrheaSymptomDefinitions
+    );
+    gonorrheaSymptomOrder.forEach((symptomKey) => {
       expect(parsedPayload[symptomKey]).toEqual(false);
     });
   });

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -4,6 +4,8 @@ import _ from "lodash";
 
 import { AoeQuestionResponses } from "../TestCardFormReducer";
 import {
+  gonorrheaSymptomDefinitions,
+  gonorrheaSymptomsMap,
   hepatitisCSymptomDefinitions,
   hepatitisCSymptomsMap,
   PregnancyCode,
@@ -183,6 +185,11 @@ export function stringifySymptomJsonForAoeUpdate(
       mapSymptomBoolLiteralsToBool(symptomJson, hepatitisCSymptomDefinitions)
     );
   }
+  if (_.isEqual(symptomKeys, Object.keys(gonorrheaSymptomsMap))) {
+    symptomPayload = JSON.stringify(
+      mapSymptomBoolLiteralsToBool(symptomJson, gonorrheaSymptomDefinitions)
+    );
+  }
   return symptomPayload;
 }
 
@@ -199,6 +206,9 @@ export function mapSpecifiedSymptomBoolLiteralsToBool(
   }
   if (disease === AOEFormOption.HEPATITIS_C) {
     symptomDefinitionToParse = hepatitisCSymptomDefinitions;
+  }
+  if (disease === AOEFormOption.GONORRHEA) {
+    symptomDefinitionToParse = gonorrheaSymptomDefinitions;
   }
   // there are no symptoms for that test card, so return true
   if (!symptomDefinitionToParse) return { shouldReturn: true };

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -9,6 +9,7 @@ import {
 } from "../../generated/graphql";
 import mockSupportedDiseaseTestPerformedHIV from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHIV";
 import mockSupportedDiseaseTestPerformedSyphilis from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedSyphilis";
+import mockSupportedDiseaseTestPerformedGonorrhea from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedGonorrhea";
 
 import { QueriedFacility, QueriedTestOrder } from "./TestCardForm/types";
 import mockSupportedDiseaseCovid from "./mocks/mockSupportedDiseaseCovid";
@@ -32,6 +33,8 @@ export const syphilisDeviceName = "SYPHILIS";
 export const syphilisDeviceId = "SYPHILIS-DEVICE-ID";
 export const hepatitisCDeviceName = "HEPATITIS C";
 export const hepatitisCDeviceId = "HEPATITIS C-DEVICE-ID";
+export const gonorrheaDeviceName = "GONORRHEA";
+export const gonorrheaDeviceId = "GONORRHEA-DEVICE-ID";
 
 // 6 instead of 7 because HIV devices are filtered out when HIV feature flag is disabled
 export const DEFAULT_DEVICE_OPTIONS_LENGTH = 6;
@@ -45,6 +48,7 @@ export const device6Name = "FluOnly";
 export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
 export const device9Name = "Hepatitis C device";
+export const device10Name = "Gonorrhea device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -55,6 +59,7 @@ export const device6Id = "DEVICE-6-ID";
 export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
 export const device9Id = "DEVICE-9-ID";
+export const device10Id = "DEVICE-10-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";
@@ -405,6 +410,21 @@ export const facilityInfo: QueriedFacility = {
       name: hivDeviceName,
       testLength: 15,
       supportedDiseaseTestPerformed: [...mockSupportedDiseaseTestPerformedHIV],
+      swabTypes: [
+        {
+          name: specimen1Name,
+          internalId: specimen1Id,
+          typeCode: "445297001",
+        },
+      ],
+    },
+    {
+      internalId: gonorrheaDeviceId,
+      name: gonorrheaDeviceName,
+      testLength: 15,
+      supportedDiseaseTestPerformed: [
+        ...mockSupportedDiseaseTestPerformedGonorrhea,
+      ],
       swabTypes: [
         {
           name: specimen1Name,

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -7,6 +7,7 @@ export enum MULTIPLEX_DISEASES {
   SYPHILIS = "Syphilis",
   FLU_A_AND_B = "Flu A and B",
   HEPATITIS_C = "Hepatitis C",
+  GONORRHEA = "Gonorrhea",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -18,6 +18,10 @@ export const useSupportedDiseaseList = () => {
       (d) => d !== MULTIPLEX_DISEASES.HEPATITIS_C
     );
   }
+  const gonorrheaEnabled = Boolean(useFeature("gonorrheaEnabled"));
+  if (!gonorrheaEnabled) {
+    allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.GONORRHEA);
+  }
   return allDiseases;
 };
 

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -157,18 +157,45 @@ export const hepatitisCSymptomDefinitions: SymptomDefinitionMap[] =
     label: hepatitisCSymptomsMap[value],
   }));
 
+export const gonorrheaSymptomsMap = {
+  "49650001": "Painful or burning sensation when peeing",
+  "289560001": "Increased vaginal discharge",
+  "399131003": "Vaginal bleeding between periods",
+  "249661007": "Discharge from anus",
+  "90446007": "Anal itching",
+  "71393004": "Soreness",
+  "131148009": "Anal bleeding",
+  "225595004": "Painful bowel movements",
+} as const;
+
+export type GonorrheaSymptoms = typeof gonorrheaSymptomsMap;
+export type GonorrheaSymptomCode = keyof GonorrheaSymptoms;
+export type GonorrheaSymptomName = GonorrheaSymptoms[GonorrheaSymptomCode];
+
+export const gonorrheaSymptomOrder: GonorrheaSymptomCode[] =
+  alphabetizeSymptomKeysFromMapValues(gonorrheaSymptomsMap);
+
+export const gonorrheaSymptomDefinitions: SymptomDefinitionMap[] =
+  gonorrheaSymptomOrder.map((value) => ({
+    value,
+    label: gonorrheaSymptomsMap[value],
+  }));
+
 export const SYMPTOM_SUBQUESTION_ERROR =
   "This question is required if the patient has symptoms.";
 export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";
 
 export type AllSymptomsCode = keyof RespiratorySymptoms &
   keyof SyphilisSymptoms &
-  keyof HepatitisCSymptoms;
+  keyof HepatitisCSymptoms &
+  keyof GonorrheaSymptoms;
 export type AllSymptomsName = RespiratorySymptomName &
   SyphilisSymptomName &
-  HepatitisCSymptomName;
+  HepatitisCSymptomName &
+  GonorrheaSymptomName;
 export const allSymptomsMap = {
   ...syphilisSymptomsMap,
   ...respiratorySymptomsMap,
   ...hepatitisCSymptomsMap,
+  ...gonorrheaSymptomsMap,
 };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7434 

## Changes Proposed

- Adds support for Gonorrhea to the test card
- Converts the `HepatitisCAoeForm` component into `STIGenericAoeForm` that receives the disease specific data as props. This component is used for Hep C AOE and Gonorrhea AOE

## Additional Information

- This also adds support for Gonorrhea on the dashboard and (most) of the result page besides result specific guidance and some conditional logic for showing genders of sexual partners on view details
- Gonorrhea symptoms list may not necessarily be final ([see this Slack thread](https://skylight-hq.slack.com/archives/C065V4DHBQF/p1732566859771869))

## Testing

- Deployed on dev5
- Gonorrhea test device has been created on Boban's Org and boban 1 facility

## Screenshots
![image](https://github.com/user-attachments/assets/45147d73-b50c-4142-bafc-50ce57fe8b10)
