### PR TITLE
Bug fix: reminder service not using config

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ReminderService.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +27,9 @@ public class ReminderService {
 
   private final OrganizationQueueRepository _orgQueueRepo;
   private final EmailService _emailService;
+
+  @Value("${simple-report.id-verification-reminders.enabled}")
+  private boolean remindersEnabled;
 
   public ReminderService(OrganizationQueueRepository orgQueueRepo, EmailService emailService) {
     _orgQueueRepo = orgQueueRepo;
@@ -42,9 +45,12 @@ public class ReminderService {
       name = "ReminderService_sendAccountReminderEmails",
       lockAtLeastFor = "PT30S",
       lockAtMostFor = "PT30M")
-  @ConditionalOnProperty("simple-report.id-verification-reminders.enabled")
   public void scheduledSendAccountReminderEmails() {
-    sendAccountReminderEmails();
+    if (remindersEnabled) {
+      sendAccountReminderEmails();
+    } else {
+      log.info("Skipping sending ID verification reminder emails");
+    }
   }
 
   /*


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Discovered while I was reviewing #8315 
Context: This service sends reminder emails every day to recently created orgs that have not ID verified. It was originally disabled in the non-prod envs but in [this PR](https://github.com/CDCgov/prime-simplereport/pull/4891/files#diff-2d8d399935b65da70b4bdf4f05c9bbcc11322318011fc874a5b0e3e880f0b92bR45) almost 2 years ago I accidentally broke that part so it's been not using the config property correctly since then

## Changes Proposed

use the `@Value` annotation to get the property instead of `@ConditionalOnProperty`, which is meant to be used for bean registration

## Testing
Tested in `dev5` by deploying [merethe/fix-reminderservice-config-TEST](https://github.com/CDCgov/prime-simplereport/tree/merethe/fix-reminderservice-config-TEST) and checked app insights to see it's hitting the log for skipping

<img width="1536" alt="Screenshot 2024-12-20 at 3 35 41 PM" src="https://github.com/user-attachments/assets/38e7a89d-097f-4824-9fa7-bdfb076aee94" />