### PR TITLE
Add backend support for Manage Users pagination

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/ManageUsersPageWrapper.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/ManageUsersPageWrapper.java
@@ -1,0 +1,22 @@
+package gov.cdc.usds.simplereport.api.apiuser;
+
+import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+/**
+ * When the page content contains zero entries, this could be due to either: - zero search results
+ * for the query string - OR due to zero users in the entire organization. The value for total users
+ * in the org helps differentiate this.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class ManageUsersPageWrapper {
+
+  Page<ApiUserWithStatus> pageContent;
+
+  int totalUsersInOrg;
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -1,7 +1,5 @@
 package gov.cdc.usds.simplereport.api.apiuser;
 
-import static gov.cdc.usds.simplereport.service.ApiUserService.DEFAULT_OKTA_USER_PAGE_SIZE;
-
 import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
 import gov.cdc.usds.simplereport.api.model.User;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
@@ -18,6 +16,8 @@ import org.springframework.stereotype.Controller;
 /** Resolver for the graphql User type */
 @Controller
 public class UserResolver {
+  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 10;
+  public static final int DEFAULT_OKTA_USER_PAGE_OFFSET = 0;
 
   private ApiUserService _userService;
 
@@ -44,7 +44,7 @@ public class UserResolver {
   public ManageUsersPageWrapper usersWithStatusPage(
       @Argument int pageNumber, @Argument String searchQuery) {
     if (pageNumber < 0) {
-      pageNumber = ApiUserService.DEFAULT_OKTA_USER_PAGE_OFFSET;
+      pageNumber = DEFAULT_OKTA_USER_PAGE_OFFSET;
     }
     if (!searchQuery.isBlank()) {
       return _userService.searchUsersAndStatusInCurrentOrgPaged(

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -11,7 +11,6 @@ import gov.cdc.usds.simplereport.service.ApiUserService;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.data.domain.Page;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
@@ -42,7 +41,7 @@ public class UserResolver {
   }
 
   @QueryMapping
-  public Page<ApiUserWithStatus> usersWithStatusPage(
+  public ManageUsersPageWrapper usersWithStatusPage(
       @Argument int pageNumber, @Argument String searchQuery) {
     if (pageNumber < 0) {
       pageNumber = ApiUserService.DEFAULT_OKTA_USER_PAGE_OFFSET;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -42,9 +42,14 @@ public class UserResolver {
   }
 
   @QueryMapping
-  public Page<ApiUserWithStatus> usersWithStatusPage(@Argument int pageNumber) {
+  public Page<ApiUserWithStatus> usersWithStatusPage(
+      @Argument int pageNumber, @Argument String searchQuery) {
     if (pageNumber < 0) {
       pageNumber = ApiUserService.DEFAULT_OKTA_USER_PAGE_OFFSET;
+    }
+    if (!searchQuery.isBlank()) {
+      return _userService.searchUsersAndStatusInCurrentOrgPaged(
+          pageNumber, DEFAULT_OKTA_USER_PAGE_SIZE, searchQuery);
     }
     return _userService.getPagedUsersAndStatusInCurrentOrg(pageNumber, DEFAULT_OKTA_USER_PAGE_SIZE);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -1,5 +1,7 @@
 package gov.cdc.usds.simplereport.api.apiuser;
 
+import static gov.cdc.usds.simplereport.service.ApiUserService.DEFAULT_OKTA_USER_PAGE_SIZE;
+
 import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
 import gov.cdc.usds.simplereport.api.model.User;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
@@ -9,6 +11,7 @@ import gov.cdc.usds.simplereport.service.ApiUserService;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Page;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
@@ -36,6 +39,14 @@ public class UserResolver {
   @QueryMapping
   public List<ApiUserWithStatus> usersWithStatus() {
     return _userService.getUsersAndStatusInCurrentOrg();
+  }
+
+  @QueryMapping
+  public Page<ApiUserWithStatus> usersWithStatusPage(@Argument int pageNumber) {
+    if (pageNumber < 0) {
+      pageNumber = ApiUserService.DEFAULT_OKTA_USER_PAGE_OFFSET;
+    }
+    return _userService.getPagedUsersAndStatusInCurrentOrg(pageNumber, DEFAULT_OKTA_USER_PAGE_SIZE);
   }
 
   @QueryMapping

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -273,6 +273,7 @@ public class DemoOktaRepository implements OktaRepository {
         .collect(Collectors.toMap(u -> u, u -> getUserStatus(u)));
   }
 
+  @Override
   public Map<String, UserStatus> getPagedUsersWithStatusForOrganization(
       Organization org, int pageNumber, int pageSize) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
@@ -413,6 +414,7 @@ public class DemoOktaRepository implements OktaRepository {
     allUsernames.clear();
   }
 
+  @Override
   public Integer getUsersInSingleFacility(Facility facility) {
     Integer accessCount = 0;
 
@@ -431,6 +433,7 @@ public class DemoOktaRepository implements OktaRepository {
     return accessCount;
   }
 
+  @Override
   public Integer getUsersInOrganization(Organization org) {
     return orgUsernamesMap.get(org.getExternalId()).size();
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -273,6 +273,20 @@ public class DemoOktaRepository implements OktaRepository {
         .collect(Collectors.toMap(u -> u, u -> getUserStatus(u)));
   }
 
+  public Map<String, UserStatus> getPagedUsersWithStatusForOrganization(
+      Organization org, int pageNumber, int pageSize) {
+    if (!orgUsernamesMap.containsKey(org.getExternalId())) {
+      throw new IllegalGraphqlArgumentException(
+          "Cannot get Okta users from nonexistent organization.");
+    }
+    List<String> allOrgUsernamesList =
+        orgUsernamesMap.get(org.getExternalId()).stream().sorted().collect(Collectors.toList());
+    int startIndex = pageNumber * pageSize;
+    int endIndex = Math.min((startIndex + pageSize), allOrgUsernamesList.size());
+    List<String> pageContent = allOrgUsernamesList.subList(startIndex, endIndex);
+    return pageContent.stream().collect(Collectors.toMap(u -> u, this::getUserStatus));
+  }
+
   // this method doesn't mean much in a demo env
   public void createOrganization(Organization org) {
     String externalId = org.getExternalId();
@@ -415,6 +429,10 @@ public class DemoOktaRepository implements OktaRepository {
     }
 
     return accessCount;
+  }
+
+  public Integer getUsersInOrganization(Organization org) {
+    return orgUsernamesMap.get(org.getExternalId()).size();
   }
 
   @Override

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -43,6 +43,8 @@ public class DemoOktaRepository implements OktaRepository {
   @Value("${simple-report.authorization.environment-name:DEV}")
   private String environment;
 
+  private static final String NON_EXISTANT_ORG_GET_USERS_ERROR =
+      "Cannot get Okta users from nonexistent organization.";
   private final OrganizationExtractor organizationExtractor;
   private final CurrentTenantDataAccessContextHolder tenantDataContextHolder;
 
@@ -257,8 +259,7 @@ public class DemoOktaRepository implements OktaRepository {
   // returns ALL users including inactive ones
   public Set<String> getAllUsersForOrganization(Organization org) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
-      throw new IllegalGraphqlArgumentException(
-          "Cannot get Okta users from nonexistent organization.");
+      throw new IllegalGraphqlArgumentException(NON_EXISTANT_ORG_GET_USERS_ERROR);
     }
     return orgUsernamesMap.get(org.getExternalId()).stream()
         .collect(Collectors.toUnmodifiableSet());
@@ -266,8 +267,7 @@ public class DemoOktaRepository implements OktaRepository {
 
   public Map<String, UserStatus> getAllUsersWithStatusForOrganization(Organization org) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
-      throw new IllegalGraphqlArgumentException(
-          "Cannot get Okta users from nonexistent organization.");
+      throw new IllegalGraphqlArgumentException(NON_EXISTANT_ORG_GET_USERS_ERROR);
     }
     return orgUsernamesMap.get(org.getExternalId()).stream()
         .collect(Collectors.toMap(u -> u, u -> getUserStatus(u)));
@@ -277,8 +277,7 @@ public class DemoOktaRepository implements OktaRepository {
   public Map<String, UserStatus> getPagedUsersWithStatusForOrganization(
       Organization org, int pageNumber, int pageSize) {
     if (!orgUsernamesMap.containsKey(org.getExternalId())) {
-      throw new IllegalGraphqlArgumentException(
-          "Cannot get Okta users from nonexistent organization.");
+      throw new IllegalGraphqlArgumentException(NON_EXISTANT_ORG_GET_USERS_ERROR);
     }
     List<String> allOrgUsernamesList =
         orgUsernamesMap.get(org.getExternalId()).stream().sorted().collect(Collectors.toList());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/DemoOktaRepository.java
@@ -415,7 +415,7 @@ public class DemoOktaRepository implements OktaRepository {
   }
 
   @Override
-  public Integer getUsersInSingleFacility(Facility facility) {
+  public Integer getUsersCountInSingleFacility(Facility facility) {
     Integer accessCount = 0;
 
     for (OrganizationRoleClaims existingClaims : usernameOrgRolesMap.values()) {
@@ -434,7 +434,7 @@ public class DemoOktaRepository implements OktaRepository {
   }
 
   @Override
-  public Integer getUsersInOrganization(Organization org) {
+  public Integer getUsersCountInOrganization(Organization org) {
     return orgUsernamesMap.get(org.getExternalId()).size();
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepository.java
@@ -688,7 +688,8 @@ public class LiveOktaRepository implements OktaRepository {
     }
   }
 
-  public Integer getUsersInSingleFacility(Facility facility) {
+  @Override
+  public Integer getUsersCountInSingleFacility(Facility facility) {
     String facilityAccessGroupName =
         generateFacilityGroupName(
             facility.getOrganization().getExternalId(), facility.getInternalId());
@@ -696,7 +697,8 @@ public class LiveOktaRepository implements OktaRepository {
     return getUsersCountInOktaGroup(facilityAccessGroupName);
   }
 
-  public Integer getUsersInOrganization(Organization org) {
+  @Override
+  public Integer getUsersCountInOrganization(Organization org) {
     String orgDefaultGroupName =
         generateRoleGroupName(org.getExternalId(), OrganizationRole.getDefault());
     return getUsersCountInOktaGroup(orgDefaultGroupName);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -92,9 +92,9 @@ public interface OktaRepository {
 
   Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username);
 
-  Integer getUsersInSingleFacility(Facility facility);
+  Integer getUsersCountInSingleFacility(Facility facility);
 
-  Integer getUsersInOrganization(Organization org);
+  Integer getUsersCountInOrganization(Organization org);
 
   PartialOktaUser findUser(String username);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/idp/repository/OktaRepository.java
@@ -67,6 +67,15 @@ public interface OktaRepository {
 
   Map<String, UserStatus> getAllUsersWithStatusForOrganization(Organization org);
 
+  /**
+   * @param org Organization being queried
+   * @param pageNumber Starts at page number 0
+   * @param pageSize Number of results per page
+   * @return Map of usernames to the user status in Okta
+   */
+  Map<String, UserStatus> getPagedUsersWithStatusForOrganization(
+      Organization org, int pageNumber, int pageSize);
+
   void createOrganization(Organization org);
 
   void activateOrganization(Organization org);
@@ -84,6 +93,8 @@ public interface OktaRepository {
   Optional<OrganizationRoleClaims> getOrganizationRoleClaimsForUser(String username);
 
   Integer getUsersInSingleFacility(Facility facility);
+
+  Integer getUsersInOrganization(Organization org);
 
   PartialOktaUser findUser(String username);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -632,7 +632,7 @@ public class ApiUserService {
             .map(u -> new ApiUserWithStatus(u, emailsToStatus.get(u.getLoginEmail())))
             .toList();
 
-    Integer userCountInOrg = _oktaRepo.getUsersInOrganization(org);
+    Integer userCountInOrg = _oktaRepo.getUsersCountInOrganization(org);
     PageRequest pageRequest = PageRequest.of(pageNumber, pageSize);
 
     return new PageImpl<>(userWithStatusList, pageRequest, userCountInOrg);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -85,8 +85,6 @@ public class ApiUserService {
   @Autowired private DbOrgRoleClaimsService _dbOrgRoleClaimsService;
 
   @Autowired private FeatureFlagsConfig _featureFlagsConfig;
-  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 10;
-  public static final int DEFAULT_OKTA_USER_PAGE_OFFSET = 0;
 
   private void createUserUpdatedAuditLog(Object authorId, Object updatedUserId) {
     log.info("User with id={} updated by user with id={}", authorId, updatedUserId);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -638,6 +638,33 @@ public class ApiUserService {
     return new PageImpl<>(userWithStatusList, pageRequest, userCountInOrg);
   }
 
+  public Page<ApiUserWithStatus> searchUsersAndStatusInCurrentOrgPaged(
+      int pageNumber, int pageSize, String searchQuery) {
+    List<ApiUserWithStatus> allUsers = getUsersAndStatusInCurrentOrg();
+
+    List<ApiUserWithStatus> filteredUsersList =
+        allUsers.stream()
+            .filter(
+                u -> {
+                  String firstName =
+                      u.getFirstName() == null ? "" : String.format("%s ", u.getFirstName());
+                  String middleName =
+                      u.getMiddleName() == null ? "" : String.format("%s ", u.getMiddleName());
+                  String fullName = firstName + middleName + u.getLastName();
+                  return fullName.toLowerCase().contains(searchQuery.toLowerCase());
+                })
+            .toList();
+
+    int totalResults = filteredUsersList.size();
+    int startIndex = pageNumber * pageSize;
+    int endIndex = Math.min((startIndex + pageSize), filteredUsersList.size());
+
+    List<ApiUserWithStatus> pageContent = filteredUsersList.subList(startIndex, endIndex);
+    PageRequest pageRequest = PageRequest.of(pageNumber, pageSize);
+
+    return new PageImpl<>(pageContent, pageRequest, totalResults);
+  }
+
   // To be addressed in #8108
   @AuthorizationConfiguration.RequirePermissionManageUsers
   public List<ApiUserWithStatus> getUsersAndStatusInCurrentOrg() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/OrganizationService.java
@@ -496,7 +496,7 @@ public class OrganizationService {
       usersWithSingleFacilityAccess =
           dbAuthorizationService.getUsersWithSingleFacilityAccessCount(facility);
     } else {
-      usersWithSingleFacilityAccess = this.oktaRepository.getUsersInSingleFacility(facility);
+      usersWithSingleFacilityAccess = this.oktaRepository.getUsersCountInSingleFacility(facility);
     }
     return FacilityStats.builder()
         .usersSingleAccessCount(usersWithSingleFacilityAccess)

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -660,6 +660,39 @@ class LiveOktaRepositoryTest {
   }
 
   @Test
+  void getPagedUsersWithStatusForOrganization() {
+    var org = new Organization("orgName", "orgType", "1", true);
+    var groupProfilePrefix = "SR-UNITTEST-TENANT:" + org.getExternalId() + ":NO_ACCESS";
+
+    var mockGroup = mock(Group.class);
+    var mockGroupList = List.of(mockGroup);
+    var mockGroupProfile = mock(GroupProfile.class);
+    var mockUser = mock(User.class);
+    PagedList<User> mockUserList = new PagedList<>(List.of(mockUser), "", "", null);
+    var mockUserProfile = mock(UserProfile.class);
+    when(groupApi.listGroups(
+            eq(groupProfilePrefix),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull()))
+        .thenReturn(mockGroupList);
+    when(mockGroup.getProfile()).thenReturn(mockGroupProfile);
+    when(mockGroupProfile.getName()).thenReturn(groupProfilePrefix);
+    when(mockGroup.getId()).thenReturn("1234");
+    when(groupApi.listGroupUsers(eq("1234"), any(), any())).thenReturn(mockUserList);
+    when(mockUser.getProfile()).thenReturn(mockUserProfile);
+    when(mockUserProfile.getLogin()).thenReturn("email@example.com");
+    when(mockUser.getStatus()).thenReturn(UserStatus.ACTIVE);
+
+    var actual = _repo.getPagedUsersWithStatusForOrganization(org, 0, 10);
+    assertEquals(Map.of("email@example.com", UserStatus.ACTIVE), actual);
+  }
+
+  @Test
   void updateUserPrivileges() {
     var username = "fraud@example.com";
     var org = new Organization("orgName", "orgType", "1", true);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/idp/repository/LiveOktaRepositoryTest.java
@@ -719,8 +719,8 @@ class LiveOktaRepositoryTest {
     var mockEmbeddedMap = mock(Map.class);
     when(mockGroup.getEmbedded()).thenReturn(mockEmbeddedMap);
     var mockStatsLinkedHashMap = mock(LinkedHashMap.class);
-    when(mockEmbeddedMap.get(eq("stats"))).thenReturn(mockStatsLinkedHashMap);
-    when(mockStatsLinkedHashMap.get(eq("usersCount"))).thenReturn(10);
+    when(mockEmbeddedMap.get("stats")).thenReturn(mockStatsLinkedHashMap);
+    when(mockStatsLinkedHashMap.get("usersCount")).thenReturn(10);
 
     var actual = _repo.getUsersCountInOrganization(mockOrg);
     assertEquals(10, actual);
@@ -756,8 +756,8 @@ class LiveOktaRepositoryTest {
     var mockEmbeddedMap = mock(Map.class);
     when(mockGroup.getEmbedded()).thenReturn(mockEmbeddedMap);
     var mockStatsLinkedHashMap = mock(LinkedHashMap.class);
-    when(mockEmbeddedMap.get(eq("stats"))).thenReturn(mockStatsLinkedHashMap);
-    when(mockStatsLinkedHashMap.get(eq("usersCount"))).thenReturn(10);
+    when(mockEmbeddedMap.get("stats")).thenReturn(mockStatsLinkedHashMap);
+    when(mockStatsLinkedHashMap.get("usersCount")).thenReturn(10);
 
     var actual = _repo.getUsersCountInSingleFacility(mockFacility);
     assertEquals(10, actual);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.okta.sdk.resource.model.UserStatus;
+import gov.cdc.usds.simplereport.api.apiuser.ManageUsersPageWrapper;
 import gov.cdc.usds.simplereport.api.model.ApiUserWithStatus;
 import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.ConflictingUserException;
@@ -154,7 +155,10 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
   @WithSimpleReportOrgAdminUser
   void getPagedUsersAndStatusInCurrentOrg_success() {
     initSampleData();
-    Page<ApiUserWithStatus> usersPage = _service.getPagedUsersAndStatusInCurrentOrg(0, 3);
+    ManageUsersPageWrapper usersPageWrapper = _service.getPagedUsersAndStatusInCurrentOrg(0, 3);
+    assertEquals(6, usersPageWrapper.getTotalUsersInOrg());
+
+    Page<ApiUserWithStatus> usersPage = usersPageWrapper.getPageContent();
     List<ApiUserWithStatus> users = usersPage.stream().toList();
     assertEquals(3, users.size());
 
@@ -163,7 +167,10 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     checkApiUserWithStatus(
         users.get(2), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
 
-    Page<ApiUserWithStatus> users2ndPage = _service.getPagedUsersAndStatusInCurrentOrg(1, 3);
+    ManageUsersPageWrapper users2ndPageWrapper = _service.getPagedUsersAndStatusInCurrentOrg(1, 3);
+    assertEquals(6, users2ndPageWrapper.getTotalUsersInOrg());
+
+    Page<ApiUserWithStatus> users2ndPage = users2ndPageWrapper.getPageContent();
     List<ApiUserWithStatus> users2ndList = users2ndPage.stream().toList();
     assertEquals(3, users2ndList.size());
 
@@ -177,10 +184,12 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
   @WithSimpleReportOrgAdminUser
   void searchUsersAndStatusInCurrentOrgPaged_success() {
     initSampleData();
-    Page<ApiUserWithStatus> usersPage =
+    ManageUsersPageWrapper usersPageWrapper =
         _service.searchUsersAndStatusInCurrentOrgPaged(0, 10, "Bob");
+    Page<ApiUserWithStatus> usersPage = usersPageWrapper.getPageContent();
     List<ApiUserWithStatus> users = usersPage.stream().toList();
     assertEquals(1, users.size());
+    assertEquals(6, usersPageWrapper.getTotalUsersInOrg());
     checkApiUserWithStatus(users.get(0), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
   }
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.TestPropertySource;
 
@@ -147,6 +148,29 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
     checkApiUserWithStatus(users.get(4), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
     checkApiUserWithStatus(
         users.get(5), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void getPagedUsersAndStatusInCurrentOrg_success() {
+    initSampleData();
+    Page<ApiUserWithStatus> usersPage = _service.getPagedUsersAndStatusInCurrentOrg(0, 3);
+    List<ApiUserWithStatus> users = usersPage.stream().toList();
+    assertEquals(3, users.size());
+
+    checkApiUserWithStatus(users.get(0), "admin@example.com", "Andrews", UserStatus.ACTIVE);
+    checkApiUserWithStatus(users.get(1), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
+    checkApiUserWithStatus(
+        users.get(2), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
+
+    Page<ApiUserWithStatus> users2ndPage = _service.getPagedUsersAndStatusInCurrentOrg(1, 3);
+    List<ApiUserWithStatus> users2ndList = users2ndPage.stream().toList();
+    assertEquals(3, users2ndList.size());
+
+    checkApiUserWithStatus(users2ndList.get(0), "invalid@example.com", "Irwin", UserStatus.ACTIVE);
+    checkApiUserWithStatus(users2ndList.get(1), "nobody@example.com", "Nixon", UserStatus.ACTIVE);
+    checkApiUserWithStatus(
+        users2ndList.get(2), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
   }
 
   @Test

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -175,6 +175,17 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
+  void searchUsersAndStatusInCurrentOrgPaged_success() {
+    initSampleData();
+    Page<ApiUserWithStatus> usersPage =
+        _service.searchUsersAndStatusInCurrentOrgPaged(0, 10, "Bob");
+    List<ApiUserWithStatus> users = usersPage.stream().toList();
+    assertEquals(1, users.size());
+    checkApiUserWithStatus(users.get(0), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
   void getUser_withAdminUser_withOktaMigrationDisabled_success() {
     initSampleData();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -459,7 +459,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     UUID facilityId = UUID.randomUUID();
     Facility mockFacility = mock(Facility.class);
     doReturn(Optional.of(mockFacility)).when(this.facilityRepository).findById(facilityId);
-    doReturn(2).when(oktaRepository).getUsersInSingleFacility(mockFacility);
+    doReturn(2).when(oktaRepository).getUsersCountInSingleFacility(mockFacility);
     doReturn(1).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
     FacilityStats stats = _service.getFacilityStats(facilityId);
 
@@ -479,7 +479,7 @@ class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
     doReturn(2).when(personRepository).countByFacilityAndIsDeleted(mockFacility, false);
     FacilityStats stats = _service.getFacilityStats(facilityId);
 
-    verify(oktaRepository, times(0)).getUsersInSingleFacility(mockFacility);
+    verify(oktaRepository, times(0)).getUsersCountInSingleFacility(mockFacility);
     assertEquals(4, stats.getUsersSingleAccessCount());
     assertEquals(2, stats.getPatientsSingleAccessCount());
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Part 1 of #8103

## Changes Proposed

- Adds backend support for pagination on manage users page

## Additional Information

- Follow up PR will add the frontend changes (#8371  being split for ease of review)

## Testing
- Deployed on dev4
- This should still behave exactly like `main`