### PR TITLE
Add prod device sync related secrets to tf configs

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -159,6 +159,9 @@ simple-report:
   fhir-reporting-enabled: true
   support-escalation:
     enabled: false
+  production:
+    backend-url: ${SR_PROD_BACKEND_URL:http://localhost:8080}
+    devices-token: ${SR_PROD_DEVICES_TOKEN:sr-prod-devices-fake-token}
 twilio:
   messaging-service-sid: ${TWILIO_MESSAGING_SID}
 logging:

--- a/ops/demo/_data.tf
+++ b/ops/demo/_data.tf
@@ -182,3 +182,14 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+

--- a/ops/demo/api.tf
+++ b/ops/demo/api.tf
@@ -53,6 +53,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev/_data.tf
+++ b/ops/dev/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -59,6 +59,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev2/_data.tf
+++ b/ops/dev2/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev2/api.tf
+++ b/ops/dev2/api.tf
@@ -60,6 +60,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev3/_data.tf
+++ b/ops/dev3/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev3/api.tf
+++ b/ops/dev3/api.tf
@@ -60,6 +60,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev4/_data.tf
+++ b/ops/dev4/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev4/api.tf
+++ b/ops/dev4/api.tf
@@ -60,6 +60,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev5/_data.tf
+++ b/ops/dev5/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev5/api.tf
+++ b/ops/dev5/api.tf
@@ -60,7 +60,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
-
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev6/_data.tf
+++ b/ops/dev6/_data.tf
@@ -235,3 +235,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/dev6/api.tf
+++ b/ops/dev6/api.tf
@@ -61,6 +61,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/pentest/_data.tf
+++ b/ops/pentest/_data.tf
@@ -216,3 +216,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/pentest/api.tf
+++ b/ops/pentest/api.tf
@@ -60,6 +60,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/prod/_data.tf
+++ b/ops/prod/_data.tf
@@ -248,3 +248,13 @@ data "azurerm_key_vault_secret" "slack_hook_token" {
   name         = "slack-hook-token-prod"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -65,7 +65,8 @@ module "simple_report_api" {
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
     SLACK_HOOK_TOKEN                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_hook_token.id})"
-
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -243,3 +243,13 @@ data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
   name         = "report-stream-exception-callback-test"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -64,7 +64,8 @@ module "simple_report_api" {
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
     AZ_REPORTING_QUEUE_CXN_STRING                 = data.azurerm_storage_account.app.primary_connection_string
     RS_QUEUE_CALLBACK_TOKEN                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.report_stream_exception_callback_token.id})"
-
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/test/_data.tf
+++ b/ops/test/_data.tf
@@ -240,3 +240,13 @@ data "azurerm_key_vault_secret" "slack_hook_token" {
   name         = "slack-hook-token-test"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}

--- a/ops/test/api.tf
+++ b/ops/test/api.tf
@@ -58,7 +58,8 @@ module "simple_report_api" {
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
     SLACK_HOOK_TOKEN                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_hook_token.id})"
-
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default, can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows/overrides an identical declaration in application.yaml

--- a/ops/training/_data.tf
+++ b/ops/training/_data.tf
@@ -210,3 +210,13 @@ data "azurerm_key_vault_secret" "datahub_signing_key" {
   name         = "datahub-signing-key-test"
   key_vault_id = data.azurerm_key_vault.global.id
 }
+
+data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
+  name         = "simple-report-prod-backend-url"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
+  name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}

--- a/ops/training/api.tf
+++ b/ops/training/api.tf
@@ -55,7 +55,8 @@ module "simple_report_api" {
     DATAHUB_API_KEY                               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_api_key.id})"
     DATAHUB_FHIR_KEY                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_fhir_key.id})"
     DATAHUB_SIGNING_KEY                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.datahub_signing_key.id})"
-
+    SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
+    SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml


### PR DESCRIPTION
# BACKEND & DEVOPS PULL REQUEST

## Related Issue

- Part I of #7492 

## Changes Proposed

- Adds the following references to our secrets in our Azure key vault in all the terraform files
  - `simple-report-prod-backend-url`
  - `simple-report-prod-devices-token`

## Additional Information

- This works allows us to protect the soon-to-be-added public prod device sync related endpoints
- The token will be passed as part of the request headers

## Testing
- Navigate to our [Azure key vault](https://portal.azure.com/#@cdc.onmicrosoft.com/resource/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-simple-report-management/providers/Microsoft.KeyVault/vaults/simple-report-global/secrets) and ensure the keys and values are there as expected

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->