### PR TITLE
Elisa/7492 public device endpoint

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
@@ -3,21 +3,26 @@ package gov.cdc.usds.simplereport.api.devicetype;
 import com.fasterxml.jackson.annotation.JsonView;
 import gov.cdc.usds.simplereport.api.model.errors.DryRunException;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.service.DeviceTypeProdSyncService;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.DeviceTypeSyncService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
-@RequiredArgsConstructor
 public class DeviceTypeController {
-  private final DeviceTypeSyncService deviceTypeSyncService;
-  private final DeviceTypeService deviceTypeService;
+  @Autowired private DeviceTypeSyncService deviceTypeSyncService;
+  @Autowired private DeviceTypeProdSyncService deviceTypeProdSyncService;
+  @Autowired private DeviceTypeService deviceTypeService;
 
   @GetMapping("/devices/sync")
   public void syncDevices(@RequestParam boolean dryRun) {
@@ -30,11 +35,14 @@ public class DeviceTypeController {
 
   @GetMapping("/devices")
   @JsonView(PublicDeviceType.class)
-  public List<DeviceType> getDevices() {
+  public ResponseEntity<Object> getDevices(HttpServletRequest request) {
     try {
-      return deviceTypeService.fetchDeviceTypes();
-    } catch (Exception e) {
-      return null;
+      String headerToken = request.getHeader("Sr-Prod-Devices-Token");
+      deviceTypeProdSyncService.validateToken(headerToken);
+      List<DeviceType> devices = deviceTypeService.fetchDeviceTypes();
+      return ResponseEntity.status(HttpStatus.OK).body(devices);
+    } catch (AccessDeniedException e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
@@ -1,17 +1,23 @@
 package gov.cdc.usds.simplereport.api.devicetype;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import gov.cdc.usds.simplereport.api.model.errors.DryRunException;
+import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.service.DeviceTypeService;
 import gov.cdc.usds.simplereport.service.DeviceTypeSyncService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
+@RequiredArgsConstructor
 public class DeviceTypeController {
-  @Autowired private DeviceTypeSyncService deviceTypeSyncService;
+  private final DeviceTypeSyncService deviceTypeSyncService;
+  private final DeviceTypeService deviceTypeService;
 
   @GetMapping("/devices/sync")
   public void syncDevices(@RequestParam boolean dryRun) {
@@ -19,6 +25,16 @@ public class DeviceTypeController {
       deviceTypeSyncService.syncDevices(dryRun);
     } catch (DryRunException e) {
       log.info("Dry run");
+    }
+  }
+
+  @GetMapping("/devices")
+  @JsonView(PublicDeviceType.class)
+  public List<DeviceType> getDevices() {
+    try {
+      return deviceTypeService.fetchDeviceTypes();
+    } catch (Exception e) {
+      return null;
     }
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/PublicDeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/PublicDeviceType.java
@@ -1,0 +1,3 @@
+package gov.cdc.usds.simplereport.api.devicetype;
+
+public interface PublicDeviceType {}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/SecurityConfiguration.java
@@ -84,6 +84,9 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, WebConfiguration.USER_ACCOUNT_REQUEST + "/**")
                     .permitAll()
+                    // Devices endpoint authorization is handled at the service or controller level
+                    .requestMatchers(HttpMethod.GET, WebConfiguration.DEVICES + "/**")
+                    .permitAll()
                     // Anything else goes through Okta
                     .anyRequest()
                     .authenticated())

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/WebConfiguration.java
@@ -24,6 +24,8 @@ public class WebConfiguration implements WebMvcConfigurer {
   public static final String PATIENT_UPLOAD = "/upload/patients";
   public static final String RESULT_UPLOAD = "/upload/results";
   public static final String CONDITION_AGNOSTIC_RESULT_UPLOAD = "/upload/condition-agnostic";
+
+  public static final String DEVICES = "/devices";
   public static final String GRAPH_QL = "/graphql";
 
   @Autowired private RestLoggingInterceptor _loggingInterceptor;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -47,7 +47,6 @@ public class DeviceType extends EternalAuditedEntity {
   @JsonView(PublicDeviceType.class)
   private int testLength;
 
-  //  @JsonIgnore
   @OneToMany(mappedBy = "deviceTypeId", cascade = CascadeType.ALL, orphanRemoval = true)
   @JsonView(PublicDeviceType.class)
   List<DeviceTypeDisease> supportedDiseaseTestPerformed = new ArrayList<>();

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceType.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import gov.cdc.usds.simplereport.api.devicetype.PublicDeviceType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,12 +24,15 @@ import org.springframework.boot.context.properties.bind.ConstructorBinding;
 public class DeviceType extends EternalAuditedEntity {
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String name;
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String manufacturer;
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String model;
 
   @JoinTable(
@@ -36,13 +40,16 @@ public class DeviceType extends EternalAuditedEntity {
       joinColumns = @JoinColumn(name = "device_type_id"),
       inverseJoinColumns = @JoinColumn(name = "specimen_type_id"))
   @OneToMany(fetch = FetchType.LAZY)
+  @JsonView(PublicDeviceType.class)
   private List<SpecimenType> swabTypes;
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private int testLength;
 
-  @JsonIgnore
+  //  @JsonIgnore
   @OneToMany(mappedBy = "deviceTypeId", cascade = CascadeType.ALL, orphanRemoval = true)
+  @JsonView(PublicDeviceType.class)
   List<DeviceTypeDisease> supportedDiseaseTestPerformed = new ArrayList<>();
 
   protected DeviceType() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -21,7 +21,6 @@ import lombok.NoArgsConstructor;
 public class DeviceTypeDisease extends IdentifiedEntity {
 
   @Column(name = "device_type_id")
-  @JsonView(PublicDeviceType.class)
   private UUID deviceTypeId;
 
   @ManyToOne

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import gov.cdc.usds.simplereport.api.devicetype.PublicDeviceType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
@@ -19,19 +21,40 @@ import lombok.NoArgsConstructor;
 public class DeviceTypeDisease extends IdentifiedEntity {
 
   @Column(name = "device_type_id")
+  @JsonView(PublicDeviceType.class)
   private UUID deviceTypeId;
 
   @ManyToOne
   @JoinColumn(name = "supported_disease_id")
   private SupportedDisease supportedDisease;
 
-  @Column private String testPerformedLoincCode;
-  @Column private String testPerformedLoincLongName;
-  @Column private String equipmentUid;
-  @Column private String equipmentUidType;
-  @Column private String testkitNameId;
-  @Column private String testOrderedLoincCode;
-  @Column private String testOrderedLoincLongName;
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String testPerformedLoincCode;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String testPerformedLoincLongName;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String equipmentUid;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String equipmentUidType;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String testkitNameId;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String testOrderedLoincCode;
+
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String testOrderedLoincLongName;
 
   @Override
   public boolean equals(Object o) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SpecimenType.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.db.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import gov.cdc.usds.simplereport.api.devicetype.PublicDeviceType;
 import gov.cdc.usds.simplereport.validators.NumericCode;
 import gov.cdc.usds.simplereport.validators.RequiredNumericCode;
 import jakarta.persistence.Column;
@@ -12,16 +14,23 @@ import org.springframework.boot.context.properties.bind.ConstructorBinding;
 public class SpecimenType extends EternalAuditedEntity {
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String name;
 
   @Column(nullable = false, updatable = false)
   @RequiredNumericCode
   @NaturalId
+  @JsonView(PublicDeviceType.class)
   private String typeCode;
 
-  @Column private String collectionLocationName;
+  @Column
+  @JsonView(PublicDeviceType.class)
+  private String collectionLocationName;
 
-  @Column @NumericCode private String collectionLocationCode;
+  @Column
+  @NumericCode
+  @JsonView(PublicDeviceType.class)
+  private String collectionLocationCode;
 
   protected SpecimenType() {} // for hibernate
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeProdSyncService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeProdSyncService.java
@@ -1,0 +1,23 @@
+package gov.cdc.usds.simplereport.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Service to fetch and save DeviceTypes from our prod env */
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class DeviceTypeProdSyncService {
+  @Value("${simple-report.production.devices-token}")
+  private String token;
+
+  public boolean validateToken(String headerToken) throws AccessDeniedException {
+    if (token.equals(headerToken)) {
+      return true;
+    }
+    throw new AccessDeniedException("Access denied");
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceTypeControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceTypeControllerTest.java
@@ -1,0 +1,90 @@
+package gov.cdc.usds.simplereport.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import gov.cdc.usds.simplereport.service.DeviceTypeProdSyncService;
+import gov.cdc.usds.simplereport.test_util.TestUserIdentities;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+class DeviceTypeControllerTest extends BaseFullStackTest {
+
+  @Autowired private MockMvc _mockMvc;
+  @MockBean private DeviceTypeProdSyncService _mockDeviceTypeProdSyncService;
+
+  @BeforeEach
+  void init() {
+    TestUserIdentities.withStandardUser(
+        () -> {
+          _dataFactory.initGenericDeviceTypeAndSpecimenType();
+        });
+  }
+
+  @Test
+  void getDevices_withValidateToken_success() throws Exception {
+    when(_mockDeviceTypeProdSyncService.validateToken(any())).thenReturn(true);
+    MockHttpServletRequestBuilder builder =
+        get(ResourceLinks.DEVICES)
+            .contentType(MediaType.valueOf(MediaType.APPLICATION_JSON_VALUE))
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8");
+
+    MvcResult result = this._mockMvc.perform(builder).andReturn();
+    MockHttpServletResponse res = result.getResponse();
+
+    assertThat(res.getStatus()).isEqualTo(200);
+
+    JSONArray jsonRes = new JSONArray(res.getContentAsString());
+    assertThat(jsonRes.length()).isEqualTo(1);
+
+    JSONObject deviceType = jsonRes.getJSONObject(0);
+    assertThat(deviceType.getString("manufacturer")).isEqualTo("Acme");
+    assertThat(deviceType.getString("model")).isEqualTo("SFN");
+    assertThat(deviceType.getString("name")).isEqualTo("Acme SuperFine");
+    assertThat(deviceType.getInt("testLength")).isEqualTo(15);
+    assertThat(deviceType.getJSONArray("supportedDiseaseTestPerformed")).isEmpty();
+    // ensure deviceType internalId is not returned
+    assertTrue(deviceType.isNull("internalId"));
+
+    JSONArray swabTypes = deviceType.getJSONArray("swabTypes");
+    assertThat(swabTypes.length()).isEqualTo(1);
+    JSONObject swabType = swabTypes.getJSONObject(0);
+    assertThat(swabType.getString("collectionLocationCode")).isEqualTo("986543321");
+    assertThat(swabType.getString("collectionLocationName")).isEqualTo("Da Nose");
+    assertThat(swabType.getString("name")).isEqualTo("Nasal swab");
+    assertThat(swabType.getString("typeCode")).isEqualTo("000111222");
+    // ensure swabType internalId is not returned
+    assertTrue(swabType.isNull("internalId"));
+  }
+
+  @Test
+  void getDevices_withValidateToken_failure() throws Exception {
+    when(_mockDeviceTypeProdSyncService.validateToken(any()))
+        .thenThrow(new AccessDeniedException("Bad token"));
+    MockHttpServletRequestBuilder builder =
+        get(ResourceLinks.DEVICES)
+            .contentType(MediaType.valueOf(MediaType.APPLICATION_JSON_VALUE))
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8");
+
+    MvcResult result = this._mockMvc.perform(builder).andReturn();
+    MockHttpServletResponse res = result.getResponse();
+
+    assertThat(res.getStatus()).isEqualTo(401);
+    assertThat(res.getContentAsString()).isEmpty();
+  }
+}

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/ResourceLinks.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.api;
 
 /** Container class for test constants related to REST handler testing */
 public final class ResourceLinks {
+  public static final String DEVICES = "/devices";
   public static final String VERIFY_LINK_V2 = "/pxp/link/verify/v2";
 
   public static final String SELF_REGISTER = "/pxp/register";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeProdSyncServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeProdSyncServiceTest.java
@@ -1,0 +1,23 @@
+package gov.cdc.usds.simplereport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+
+class DeviceTypeProdSyncServiceTest extends BaseServiceTest<DeviceTypeProdSyncService> {
+  @Value("${simple-report.production.devices-token}")
+  private String token;
+
+  @Test
+  void validateToken_withValidToken_success() {
+    assertThat(_service.validateToken(token)).isTrue();
+  }
+
+  @Test
+  void validateToken_withInvalidToken_throwsException() {
+    assertThrows(AccessDeniedException.class, () -> _service.validateToken("foo"));
+  }
+}


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
- Part II of #7492

## Changes Proposed

- Add a public endpoint `/devices` that returns all `DeviceType`s (without any internal ids)
  - leverage [`@JsonView` annotation](https://www.baeldung.com/jackson-json-view-annotation) to return certain fields
  - protect the endpoint by ensuring the request to that endpoint has a custom header `Sr-Prod-Devices-Token` with the valid token (See #8323 for how to get the token value)

## Additional Information
- co-authored by @DanielSass
- created a new `DeviceTypeProdSyncService` for logic related to the device sync from prod
  - TBD I may or may not combine this with the existing [DeviceTypeSyncService](https://github.com/CDCgov/prime-simplereport/blob/a6fa1a9e4278a61e9531ebde0e3e53a28791ce12/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeSyncService.java#L43) or just rename this service to make it clear it is for the LIVD sync will depend on how the sync is implemented in part III

## Testing
- deployed on `dev4`
- use an API testing tool of your choice to fetch the device list from `dev4`
   e.g.
   ```
   curl --header "Sr-Prod-Devices-Token: REPLACE_TOKEN_HERE" https://dev4.simplereport.gov/api/devices
   ```
   - you should see the entire list without any InternalIds
- use an API testing tool of your choice to hit that same endpoint without the `Sr-Prod-Devices-Token` header
   e.g.
   ```
   curl -v  https://dev4.simplereport.gov/api/devices
   ```
   - you should see no devices and see that the request is `Unauthorized`

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
