### PR TITLE
Remove ordering provider column from facility

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Facility.java
@@ -34,10 +34,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
 
   @Column @Getter @Setter private String cliaNumber;
 
-  @ManyToOne(optional = false)
-  @JoinColumn(name = "ordering_provider_id", nullable = false)
-  private Provider orderingProvider;
-
   @ManyToOne
   @JoinColumn(name = "default_ordering_provider_id")
   private Provider defaultOrderingProvider;
@@ -77,7 +73,6 @@ public class Facility extends OrganizationScopedEternalEntity implements Located
     this.address = facilityBuilder.facilityAddress;
     this.telephone = facilityBuilder.phone;
     this.email = facilityBuilder.email;
-    this.orderingProvider = facilityBuilder.orderingProvider;
     this.defaultOrderingProvider = facilityBuilder.orderingProvider;
     this.orderingProviders.add(facilityBuilder.orderingProvider);
     this.configuredDeviceTypes.addAll(facilityBuilder.configuredDevices);

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5804,3 +5804,36 @@ databaseChangeLog:
               SET
                 default_ordering_provider_id = NULL
               WHERE facility.default_ordering_provider_id is NOT NULL;
+  - changeSet:
+      id: drop-ordering-provider-column
+      author: tnd8@cdc.gov
+      changes:
+        - dropColumn:
+            columnName: ordering_provider_id
+            tableName: facility
+      rollback:
+        - addColumn:
+            tableName: facility
+            columns:
+              - column:
+                  name: ordering_provider_id
+                  type: uuid
+                  remarks: The healthcare provider who orders tests at this facility.
+                  constraints:
+                    foreignKeyName: fk__facility__ordering_provider
+                    referencedTableName: provider
+        - sql:
+            sql: |
+              UPDATE ${database.defaultSchemaName}.facility
+              SET ordering_provider_id = COALESCE(
+                  default_ordering_provider_id, 
+                  (
+                    SELECT provider_id
+                    FROM ${database.defaultSchemaName}.facility_providers
+                    WHERE facility_providers.facility_id = facility.internal_id
+                    LIMIT 1
+                  )
+                );
+        - addNotNullConstraint:
+            tableName: facility
+            columnName: ordering_provider_id

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5808,6 +5808,8 @@ databaseChangeLog:
       id: drop-ordering-provider-column
       author: tnd8@cdc.gov
       changes:
+        - tagDatabase:
+            tag: facility-supports-multiple-providers
         - dropColumn:
             columnName: ordering_provider_id
             tableName: facility


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Follow up on #8271 - removing unused ordering provider column
Part of implementation of #7982 

## Changes Proposed

Remove the unused ordering_provider_id column

## Additional Information

Rollback copies value from `default_ordering_provider_id` or gets value from `facility_providers` table in case default is null (jic since default field does not have the not-null constraint so it's not guaranteed to have a value)

## Testing

To test the full rollback logic, in my local setup I manually updated one of the rows in `facility` to have `default_ordering_provider_id = NULL` and then ran the rollback and verified it populated `ordering_provider_id` with a valid value from the `facility_providers` table

Deployed to `dev4` - will need to hold this env til this gets merged to `main` since removing the column will cause build issues for versions of the backend that still have that field