### PR TITLE
CSV Bulk Results Uploader supports Chlamydia test results

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/filerow/TestResultRow.java
@@ -541,6 +541,18 @@ public class TestResultRow implements FileRow {
                 equipmentModelName.getValue(), testPerformedCode.getValue()));
   }
 
+  private boolean isChlamydiaResult() {
+    if (equipmentModelName.getValue() == null || testPerformedCode.getValue() == null) {
+      return false;
+    }
+
+    return resultsUploaderCachingService
+        .getChlamydiaEquipmentModelAndTestPerformedCodeSet()
+        .contains(
+            ResultsUploaderCachingService.getKey(
+                equipmentModelName.getValue(), testPerformedCode.getValue()));
+  }
+
   private List<FeedbackMessage> generateInvalidDataErrorMessages() {
     String errorMessage =
         "Invalid " + EQUIPMENT_MODEL_NAME + " and " + TEST_PERFORMED_CODE + " combination";
@@ -681,6 +693,14 @@ public class TestResultRow implements FileRow {
           validateRequiredFieldsForPositiveResult(
               testResult,
               DiseaseService.GONORRHEA_NAME,
+              List.of(gendersOfSexualPartners, pregnant, symptomaticForDisease)));
+    }
+
+    if (isChlamydiaResult()) {
+      errors.addAll(
+          validateRequiredFieldsForPositiveResult(
+              testResult,
+              DiseaseService.CHLAMYDIA_NAME,
               List.of(gendersOfSexualPartners, pregnant, symptomaticForDisease)));
     }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/CachingConfig.java
@@ -17,6 +17,9 @@ public class CachingConfig {
 
   public static final String GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "gonorrheaEquipmentModelAndTestPerformedCodeSet";
+
+  public static final String CHLAMYDIA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
+      "chlamydiaEquipmentModelAndTestPerformedCodeSet";
   public static final String HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
       "hivEquipmentModelAndTestPerformedCodeSet";
   public static final String SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET =
@@ -36,6 +39,7 @@ public class CachingConfig {
         GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         HIV_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         SYPHILIS_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+        CHLAMYDIA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
         DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP,
         SPECIMEN_NAME_TO_SNOMED_MAP,
         SNOMED_TO_SPECIMEN_NAME_MAP,

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DiseaseService.java
@@ -26,6 +26,7 @@ public class DiseaseService {
   public static final String HIV_NAME = "HIV";
   public static final String SYPHILIS_NAME = "Syphilis";
   public static final String GONORRHEA_NAME = "Gonorrhea";
+  public static final String CHLAMYDIA_NAME = "Chlamydia";
 
   private final DiseaseCacheService diseaseCacheService;
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.service;
 
 import static gov.cdc.usds.simplereport.config.CachingConfig.ADDRESS_TIMEZONE_LOOKUP_MAP;
+import static gov.cdc.usds.simplereport.config.CachingConfig.CHLAMYDIA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.COVID_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
 import static gov.cdc.usds.simplereport.config.CachingConfig.DEVICE_MODEL_AND_TEST_PERFORMED_CODE_MAP;
 import static gov.cdc.usds.simplereport.config.CachingConfig.GONORRHEA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET;
@@ -177,6 +178,12 @@ public class ResultsUploaderCachingService {
     return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.GONORRHEA_NAME);
   }
 
+  @Cacheable(CHLAMYDIA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET)
+  public Set<String> getChlamydiaEquipmentModelAndTestPerformedCodeSet() {
+    log.info("generating chlamydiaEquipmentModelAndTestPerformedCodeSet cache");
+    return getDiseaseSpecificEquipmentModelAndTestPerformedCodeSet(DiseaseService.CHLAMYDIA_NAME);
+  }
+
   @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
   @Caching(
       evict = {
@@ -219,6 +226,18 @@ public class ResultsUploaderCachingService {
   public void cacheGonorrheaEquipmentModelAndTestPerformedCodeSet() {
     log.info("clear and generate gonorrheaEquipmentModelAndTestPerformedCodeSet cache");
     getGonorrheaEquipmentModelAndTestPerformedCodeSet();
+  }
+
+  @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
+  @Caching(
+      evict = {
+        @CacheEvict(
+            value = CHLAMYDIA_EQUIPMENT_MODEL_AND_TEST_PERFORMED_CODE_SET,
+            allEntries = true)
+      })
+  public void cacheChlamydiaEquipmentModelAndTestPerformedCodeSet() {
+    log.info("clear and generate chlamydiaEquipmentModelAndTestPerformedCodeSet cache");
+    getChlamydiaEquipmentModelAndTestPerformedCodeSet();
   }
 
   @Cacheable(SNOMED_TO_SPECIMEN_NAME_MAP)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/TestResultRowTest.java
@@ -558,6 +558,37 @@ class TestResultRowTest {
                     "This is required because the row contains a positive Gonorrhea test result."));
   }
 
+  @Test
+  void validatePositiveChlamydiaRequiredAoeFields() {
+    Map<String, String> missingChlamydiaRequiredAoeFields =
+        getPositiveResultRowMap("Chlamydia Model", "14298-1");
+    missingChlamydiaRequiredAoeFields.put("pregnant", "");
+    missingChlamydiaRequiredAoeFields.put("genders_of_sexual_partners", "");
+    missingChlamydiaRequiredAoeFields.put("symptomatic_for_disease", "");
+
+    ResultsUploaderCachingService resultsUploaderCachingService =
+        mock(ResultsUploaderCachingService.class);
+    when(resultsUploaderCachingService.getModelAndTestPerformedCodeToDeviceMap())
+        .thenReturn(Map.of("chlamydia model|14298-1", TestDataBuilder.createDeviceType()));
+    when(resultsUploaderCachingService.getChlamydiaEquipmentModelAndTestPerformedCodeSet())
+        .thenReturn(Set.of("chlamydia model|14298-1"));
+
+    TestResultRow testResultRow =
+        new TestResultRow(
+            missingChlamydiaRequiredAoeFields,
+            resultsUploaderCachingService,
+            mock(FeatureFlagsConfig.class));
+
+    List<FeedbackMessage> actual = testResultRow.validateIndividualValues();
+
+    assertThat(actual).hasSize(3);
+    actual.forEach(
+        message ->
+            assertThat(message.getMessage())
+                .contains(
+                    "This is required because the row contains a positive Chlamydia test result."));
+  }
+
   @NotNull
   private Map<String, String> getPositiveResultRowMap(
       String deviceModelName, String testPerformedCode) {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #7451 

## Changes Proposed

- Bulk upload throws a validation error if user tries to upload a positive Chlamydia result without the required AOE columns (`pregnancy`, `gender_of_sexual_partners`, `symptomatic_for_disease`)


