### PR TITLE
Use var instead of const

### DIFF
--- a/frontend/public/touchpoints.js
+++ b/frontend/public/touchpoints.js
@@ -654,7 +654,7 @@ var formOptions = {
 
 // Note: When updating Touchpoints you need to update this HTML
 // To whoever has to maintain this, I'm sorry this is so gross.
-const touchpointsFormHtmlString = `
+var touchpointsFormHtmlString = `
   <div class="fba-modal">
     <div id="fba-modal-dialog" class="fba-modal-dialog" role="dialog" aria-modal="true">
       <div class="touchpoints-form-wrapper" id="touchpoints-form-5b1efe87" data-touchpoints-form-id="5b1efe87" tabindex="-1">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Running this locally was causing this runtime error to appear
<img width="1280" alt="Screenshot 2024-12-12 at 15 38 39" src="https://github.com/user-attachments/assets/a239e46c-8a49-4f8f-a044-965ee08f4932" />

## Changes Proposed
- Touchpoints form modal should open as expected

## Additional Information

## Testing
- Running app locally should no longer show runtime error

## Screenshots / Demos
<img width="1557" alt="Screenshot 2024-12-12 at 17 25 06" src="https://github.com/user-attachments/assets/8bc224ea-5fc1-45a1-a2b3-5c082dcc6955" />


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
