### PR TITLE
Use new RS sender client for bulk upload

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -174,7 +174,7 @@ datahub:
   jwt-scope: "simple_report.*.report"
   signing-key: ${DATAHUB_SIGNING_KEY:super-secret-signing-key}
   csv-upload-api-client: "simple_report.csvuploader"
-  csv-upload-api-fhir-client: "simple_report.fullelr"
+  csv-upload-api-fhir-client: "simple_report.fullelr-bulkuploader"
 features:
   oktaMigrationEnabled: false
   gonorrheaEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #8031 

## Changes Proposed

- Changes config for bulk upload so that it sends to RS with the `simple_report.fullelr-bulkuploader` client parameter instead of `simple_report.fullelr`. This will help RS separate results from single entry and bulk upload.

## Additional Information

- RS confirmed that results were successfully sent in [this slack thread](https://skylight-hq.slack.com/archives/C0411VC78DN/p1732735456639899?thread_ts=1723234595.104049&cid=C0411VC78DN)

## Testing

- As long as you have the `datahub` configuration credentials in `application-local.yaml`, you can test this locally by submitting a bulk upload and verifying that you receive the confirmation code/report id from the successful submission to RS staging
- Also deployed to dev5 for testing