### PR TITLE
Hotfix to catch MisconfiguredUserException

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -730,10 +730,14 @@ public class ApiUserService {
     OrganizationRoles orgRoles =
         getOrganizationRoles(Optional.ofNullable(oktaClaims), apiUser, isSiteAdmin);
 
-    _dbOrgRoleClaimsService.checkOrgRoleClaimsEquality(
-        List.of(oktaClaims),
-        List.of(_dbOrgRoleClaimsService.getOrganizationRoleClaims(apiUser)),
-        apiUser.getLoginEmail());
+    try {
+      _dbOrgRoleClaimsService.checkOrgRoleClaimsEquality(
+          List.of(oktaClaims),
+          List.of(_dbOrgRoleClaimsService.getOrganizationRoleClaims(apiUser)),
+          apiUser.getLoginEmail());
+    } catch (MisconfiguredUserException e) {
+      log.error("Misconfigured organizations in DB for User ID: {}", apiUser.getInternalId());
+    }
     return new UserInfo(apiUser, Optional.of(orgRoles), isSiteAdmin, userStatus);
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DbOrgRoleClaimsService.java
@@ -47,7 +47,10 @@ public class DbOrgRoleClaimsService {
   public OrganizationRoleClaims getOrganizationRoleClaims(ApiUser user) {
     Set<Organization> orgs = user.getOrganizations();
     if (orgs.size() != 1) {
-      log.error("Misconfigured organizations in DB for User ID: {}", user.getInternalId());
+      log.error(
+          "Misconfigured organizations in DB for User ID: {}. Number of organizations for user was: {}",
+          user.getInternalId(),
+          orgs.size());
       throw new MisconfiguredUserException();
     }
     Set<OrganizationRole> roles = user.getRoles();


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Changes Proposed

- Hotfix for a support escalation ticket

## Additional Information

- #8258 will still need to be addressed in the future, but this fix will allow the ManageUsers page to access users who do not have any facility assignments

## Testing

- Deployed to dev2
- removing any roles and facilities a user currently has
- removing any of that user’s facility assignment in Okta
- searching for them via Postman
- finally, seeing if we still have an issue loading that user
