### PR TITLE
Add Chlamydia to Supported Diseases Table

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5701,3 +5701,21 @@ databaseChangeLog:
           - sql:
               sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Gonorrhea';
 
+  - changeSet:
+      id: add-chlamydia-to-supported_disease-table
+      author: bobby@skyliight.digital
+      comment: Add chlamydia to the supported_disease table.
+      changes:
+        - tagDatabase:
+            tag: add-chlamydia-to-supported_disease-table
+        - sql:
+            sql: |
+              INSERT INTO ${database.defaultSchemaName}.supported_disease (
+                   internal_id,
+                   name,
+                   loinc)
+              VALUES
+                   (gen_random_uuid(), 'Chlamydia', 'LP14298-1')
+      rollback:
+        - sql:
+            sql: DELETE FROM ${database.defaultSchemaName}.supported_disease WHERE name = 'Chlamydia';


### PR DESCRIPTION
# DATABASE PULL REQUEST

## Related Issue

- Part of #7451 

## Changes Proposed

- Adds chlamydia to the SupportedDiseases table


## Testing
- Verify that Chlamydia  is available as an option for support admins adding a new test device on dev5 
<img width="668" alt="Screenshot 2024-12-10 at 1 01 06 PM" src="https://github.com/user-attachments/assets/f1e01d3f-9a0e-43b2-a3fa-36fadabb8804">
