### PR TITLE
Add liquibase-gradle-plugin as buildscript dependency

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         classpath 'org.liquibase:liquibase-core:4.29.1'
+        classpath "org.liquibase:liquibase-gradle-plugin:3.0.1"
     }
 }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Running any liquibase command locally was running into issues.
e.g. running `./gradlew liquibaseRollbackCount -PliquibaseCount=1` resulted in the following:
```
Error parsing command line: Invalid argument '--changelog-file': missing required argument. If you need to configure new liquibase project files and arguments, run the 'liquibase init project' command.
```

## Changes Proposed
- Fixes bug introduced as part of #8234 

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing
- 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
