### PR TITLE
Add frontend support for Manage Users pagination

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -47,6 +47,10 @@ public class UserResolver {
       pageNumber = DEFAULT_OKTA_USER_PAGE_OFFSET;
     }
 
+    if (searchQuery == null) {
+      searchQuery = "";
+    }
+
     return _userService.getPagedUsersAndStatusInCurrentOrg(
         pageNumber, DEFAULT_OKTA_USER_PAGE_SIZE, searchQuery);
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Controller;
 /** Resolver for the graphql User type */
 @Controller
 public class UserResolver {
-  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 10;
+  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 14;
   public static final int DEFAULT_OKTA_USER_PAGE_OFFSET = 0;
 
   private ApiUserService _userService;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/apiuser/UserResolver.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Controller;
 /** Resolver for the graphql User type */
 @Controller
 public class UserResolver {
-  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 14;
+  public static final int DEFAULT_OKTA_USER_PAGE_SIZE = 12;
   public static final int DEFAULT_OKTA_USER_PAGE_OFFSET = 0;
 
   private ApiUserService _userService;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -642,8 +642,17 @@ public class ApiUserService {
     }
 
     int totalSearchResults = filteredUsers.size();
-    int startIndex = totalSearchResults > pageSize ? pageNumber * pageSize : 0;
-    int endIndex = Math.min((startIndex + pageSize), filteredUsers.size());
+
+    int startIndex = pageNumber * pageSize;
+
+    boolean onlyOnePageOfResults = totalSearchResults <= pageSize;
+    boolean requestedPageOutOfBounds = startIndex > totalSearchResults;
+
+    if (onlyOnePageOfResults || requestedPageOutOfBounds) {
+      startIndex = 0;
+    }
+
+    int endIndex = Math.min((startIndex + pageSize), totalSearchResults);
 
     List<ApiUserWithStatus> filteredSublist = filteredUsers.subList(startIndex, endIndex);
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -35,6 +35,7 @@ import gov.cdc.usds.simplereport.service.model.IdentityAttributes;
 import gov.cdc.usds.simplereport.service.model.IdentitySupplier;
 import gov.cdc.usds.simplereport.service.model.OrganizationRoles;
 import gov.cdc.usds.simplereport.service.model.UserInfo;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -631,12 +632,18 @@ public class ApiUserService {
           allUsers.stream()
               .filter(
                   u -> {
-                    String firstName =
-                        u.getFirstName() == null ? "" : String.format("%s ", u.getFirstName());
-                    String middleName =
-                        u.getMiddleName() == null ? "" : String.format("%s ", u.getMiddleName());
-                    String fullName = firstName + middleName + u.getLastName();
-                    return fullName.toLowerCase().contains(searchQuery.toLowerCase());
+                    String cleanedSearchQuery = searchQuery.replace(",", " ");
+                    List<String> querySubstringList =
+                        Arrays.stream(cleanedSearchQuery.toLowerCase().split("\\s+")).toList();
+
+                    String fullName =
+                        u.getNameInfo().getFirstName()
+                            + " "
+                            + u.getNameInfo().getMiddleName()
+                            + " "
+                            + u.getNameInfo().getLastName();
+
+                    return querySubstringList.stream().allMatch(fullName.toLowerCase()::contains);
                   })
               .toList();
     }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -196,6 +196,28 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
+  void searchUsersAndStatusInCurrentOrgPaged_lastFirstPartial_success() {
+    initSampleData();
+    ManageUsersPageWrapper usersPageWrapper =
+        _service.getPagedUsersAndStatusInCurrentOrg(0, 10, "be, bo");
+    List<ApiUserWithStatus> users = usersPageWrapper.getPageContent().stream().toList();
+    assertEquals(1, users.size());
+    checkApiUserWithStatus(users.get(0), "bobbity@example.com", "Bobberoo", UserStatus.ACTIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
+  void searchUsersAndStatusInCurrentOrgPaged_firstLastPartial_success() {
+    initSampleData();
+    ManageUsersPageWrapper usersPageWrapper =
+        _service.getPagedUsersAndStatusInCurrentOrg(0, 10, "ru re");
+    List<ApiUserWithStatus> users = usersPageWrapper.getPageContent().stream().toList();
+    assertEquals(1, users.size());
+    checkApiUserWithStatus(users.get(0), "notruby@example.com", "Reynolds", UserStatus.ACTIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
   void searchUsersAndStatusInCurrentOrgPaged_pageNumberOutOfBounds_success() {
     initSampleData();
     ManageUsersPageWrapper usersPageWrapper =

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ApiUserServiceTest.java
@@ -196,6 +196,20 @@ class ApiUserServiceTest extends BaseServiceTest<ApiUserService> {
 
   @Test
   @WithSimpleReportOrgAdminUser
+  void searchUsersAndStatusInCurrentOrgPaged_pageNumberOutOfBounds_success() {
+    initSampleData();
+    ManageUsersPageWrapper usersPageWrapper =
+        _service.getPagedUsersAndStatusInCurrentOrg(25, 10, "Will");
+    Page<ApiUserWithStatus> usersPage = usersPageWrapper.getPageContent();
+    List<ApiUserWithStatus> users = usersPage.stream().toList();
+    assertEquals(1, users.size());
+    assertEquals(6, usersPageWrapper.getTotalUsersInOrg());
+    checkApiUserWithStatus(
+        users.get(0), "allfacilities@example.com", "Williams", UserStatus.ACTIVE);
+  }
+
+  @Test
+  @WithSimpleReportOrgAdminUser
   void getUser_withAdminUser_withOktaMigrationDisabled_success() {
     initSampleData();
 

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -29,7 +29,7 @@ const Settings = () => {
             path={"self-registration"}
             element={<ManageSelfRegistrationLinksContainer />}
           />
-          <Route path="/:pageNumber" element={<ManageUsersContainer />} />
+          <Route path="users/:pageNumber" element={<ManageUsersContainer />} />
         </Routes>
       </div>
     </div>

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -8,8 +8,13 @@ import SettingsNav from "./SettingsNav";
 import { ManageSelfRegistrationLinksContainer } from "./ManageSelfRegistrationLinksContainer";
 
 import "./Settings.scss";
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 const Settings = () => {
+  const [facility] = useSelectedFacility();
+  const activeFacilityId = facility?.id || "";
+  const settingsIndexRedirect = "/settings/users/1?" + activeFacilityId;
+
   return (
     <div className="prime-home flex-1">
       <div className="grid-container">
@@ -30,7 +35,7 @@ const Settings = () => {
             element={<ManageSelfRegistrationLinksContainer />}
           />
           <Route path="users/:pageNumber" element={<ManageUsersContainer />} />
-          <Route index element={<Navigate to="/settings/users/1" />} />
+          <Route index element={<Navigate to={settingsIndexRedirect} />} />
         </Routes>
       </div>
     </div>

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -14,7 +14,8 @@ import "./Settings.scss";
 const Settings = () => {
   const [facility] = useSelectedFacility();
   const activeFacilityId = facility?.id || "";
-  const settingsIndexRedirect = "/settings/users/1?" + activeFacilityId;
+  const settingsIndexRedirect =
+    "/settings/users/1?facility=" + activeFacilityId;
 
   return (
     <div className="prime-home flex-1">

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import ManageOrganizationContainer from "./ManageOrganizationContainer";
 import ManageFacilitiesContainer from "./Facility/ManageFacilitiesContainer";
@@ -30,6 +30,7 @@ const Settings = () => {
             element={<ManageSelfRegistrationLinksContainer />}
           />
           <Route path="users/:pageNumber" element={<ManageUsersContainer />} />
+          <Route index element={<Navigate to="/settings/users/1" />} />
         </Routes>
       </div>
     </div>

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -29,7 +29,7 @@ const Settings = () => {
             path={"self-registration"}
             element={<ManageSelfRegistrationLinksContainer />}
           />
-          <Route path="/" element={<ManageUsersContainer />} />
+          <Route path="/:pageNumber" element={<ManageUsersContainer />} />
         </Routes>
       </div>
     </div>

--- a/frontend/src/app/Settings/Settings.tsx
+++ b/frontend/src/app/Settings/Settings.tsx
@@ -1,5 +1,7 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 
+import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
+
 import ManageOrganizationContainer from "./ManageOrganizationContainer";
 import ManageFacilitiesContainer from "./Facility/ManageFacilitiesContainer";
 import FacilityFormContainer from "./Facility/FacilityFormContainer";
@@ -8,7 +10,6 @@ import SettingsNav from "./SettingsNav";
 import { ManageSelfRegistrationLinksContainer } from "./ManageSelfRegistrationLinksContainer";
 
 import "./Settings.scss";
-import { useSelectedFacility } from "../facilitySelect/useSelectedFacility";
 
 const Settings = () => {
   const [facility] = useSelectedFacility();

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -21,7 +21,11 @@ const SettingsNav = () => {
     <nav className="prime-secondary-nav" aria-label="Secondary navigation">
       <ul className="usa-nav__secondary-links prime-nav">
         <li className="usa-nav__secondary-item">
-          <LinkWithQuery to={`/settings/1`} end className={classNameByActive}>
+          <LinkWithQuery
+            to={`/settings/users/1`}
+            end
+            className={classNameByActive}
+          >
             Manage users
           </LinkWithQuery>
         </li>

--- a/frontend/src/app/Settings/SettingsNav.tsx
+++ b/frontend/src/app/Settings/SettingsNav.tsx
@@ -21,7 +21,7 @@ const SettingsNav = () => {
     <nav className="prime-secondary-nav" aria-label="Secondary navigation">
       <ul className="usa-nav__secondary-links prime-nav">
         <li className="usa-nav__secondary-item">
-          <LinkWithQuery to={`/settings`} end className={classNameByActive}>
+          <LinkWithQuery to={`/settings/1`} end className={classNameByActive}>
             Manage users
           </LinkWithQuery>
         </li>

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -35,6 +35,10 @@
     margin: 1em auto;
   }
 
+  .no-results-found {
+    width: 75%;
+  }
+
   .usa-sidenav__item.users-sidenav-item button {
     width: 100%;
   }

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -39,6 +39,10 @@
     width: 75%;
   }
 
+  .clear-filter-button {
+    width: auto !important;
+  }
+
   .usa-sidenav__item.users-sidenav-item button {
     width: 100%;
   }

--- a/frontend/src/app/Settings/Users/ManageUsers.scss
+++ b/frontend/src/app/Settings/Users/ManageUsers.scss
@@ -43,6 +43,10 @@
     width: auto !important;
   }
 
+  .usa-pagination ol {
+    padding-left: 0 !important;
+  }
+
   .usa-sidenav__item.users-sidenav-item button {
     width: 100%;
   }

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -271,7 +271,7 @@ let reactivateUserAndResetPassword: (obj: any) => Promise<any>;
 let resetUserPassword: (obj: any) => Promise<any>;
 let resetUserMfa: (obj: any) => Promise<any>;
 let resendUserActivationEmail: (obj: any) => Promise<any>;
-let setDebouncedQueryString = jest.fn();
+let setQueryString = jest.fn();
 
 type TestContainerProps = {
   children: React.ReactNode;
@@ -367,7 +367,7 @@ describe("ManageUsers", () => {
             entriesPerPage={10}
             totalEntries={3}
             queryString={""}
-            setQueryString={setDebouncedQueryString}
+            setQueryString={setQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={3}
           />
@@ -727,7 +727,7 @@ describe("ManageUsers", () => {
             entriesPerPage={10}
             currentPage={1}
             queryString={""}
-            setQueryString={setDebouncedQueryString}
+            setQueryString={setQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={0}
           />
@@ -797,7 +797,7 @@ describe("ManageUsers", () => {
             entriesPerPage={10}
             currentPage={1}
             queryString={""}
-            setQueryString={setDebouncedQueryString}
+            setQueryString={setQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -844,7 +844,7 @@ describe("ManageUsers", () => {
             entriesPerPage={10}
             currentPage={1}
             queryString={""}
-            setQueryString={setDebouncedQueryString}
+            setQueryString={setQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -892,7 +892,7 @@ describe("ManageUsers", () => {
             entriesPerPage={10}
             currentPage={1}
             queryString={""}
-            setQueryString={setDebouncedQueryString}
+            setQueryString={setQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -996,7 +996,7 @@ describe("ManageUsers", () => {
         entriesPerPage={10}
         currentPage={1}
         queryString={""}
-        setQueryString={setDebouncedQueryString}
+        setQueryString={setQueryString}
         queryLoadingStatus={false}
         totalUsersInOrg={3}
       />

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -362,6 +362,9 @@ describe("ManageUsers", () => {
             resendUserActivationEmail={resendUserActivationEmail}
             updateUserName={updateUserName}
             updateUserEmail={updateUserEmail}
+            currentPage={1}
+            entriesPerPage={10}
+            totalEntries={3}
           />
         </TestContainer>
       );
@@ -773,6 +776,9 @@ describe("ManageUsers", () => {
             resendUserActivationEmail={resendUserActivationEmail}
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
+            totalEntries={0}
+            entriesPerPage={10}
+            currentPage={1}
           />
         </TestContainer>
       );
@@ -835,6 +841,9 @@ describe("ManageUsers", () => {
             resendUserActivationEmail={resendUserActivationEmail}
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
+            totalEntries={2}
+            entriesPerPage={10}
+            currentPage={1}
           />
         </TestContainer>
       );
@@ -875,6 +884,9 @@ describe("ManageUsers", () => {
             resendUserActivationEmail={resendUserActivationEmail}
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
+            totalEntries={2}
+            entriesPerPage={10}
+            currentPage={1}
           />
         </TestContainer>
       );
@@ -916,6 +928,9 @@ describe("ManageUsers", () => {
             resendUserActivationEmail={resendUserActivationEmail}
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
+            totalEntries={2}
+            entriesPerPage={10}
+            currentPage={1}
           />
         </TestContainer>
       );
@@ -1013,6 +1028,9 @@ describe("ManageUsers", () => {
         resendUserActivationEmail={resendUserActivationEmail}
         updateUserName={() => Promise.resolve()}
         updateUserEmail={() => Promise.resolve()}
+        totalEntries={3}
+        entriesPerPage={10}
+        currentPage={1}
       />
     );
     render(

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -364,7 +364,7 @@ describe("ManageUsers", () => {
             updateUserName={updateUserName}
             updateUserEmail={updateUserEmail}
             currentPage={1}
-            entriesPerPage={10}
+            entriesPerPage={12}
             totalEntries={3}
             queryString={""}
             setQueryString={setQueryString}
@@ -724,7 +724,7 @@ describe("ManageUsers", () => {
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
             totalEntries={0}
-            entriesPerPage={10}
+            entriesPerPage={12}
             currentPage={1}
             queryString={""}
             setQueryString={setQueryString}
@@ -794,7 +794,7 @@ describe("ManageUsers", () => {
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
             totalEntries={2}
-            entriesPerPage={10}
+            entriesPerPage={12}
             currentPage={1}
             queryString={""}
             setQueryString={setQueryString}
@@ -841,7 +841,7 @@ describe("ManageUsers", () => {
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
             totalEntries={2}
-            entriesPerPage={10}
+            entriesPerPage={12}
             currentPage={1}
             queryString={""}
             setQueryString={setQueryString}
@@ -889,7 +889,7 @@ describe("ManageUsers", () => {
             updateUserName={() => Promise.resolve()}
             updateUserEmail={() => Promise.resolve()}
             totalEntries={2}
-            entriesPerPage={10}
+            entriesPerPage={12}
             currentPage={1}
             queryString={""}
             setQueryString={setQueryString}
@@ -993,7 +993,7 @@ describe("ManageUsers", () => {
         updateUserName={() => Promise.resolve()}
         updateUserEmail={() => Promise.resolve()}
         totalEntries={3}
-        entriesPerPage={10}
+        entriesPerPage={12}
         currentPage={1}
         queryString={""}
         setQueryString={setQueryString}

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -271,6 +271,7 @@ let reactivateUserAndResetPassword: (obj: any) => Promise<any>;
 let resetUserPassword: (obj: any) => Promise<any>;
 let resetUserMfa: (obj: any) => Promise<any>;
 let resendUserActivationEmail: (obj: any) => Promise<any>;
+let setDebouncedQueryString = jest.fn();
 
 type TestContainerProps = {
   children: React.ReactNode;
@@ -365,70 +366,15 @@ describe("ManageUsers", () => {
             currentPage={1}
             entriesPerPage={10}
             totalEntries={3}
+            debouncedQueryString={""}
+            setDebouncedQueryString={setDebouncedQueryString}
+            queryLoadingStatus={false}
           />
         </TestContainer>
       );
       await waitForElementToBeRemoved(() => screen.queryByText("?, ?"));
       return { user: userEvent.setup(), ...renderControls };
     };
-
-    it("is searchable", async () => {
-      //given
-      const { user } = await renderAndWaitForLoad();
-
-      //when
-      const searchBox = screen.getByRole("searchbox", {
-        name: /search by name/i,
-      });
-
-      await user.type(searchBox, "john");
-
-      //then
-      await waitFor(() => {
-        expect(
-          screen.getByRole("tab", {
-            name: displayFullName("John", "", "Arthur"),
-          })
-        ).toBeInTheDocument();
-      });
-      await waitFor(() => {
-        expect(
-          screen.queryByText(displayFullName("Bob", "", "Bobberoo"), {
-            exact: false,
-          })
-        ).not.toBeInTheDocument();
-      });
-    });
-
-    it("displays no results message for empty filtered list", async () => {
-      //given
-      const { user } = await renderAndWaitForLoad();
-
-      //when
-      const searchBox = screen.getByRole("searchbox", {
-        name: /search by name/i,
-      });
-      await user.type(searchBox, "john wick");
-
-      //then
-      await waitFor(() => {
-        expect(
-          screen.queryByText(displayFullName("Jane", "", "Doe"), {
-            exact: false,
-          })
-        ).not.toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(
-          screen.queryByText(displayFullName("Bob", "", "Bobberoo"), {
-            exact: false,
-          })
-        ).not.toBeInTheDocument();
-      });
-
-      expect(screen.getByText("No results found.")).toBeInTheDocument();
-    });
 
     it("enables logged-in user's settings except deletion and roles", async () => {
       const { user } = await renderAndWaitForLoad();
@@ -779,6 +725,9 @@ describe("ManageUsers", () => {
             totalEntries={0}
             entriesPerPage={10}
             currentPage={1}
+            debouncedQueryString={""}
+            setDebouncedQueryString={setDebouncedQueryString}
+            queryLoadingStatus={false}
           />
         </TestContainer>
       );
@@ -789,8 +738,7 @@ describe("ManageUsers", () => {
 
     it("fails gracefully when there are no users", async () => {
       await renderWithNoUsers();
-      const noUsers = await screen.findByText("no users", { exact: false });
-      expect(noUsers).toBeInTheDocument();
+      expect(screen.getAllByText("No results found.")).toHaveLength(2);
     });
 
     it("adds a user when zero users exist", async () => {
@@ -844,6 +792,9 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
+            debouncedQueryString={""}
+            setDebouncedQueryString={setDebouncedQueryString}
+            queryLoadingStatus={false}
           />
         </TestContainer>
       );
@@ -887,6 +838,9 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
+            debouncedQueryString={""}
+            setDebouncedQueryString={setDebouncedQueryString}
+            queryLoadingStatus={false}
           />
         </TestContainer>
       );
@@ -931,6 +885,9 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
+            debouncedQueryString={""}
+            setDebouncedQueryString={setDebouncedQueryString}
+            queryLoadingStatus={false}
           />
         </TestContainer>
       );
@@ -1031,6 +988,9 @@ describe("ManageUsers", () => {
         totalEntries={3}
         entriesPerPage={10}
         currentPage={1}
+        debouncedQueryString={""}
+        setDebouncedQueryString={setDebouncedQueryString}
+        queryLoadingStatus={false}
       />
     );
     render(

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -366,8 +366,8 @@ describe("ManageUsers", () => {
             currentPage={1}
             entriesPerPage={10}
             totalEntries={3}
-            debouncedQueryString={""}
-            setDebouncedQueryString={setDebouncedQueryString}
+            queryString={""}
+            setQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={3}
           />
@@ -726,8 +726,8 @@ describe("ManageUsers", () => {
             totalEntries={0}
             entriesPerPage={10}
             currentPage={1}
-            debouncedQueryString={""}
-            setDebouncedQueryString={setDebouncedQueryString}
+            queryString={""}
+            setQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={0}
           />
@@ -796,8 +796,8 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
-            debouncedQueryString={""}
-            setDebouncedQueryString={setDebouncedQueryString}
+            queryString={""}
+            setQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -843,8 +843,8 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
-            debouncedQueryString={""}
-            setDebouncedQueryString={setDebouncedQueryString}
+            queryString={""}
+            setQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -891,8 +891,8 @@ describe("ManageUsers", () => {
             totalEntries={2}
             entriesPerPage={10}
             currentPage={1}
-            debouncedQueryString={""}
-            setDebouncedQueryString={setDebouncedQueryString}
+            queryString={""}
+            setQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
             totalUsersInOrg={2}
           />
@@ -995,8 +995,8 @@ describe("ManageUsers", () => {
         totalEntries={3}
         entriesPerPage={10}
         currentPage={1}
-        debouncedQueryString={""}
-        setDebouncedQueryString={setDebouncedQueryString}
+        queryString={""}
+        setQueryString={setDebouncedQueryString}
         queryLoadingStatus={false}
         totalUsersInOrg={3}
       />

--- a/frontend/src/app/Settings/Users/ManageUsers.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.test.tsx
@@ -369,6 +369,7 @@ describe("ManageUsers", () => {
             debouncedQueryString={""}
             setDebouncedQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
+            totalUsersInOrg={3}
           />
         </TestContainer>
       );
@@ -728,6 +729,7 @@ describe("ManageUsers", () => {
             debouncedQueryString={""}
             setDebouncedQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
+            totalUsersInOrg={0}
           />
         </TestContainer>
       );
@@ -738,7 +740,9 @@ describe("ManageUsers", () => {
 
     it("fails gracefully when there are no users", async () => {
       await renderWithNoUsers();
-      expect(screen.getAllByText("No results found.")).toHaveLength(2);
+      expect(
+        screen.getByText("There are no users in this organization.")
+      ).toBeInTheDocument();
     });
 
     it("adds a user when zero users exist", async () => {
@@ -795,6 +799,7 @@ describe("ManageUsers", () => {
             debouncedQueryString={""}
             setDebouncedQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
+            totalUsersInOrg={2}
           />
         </TestContainer>
       );
@@ -841,6 +846,7 @@ describe("ManageUsers", () => {
             debouncedQueryString={""}
             setDebouncedQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
+            totalUsersInOrg={2}
           />
         </TestContainer>
       );
@@ -888,6 +894,7 @@ describe("ManageUsers", () => {
             debouncedQueryString={""}
             setDebouncedQueryString={setDebouncedQueryString}
             queryLoadingStatus={false}
+            totalUsersInOrg={2}
           />
         </TestContainer>
       );
@@ -991,6 +998,7 @@ describe("ManageUsers", () => {
         debouncedQueryString={""}
         setDebouncedQueryString={setDebouncedQueryString}
         queryLoadingStatus={false}
+        totalUsersInOrg={3}
       />
     );
     render(

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -434,19 +434,10 @@ const ManageUsers: React.FC<Props> = ({
             {localUsers.length <= 0 ? (
               <div
                 className={
-                  "display-flex flex-column flex-align-center margin-top-2 no-results-found"
+                  "display-flex flex-column flex-align-center margin-top-8 no-results-found"
                 }
               >
                 <div className="margin-bottom-105">No results found.</div>
-                <div>
-                  Check for spelling errors or
-                  <Button
-                    className={"margin-left-1"}
-                    id={`no-results-clear-filter-button`}
-                    onClick={() => setDebouncedQueryString("")}
-                    label={"Clear search filter"}
-                  ></Button>
-                </div>
               </div>
             ) : null}
             {activeUser ? (

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -43,8 +43,8 @@ interface Props {
   currentPage: number;
   totalEntries: number;
   entriesPerPage: number;
-  debouncedQueryString: string;
-  setDebouncedQueryString: Dispatch<string>;
+  queryString: string;
+  setQueryString: Dispatch<string>;
   queryLoadingStatus: boolean;
   totalUsersInOrg: number;
 }
@@ -103,8 +103,8 @@ const ManageUsers: React.FC<Props> = ({
   currentPage,
   totalEntries,
   entriesPerPage,
-  debouncedQueryString,
-  setDebouncedQueryString,
+  queryString,
+  setQueryString,
   queryLoadingStatus,
   totalUsersInOrg,
 }) => {
@@ -428,8 +428,8 @@ const ManageUsers: React.FC<Props> = ({
               activeUserId={activeUser?.id || ""}
               users={sortedUsers}
               onChangeActiveUser={onChangeActiveUser}
-              debouncedQueryString={debouncedQueryString}
-              setDebouncedQueryString={setDebouncedQueryString}
+              queryString={queryString}
+              setQueryString={setQueryString}
             />
             {localUsers.length <= 0 ? (
               <div

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -537,6 +537,7 @@ const ManageUsers: React.FC<Props> = ({
               totalEntries={totalEntries}
               entriesPerPage={entriesPerPage}
               currentPage={currentPage}
+              pageGroupSize={5}
             ></Pagination>
           </div>
         </div>

--- a/frontend/src/app/Settings/Users/ManageUsers.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsers.tsx
@@ -46,6 +46,7 @@ interface Props {
   debouncedQueryString: string;
   setDebouncedQueryString: Dispatch<string>;
   queryLoadingStatus: boolean;
+  totalUsersInOrg: number;
 }
 
 export type LimitedUsers = { [id: string]: LimitedUser };
@@ -105,6 +106,7 @@ const ManageUsers: React.FC<Props> = ({
   debouncedQueryString,
   setDebouncedQueryString,
   queryLoadingStatus,
+  totalUsersInOrg,
 }) => {
   const [userWithPermissions, updateUserWithPermissions] =
     useState<SettingsUser | null>();
@@ -415,132 +417,139 @@ const ManageUsers: React.FC<Props> = ({
         <div className="usa-card__body">
           <p>Loading user data</p>
         </div>
-      ) : null}
-      <div className="usa-card__body">
-        <div className="grid-row">
-          <UsersSideNav
-            activeUserId={activeUser?.id || ""}
-            users={sortedUsers}
-            onChangeActiveUser={onChangeActiveUser}
-            debouncedQueryString={debouncedQueryString}
-            setDebouncedQueryString={setDebouncedQueryString}
-          />
-          {localUsers.length <= 0 ? (
-            <div
-              className={
-                "display-flex flex-column flex-align-center margin-left-10 margin-top-2"
-              }
-            >
-              <div className="margin-bottom-105">No results found.</div>
-              <div>
-                Check for spelling errors or
-                <Button
-                  className={"margin-left-1"}
-                  id={`no-results-clear-filter-button`}
-                  onClick={() => setDebouncedQueryString("")}
-                  label={"Clear search filter"}
-                ></Button>
-              </div>
-            </div>
-          ) : null}
-          {activeUser ? (
-            <div
-              role="tabpanel"
-              aria-labelledby={"user-tab-" + user?.id}
-              className="tablet:grid-col padding-left-3 user-detail-column"
-            >
-              <UserHeading
-                user={user}
-                isUserSelf={isUserSelf(user, loggedInUser)}
-                isUpdating={isUpdating}
-                onResendUserActivationEmail={handleResendUserActivationEmail}
-                onReactivateUser={handleReactivateUser}
-                onUndeleteUser={() => {}}
-              />
-              <nav
-                className="prime-secondary-nav margin-top-4 padding-bottom-0"
-                aria-label="User action navigation"
+      ) : totalUsersInOrg === 0 ? (
+        <div className="usa-card__body">
+          <p>There are no users in this organization.</p>
+        </div>
+      ) : (
+        <div className="usa-card__body">
+          <div className="grid-row">
+            <UsersSideNav
+              activeUserId={activeUser?.id || ""}
+              users={sortedUsers}
+              onChangeActiveUser={onChangeActiveUser}
+              debouncedQueryString={debouncedQueryString}
+              setDebouncedQueryString={setDebouncedQueryString}
+            />
+            {localUsers.length <= 0 ? (
+              <div
+                className={
+                  "display-flex flex-column flex-align-center margin-top-2 no-results-found"
+                }
               >
-                <div
-                  role="tablist"
-                  aria-owns={`userinformation-tab facility-access-tab-id`}
-                  className="usa-nav__secondary-links prime-nav usa-list"
-                >
-                  <div
-                    className={`usa-nav__secondary-item ${
-                      navItemSelected === "User information"
-                        ? "usa-current"
-                        : ""
-                    }`}
-                  >
-                    <button
-                      id={`userinformation-tab`}
-                      role="tab"
-                      className="usa-button--unstyled text-ink text-no-underline"
-                      onClick={() => setNavItemSelected("User information")}
-                      aria-selected={navItemSelected === "User information"}
-                    >
-                      User information
-                    </button>
-                  </div>
-                  <div
-                    className={`usa-nav__secondary-item ${
-                      navItemSelected === "Facility access" ? "usa-current" : ""
-                    }`}
-                  >
-                    <button
-                      id={`facility-access-tab-id`}
-                      role="tab"
-                      className="usa-button--unstyled text-ink text-no-underline"
-                      onClick={() => setNavItemSelected("Facility access")}
-                      aria-selected={navItemSelected === "Facility access"}
-                    >
-                      Facility access
-                    </button>
-                  </div>
+                <div className="margin-bottom-105">No results found.</div>
+                <div>
+                  Check for spelling errors or
+                  <Button
+                    className={"margin-left-1"}
+                    id={`no-results-clear-filter-button`}
+                    onClick={() => setDebouncedQueryString("")}
+                    label={"Clear search filter"}
+                  ></Button>
                 </div>
-              </nav>
-              {navItemSelected === "User information" ? (
-                <UserInfoTab
+              </div>
+            ) : null}
+            {activeUser ? (
+              <div
+                role="tabpanel"
+                aria-labelledby={"user-tab-" + user?.id}
+                className="tablet:grid-col padding-left-3 user-detail-column"
+              >
+                <UserHeading
                   user={user}
-                  isUserActive={isUserActive(user)}
                   isUserSelf={isUserSelf(user, loggedInUser)}
                   isUpdating={isUpdating}
-                  onEditUserName={handleEditUserName}
-                  onEditUserEmail={handleEditUserEmail}
-                  onResetUserPassword={handleResetUserPassword}
-                  onResetUserMfa={handleResetUserMfa}
-                  onDeleteUser={handleDeleteUser}
+                  onResendUserActivationEmail={handleResendUserActivationEmail}
+                  onReactivateUser={handleReactivateUser}
+                  onUndeleteUser={() => {}}
                 />
-              ) : (
-                <FacilityAccessTab
-                  user={user}
-                  isUpdating={isUpdating}
-                  isUserEdited={isUserEdited}
-                  onUpdateUser={handleUpdateUser}
-                  updateLocalUserState={updateLocalUserState}
-                  loggedInUser={loggedInUser}
-                  allFacilities={allFacilities}
-                />
-              )}
-            </div>
-          ) : null}
-          {showInProgressModal && (
-            <InProgressModal
-              onClose={() => updateShowInProgressModal(false)}
-              onContinue={() => handleContinueChangeActiveUser()}
-            />
-          )}
+                <nav
+                  className="prime-secondary-nav margin-top-4 padding-bottom-0"
+                  aria-label="User action navigation"
+                >
+                  <div
+                    role="tablist"
+                    aria-owns={`userinformation-tab facility-access-tab-id`}
+                    className="usa-nav__secondary-links prime-nav usa-list"
+                  >
+                    <div
+                      className={`usa-nav__secondary-item ${
+                        navItemSelected === "User information"
+                          ? "usa-current"
+                          : ""
+                      }`}
+                    >
+                      <button
+                        id={`userinformation-tab`}
+                        role="tab"
+                        className="usa-button--unstyled text-ink text-no-underline"
+                        onClick={() => setNavItemSelected("User information")}
+                        aria-selected={navItemSelected === "User information"}
+                      >
+                        User information
+                      </button>
+                    </div>
+                    <div
+                      className={`usa-nav__secondary-item ${
+                        navItemSelected === "Facility access"
+                          ? "usa-current"
+                          : ""
+                      }`}
+                    >
+                      <button
+                        id={`facility-access-tab-id`}
+                        role="tab"
+                        className="usa-button--unstyled text-ink text-no-underline"
+                        onClick={() => setNavItemSelected("Facility access")}
+                        aria-selected={navItemSelected === "Facility access"}
+                      >
+                        Facility access
+                      </button>
+                    </div>
+                  </div>
+                </nav>
+                {navItemSelected === "User information" ? (
+                  <UserInfoTab
+                    user={user}
+                    isUserActive={isUserActive(user)}
+                    isUserSelf={isUserSelf(user, loggedInUser)}
+                    isUpdating={isUpdating}
+                    onEditUserName={handleEditUserName}
+                    onEditUserEmail={handleEditUserEmail}
+                    onResetUserPassword={handleResetUserPassword}
+                    onResetUserMfa={handleResetUserMfa}
+                    onDeleteUser={handleDeleteUser}
+                  />
+                ) : (
+                  <FacilityAccessTab
+                    user={user}
+                    isUpdating={isUpdating}
+                    isUserEdited={isUserEdited}
+                    onUpdateUser={handleUpdateUser}
+                    updateLocalUserState={updateLocalUserState}
+                    loggedInUser={loggedInUser}
+                    allFacilities={allFacilities}
+                  />
+                )}
+              </div>
+            ) : null}
+            {showInProgressModal && (
+              <InProgressModal
+                onClose={() => updateShowInProgressModal(false)}
+                onContinue={() => handleContinueChangeActiveUser()}
+              />
+            )}
+          </div>
+          <div className="grid-row">
+            <Pagination
+              baseRoute={"/settings/users"}
+              totalEntries={totalEntries}
+              entriesPerPage={entriesPerPage}
+              currentPage={currentPage}
+            ></Pagination>
+          </div>
         </div>
-        <div className="grid-row">
-          <Pagination
-            baseRoute={"/settings/users"}
-            totalEntries={totalEntries}
-            entriesPerPage={entriesPerPage}
-            currentPage={currentPage}
-          ></Pagination>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
@@ -15,7 +15,7 @@ import { cloneDeep } from "lodash";
 
 import {
   GetUserDocument,
-  GetUsersAndStatusDocument,
+  GetUsersAndStatusPageDocument,
 } from "../../../generated/graphql";
 import {
   ORG_ADMIN_REACTIVATE_COPY,
@@ -101,13 +101,18 @@ describe("ManageUsersContainer", () => {
   const mocks: MockedResponse[] = [
     {
       request: {
-        operationName: "GetUsersAndStatus",
-        query: GetUsersAndStatusDocument,
-        variables: {},
+        operationName: "GetUsersAndStatusPage",
+        query: GetUsersAndStatusPageDocument,
+        variables: {
+          pageNumber: 0,
+        },
       },
       result: {
         data: {
-          usersWithStatus: mockedUsersWithStatus,
+          usersWithStatusPage: {
+            totalElements: 6,
+            content: mockedUsersWithStatus,
+          },
         },
       },
     },
@@ -149,13 +154,18 @@ describe("ManageUsersContainer", () => {
   const supendedUserMocks: MockedResponse[] = [
     {
       request: {
-        operationName: "GetUsersAndStatus",
-        query: GetUsersAndStatusDocument,
-        variables: {},
+        operationName: "GetUsersAndStatusPage",
+        query: GetUsersAndStatusPageDocument,
+        variables: {
+          pageNumber: 0,
+        },
       },
       result: {
         data: {
-          usersWithStatus: mockedUsersWithStatus,
+          usersWithStatusPage: {
+            totalElements: 6,
+            content: mockedUsersWithStatus,
+          },
         },
       },
     },

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
@@ -112,8 +112,11 @@ describe("ManageUsersContainer", () => {
       result: {
         data: {
           usersWithStatusPage: {
-            totalElements: 6,
-            content: mockedUsersWithStatus,
+            pageContent: {
+              content: mockedUsersWithStatus,
+              totalElements: 6,
+            },
+            totalUsersInOrg: 6,
           },
         },
       },
@@ -163,18 +166,21 @@ describe("ManageUsersContainer", () => {
       result: {
         data: {
           usersWithStatusPage: {
-            totalElements: 1,
-            content: [
-              {
-                id: "1029653e-24d9-428e-83b0-468319948902",
-                firstName: "Bob",
-                middleName: null,
-                lastName: "Bobberoo",
-                email: "bob@example.com",
-                status: "ACTIVE",
-                __typename: "ApiUserWithStatus",
-              },
-            ],
+            pageContent: {
+              content: [
+                {
+                  id: "1029653e-24d9-428e-83b0-468319948902",
+                  firstName: "Bob",
+                  middleName: null,
+                  lastName: "Bobberoo",
+                  email: "bob@example.com",
+                  status: "ACTIVE",
+                  __typename: "ApiUserWithStatus",
+                },
+              ],
+              totalElements: 1,
+            },
+            totalUsersInOrg: 6,
           },
         },
       },
@@ -191,8 +197,11 @@ describe("ManageUsersContainer", () => {
       result: {
         data: {
           usersWithStatusPage: {
-            totalElements: 0,
-            content: [],
+            pageContent: {
+              content: [],
+              totalElements: 0,
+            },
+            totalUsersInOrg: 6,
           },
         },
       },
@@ -212,8 +221,11 @@ describe("ManageUsersContainer", () => {
       result: {
         data: {
           usersWithStatusPage: {
-            totalElements: 6,
-            content: mockedUsersWithStatus,
+            pageContent: {
+              content: mockedUsersWithStatus,
+              totalElements: 6,
+            },
+            totalUsersInOrg: 6,
           },
         },
       },

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.test.tsx
@@ -106,7 +106,7 @@ describe("ManageUsersContainer", () => {
         query: GetUsersAndStatusPageDocument,
         variables: {
           pageNumber: 0,
-          searchQuery: "",
+          searchQuery: null,
         },
       },
       result: {
@@ -215,7 +215,7 @@ describe("ManageUsersContainer", () => {
         query: GetUsersAndStatusPageDocument,
         variables: {
           pageNumber: 0,
-          searchQuery: "",
+          searchQuery: null,
         },
       },
       result: {

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -102,7 +102,7 @@ const ManageUsersContainer = () => {
 
   const { pageNumber } = useParams();
   const currentPage = pageNumber ? +pageNumber : 1;
-  const entriesPerPage = 10;
+  const entriesPerPage = 14;
 
   const {
     data,

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -107,7 +107,6 @@ const ManageUsersContainer = () => {
   // this gets page number from the route parameters (/settings/users/1)
   const { pageNumber } = useParams();
   const currentPage = pageNumber ? +pageNumber : 1;
-  const entriesPerPage = 14;
 
   // this gets name query from the query parameters (?name=abc)
   const nameQuery = getParameterFromUrl("name", location);
@@ -182,7 +181,9 @@ const ManageUsersContainer = () => {
       getUsers={getUsers}
       currentPage={currentPage}
       totalEntries={data.usersWithStatusPage.pageContent.totalElements}
-      entriesPerPage={entriesPerPage}
+      entriesPerPage={
+        data.usersWithStatusPage.pageContent.content?.length ?? 12
+      }
       queryString={queryString}
       setQueryString={setQueryString}
       queryLoadingStatus={loading}

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -117,10 +117,6 @@ const ManageUsersContainer = () => {
       debounceTime: SEARCH_DEBOUNCE_TIME,
     });
 
-  useEffect(() => {
-    filterByName(queryString);
-  }, [queryString]);
-
   const filterByName = (name: string) => {
     let searchParams: Record<string, string> = {
       facility: activeFacilityId,
@@ -138,6 +134,10 @@ const ManageUsersContainer = () => {
       search: new URLSearchParams(searchParams).toString(),
     });
   };
+
+  useEffect(() => {
+    filterByName(queryString);
+  }, [queryString, filterByName]);
 
   const {
     data,

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -107,6 +107,7 @@ const ManageUsersContainer = () => {
   // this gets page number from the route parameters (/settings/users/1)
   const { pageNumber } = useParams();
   const currentPage = pageNumber ? +pageNumber : 1;
+  const entriesPerPage = 12;
 
   // this gets name query from the query parameters (?name=abc)
   const nameQuery = getParameterFromUrl("name", location);
@@ -181,9 +182,7 @@ const ManageUsersContainer = () => {
       getUsers={getUsers}
       currentPage={currentPage}
       totalEntries={data.usersWithStatusPage.pageContent.totalElements}
-      entriesPerPage={
-        data.usersWithStatusPage.pageContent.content?.length ?? 12
-      }
+      entriesPerPage={entriesPerPage}
       queryString={queryString}
       setQueryString={setQueryString}
       queryLoadingStatus={loading}

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { useEffect } from "react";
+import { useState } from "react";
 
 import { RootState } from "../../store";
 import { Role } from "../../permissions";
@@ -21,7 +21,7 @@ import {
   useGetUsersAndStatusPageQuery,
 } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
-import { useDebounce } from "../../testQueue/addToQueue/useDebounce";
+import { useDebouncedEffect } from "../../testQueue/addToQueue/useDebounce";
 import { SEARCH_DEBOUNCE_TIME } from "../../testQueue/constants";
 import { useSelectedFacility } from "../../facilitySelect/useSelectedFacility";
 import { getParameterFromUrl } from "../../utils/url";
@@ -112,10 +112,7 @@ const ManageUsersContainer = () => {
   // this gets name query from the query parameters (?name=abc)
   const nameQuery = getParameterFromUrl("name", location);
 
-  const [queryString, debouncedQueryString, setDebouncedQueryString] =
-    useDebounce(nameQuery ?? "", {
-      debounceTime: SEARCH_DEBOUNCE_TIME,
-    });
+  const [queryString, setQueryString] = useState(nameQuery ?? "");
 
   const filterByName = (name: string) => {
     let searchParams: Record<string, string> = {
@@ -135,9 +132,13 @@ const ManageUsersContainer = () => {
     });
   };
 
-  useEffect(() => {
-    filterByName(queryString);
-  }, [queryString, filterByName]);
+  useDebouncedEffect(
+    () => {
+      filterByName(queryString);
+    },
+    [queryString],
+    SEARCH_DEBOUNCE_TIME
+  );
 
   const {
     data,
@@ -182,8 +183,8 @@ const ManageUsersContainer = () => {
       currentPage={currentPage}
       totalEntries={data.usersWithStatusPage.pageContent.totalElements}
       entriesPerPage={entriesPerPage}
-      debouncedQueryString={debouncedQueryString}
-      setDebouncedQueryString={setDebouncedQueryString}
+      queryString={queryString}
+      setQueryString={setQueryString}
       queryLoadingStatus={loading}
       totalUsersInOrg={data.usersWithStatusPage.totalUsersInOrg}
     />

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -1,11 +1,11 @@
 import { gql, useMutation } from "@apollo/client";
 import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
 
 import { RootState } from "../../store";
 import { Role } from "../../permissions";
 import {
   Maybe,
-  useGetUsersAndStatusQuery,
   useResendActivationEmailMutation,
   useUpdateUserNameMutation,
   useEditUserEmailMutation,
@@ -17,6 +17,7 @@ import {
   useSetUserIsDeletedMutation,
   useAddUserToCurrentOrgMutation,
   useResetUserPasswordMutation,
+  useGetUsersAndStatusPageQuery,
 } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
 
@@ -92,12 +93,21 @@ const ManageUsersContainer = () => {
   const [resetMfa] = useResetUserMfaMutation();
   const [resendUserActivationEmail] = useResendActivationEmailMutation();
 
+  const { pageNumber } = useParams();
+  const currentPage = pageNumber ? +pageNumber : 1;
+  const entriesPerPage = 10;
+
   const {
     data,
     loading,
     error,
     refetch: getUsers,
-  } = useGetUsersAndStatusQuery({ fetchPolicy: "no-cache" });
+  } = useGetUsersAndStatusPageQuery({
+    fetchPolicy: "no-cache",
+    variables: {
+      pageNumber: currentPage - 1,
+    },
+  });
 
   if (loading) {
     return <p> Loading... </p>;
@@ -113,7 +123,7 @@ const ManageUsersContainer = () => {
 
   return (
     <ManageUsers
-      users={data.usersWithStatus ?? []}
+      users={data.usersWithStatusPage.content ?? []}
       loggedInUser={loggedInUser}
       allFacilities={allFacilities}
       updateUserPrivileges={updateUserPrivileges}
@@ -126,6 +136,9 @@ const ManageUsersContainer = () => {
       reactivateUser={reactivateUser}
       resendUserActivationEmail={resendUserActivationEmail}
       getUsers={getUsers}
+      currentPage={currentPage}
+      totalEntries={data.usersWithStatusPage.totalElements}
+      entriesPerPage={entriesPerPage}
     />
   );
 };

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -20,6 +20,8 @@ import {
   useGetUsersAndStatusPageQuery,
 } from "../../../generated/graphql";
 import { useDocumentTitle } from "../../utils/hooks";
+import { useDebounce } from "../../testQueue/addToQueue/useDebounce";
+import { SEARCH_DEBOUNCE_TIME } from "../../testQueue/constants";
 
 import ManageUsers from "./ManageUsers";
 
@@ -93,6 +95,11 @@ const ManageUsersContainer = () => {
   const [resetMfa] = useResetUserMfaMutation();
   const [resendUserActivationEmail] = useResendActivationEmailMutation();
 
+  const [queryString, debouncedQueryString, setDebouncedQueryString] =
+    useDebounce("", {
+      debounceTime: SEARCH_DEBOUNCE_TIME,
+    });
+
   const { pageNumber } = useParams();
   const currentPage = pageNumber ? +pageNumber : 1;
   const entriesPerPage = 10;
@@ -106,6 +113,7 @@ const ManageUsersContainer = () => {
     fetchPolicy: "no-cache",
     variables: {
       pageNumber: currentPage - 1,
+      searchQuery: queryString,
     },
   });
 
@@ -139,6 +147,9 @@ const ManageUsersContainer = () => {
       currentPage={currentPage}
       totalEntries={data.usersWithStatusPage.totalElements}
       entriesPerPage={entriesPerPage}
+      debouncedQueryString={debouncedQueryString}
+      setDebouncedQueryString={setDebouncedQueryString}
+      queryLoadingStatus={loading}
     />
   );
 };

--- a/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
+++ b/frontend/src/app/Settings/Users/ManageUsersContainer.tsx
@@ -131,7 +131,7 @@ const ManageUsersContainer = () => {
 
   return (
     <ManageUsers
-      users={data.usersWithStatusPage.content ?? []}
+      users={data.usersWithStatusPage.pageContent.content ?? []}
       loggedInUser={loggedInUser}
       allFacilities={allFacilities}
       updateUserPrivileges={updateUserPrivileges}
@@ -145,11 +145,12 @@ const ManageUsersContainer = () => {
       resendUserActivationEmail={resendUserActivationEmail}
       getUsers={getUsers}
       currentPage={currentPage}
-      totalEntries={data.usersWithStatusPage.totalElements}
+      totalEntries={data.usersWithStatusPage.pageContent.totalElements}
       entriesPerPage={entriesPerPage}
       debouncedQueryString={debouncedQueryString}
       setDebouncedQueryString={setDebouncedQueryString}
       queryLoadingStatus={loading}
+      totalUsersInOrg={data.usersWithStatusPage.totalUsersInOrg}
     />
   );
 };

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -8,6 +8,7 @@ import { formatUserStatus } from "../../utils/text";
 import { OktaUserStatus } from "../../utils/user";
 import "./ManageUsers.scss";
 import SearchInput from "../../testQueue/addToQueue/SearchInput";
+import Button from "../../commonComponents/Button/Button";
 
 import { LimitedUser } from "./ManageUsersContainer";
 
@@ -34,6 +35,7 @@ const UsersSideNav: React.FC<Props> = ({
     <div className="display-block users-sidenav">
       <h2 className="users-sidenav-header">Users</h2>
       <SearchInput
+        className="padding-right-2"
         onInputChange={(e) => setDebouncedQueryString(e.target.value)}
         disabled={true}
         queryString={debouncedQueryString}
@@ -41,7 +43,7 @@ const UsersSideNav: React.FC<Props> = ({
         showSubmitButton={false}
       />
       <nav
-        className="prime-secondary-nav maxh-tablet-lg overflow-y-scroll"
+        className="prime-secondary-nav maxh-tablet-lg"
         aria-label="Tertiary navigation"
       >
         <div
@@ -51,8 +53,19 @@ const UsersSideNav: React.FC<Props> = ({
         >
           {users.length === 0 && (
             <div className={"usa-sidenav__item users-sidenav-item"}>
-              <div className={"padding-105 padding-right-2 padding-left-3"}>
+              <div className={"padding-2 padding-left-3 padding-top-3"}>
                 No results found.
+              </div>
+              <div className={"padding-105 padding-left-3 padding-y-0"}>
+                Check for spelling errors or
+              </div>
+              <div className={"padding-1 padding-left-3 padding-bottom-4"}>
+                <Button
+                  className={"clear-filter-button"}
+                  id={`clear-filter-button`}
+                  onClick={() => setDebouncedQueryString("")}
+                  label={"Clear search filter"}
+                ></Button>
               </div>
             </div>
           )}

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Dispatch } from "react";
 import classnames from "classnames";
 
 import { ReactComponent as DeactivatedIcon } from "../../../img/account-deactivated.svg";
@@ -7,8 +7,6 @@ import { displayFullName } from "../../utils";
 import { formatUserStatus } from "../../utils/text";
 import { OktaUserStatus } from "../../utils/user";
 import "./ManageUsers.scss";
-import { useDebounce } from "../../testQueue/addToQueue/useDebounce";
-import { SEARCH_DEBOUNCE_TIME } from "../../testQueue/constants";
 import SearchInput from "../../testQueue/addToQueue/SearchInput";
 
 import { LimitedUser } from "./ManageUsersContainer";
@@ -17,41 +15,28 @@ interface Props {
   activeUserId: string;
   users: LimitedUser[];
   onChangeActiveUser: (userId: string) => void;
+  debouncedQueryString: string;
+  setDebouncedQueryString: Dispatch<string>;
 }
 
 const UsersSideNav: React.FC<Props> = ({
   activeUserId,
   users,
   onChangeActiveUser,
+  debouncedQueryString,
+  setDebouncedQueryString,
 }) => {
   const getIdsAsString = (users: LimitedUser[]) => {
     return users.map((user) => "user-tab-" + user.id.toString()).join(" ");
   };
 
-  const [queryString, debounced, setDebounced] = useDebounce("", {
-    debounceTime: SEARCH_DEBOUNCE_TIME,
-  });
-
-  const filter = (filterText: string, users: LimitedUser[]) => {
-    if (!filterText) {
-      return users;
-    }
-    return users.filter((u) => {
-      return displayFullName(u.firstName, u.middleName, u.lastName)
-        .toLowerCase()
-        .includes(filterText.toLowerCase());
-    });
-  };
-
-  const filteredUsers = filter(queryString, users);
-
   return (
     <div className="display-block users-sidenav">
       <h2 className="users-sidenav-header">Users</h2>
       <SearchInput
-        onInputChange={(e) => setDebounced(e.target.value)}
+        onInputChange={(e) => setDebouncedQueryString(e.target.value)}
         disabled={true}
-        queryString={debounced}
+        queryString={debouncedQueryString}
         placeholder={`Search by name`}
         showSubmitButton={false}
       />
@@ -64,14 +49,14 @@ const UsersSideNav: React.FC<Props> = ({
           aria-owns={getIdsAsString(users)}
           className="usa-sidenav"
         >
-          {filteredUsers.length === 0 && (
+          {users.length === 0 && (
             <div className={"usa-sidenav__item users-sidenav-item"}>
               <div className={"padding-105 padding-right-2 padding-left-3"}>
                 No results found.
               </div>
             </div>
           )}
-          {filteredUsers.map((user: LimitedUser) => {
+          {users.map((user: LimitedUser) => {
             let statusText;
             switch (user.status) {
               case OktaUserStatus.ACTIVE:

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -16,16 +16,16 @@ interface Props {
   activeUserId: string;
   users: LimitedUser[];
   onChangeActiveUser: (userId: string) => void;
-  debouncedQueryString: string;
-  setDebouncedQueryString: Dispatch<string>;
+  queryString: string;
+  setQueryString: Dispatch<string>;
 }
 
 const UsersSideNav: React.FC<Props> = ({
   activeUserId,
   users,
   onChangeActiveUser,
-  debouncedQueryString,
-  setDebouncedQueryString,
+  queryString,
+  setQueryString,
 }) => {
   const getIdsAsString = (users: LimitedUser[]) => {
     return users.map((user) => "user-tab-" + user.id.toString()).join(" ");
@@ -36,9 +36,9 @@ const UsersSideNav: React.FC<Props> = ({
       <h2 className="users-sidenav-header">Users</h2>
       <SearchInput
         className="padding-right-2"
-        onInputChange={(e) => setDebouncedQueryString(e.target.value)}
+        onInputChange={(e) => setQueryString(e.target.value)}
         disabled={true}
-        queryString={debouncedQueryString}
+        queryString={queryString}
         placeholder={`Search by name`}
         showSubmitButton={false}
       />
@@ -63,7 +63,7 @@ const UsersSideNav: React.FC<Props> = ({
                 <Button
                   className={"clear-filter-button"}
                   id={`clear-filter-button`}
-                  onClick={() => setDebouncedQueryString("")}
+                  onClick={() => setQueryString("")}
                   label={"Clear search filter"}
                 ></Button>
               </div>

--- a/frontend/src/app/Settings/Users/UsersSideNav.tsx
+++ b/frontend/src/app/Settings/Users/UsersSideNav.tsx
@@ -62,7 +62,6 @@ const UsersSideNav: React.FC<Props> = ({
               <div className={"padding-1 padding-left-3 padding-bottom-4"}>
                 <Button
                   className={"clear-filter-button"}
-                  id={`clear-filter-button`}
                   onClick={() => setQueryString("")}
                   label={"Clear search filter"}
                 ></Button>

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
               <a
                 aria-label="Page 1"
                 class="is-active"
-                href="/settings/1"
+                href="/settings/users/1"
               >
                 <span>
                   1

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -408,6 +408,29 @@ exports[`ManageUsersContainer loads the component and displays users successfull
           </div>
         </div>
       </div>
+      <div
+        class="grid-row"
+      >
+        <nav
+          aria-label="Pagination"
+          class="usa-pagination"
+          role="navigation"
+        >
+          <ol>
+            <li>
+              <a
+                aria-label="Page 1"
+                class="is-active"
+                href="/settings/1"
+              >
+                <span>
+                  1
+                </span>
+              </a>
+            </li>
+          </ol>
+        </nav>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
+++ b/frontend/src/app/Settings/Users/__snapshots__/ManageUsersContainer.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
             Users
           </h2>
           <div
-            class="prime-search-container"
+            class="prime-search-container padding-right-2"
           >
             <form
               class="usa-search usa-search--small prime-search-input display-inline-block"
@@ -73,7 +73,7 @@ exports[`ManageUsersContainer loads the component and displays users successfull
           </div>
           <nav
             aria-label="Tertiary navigation"
-            class="prime-secondary-nav maxh-tablet-lg overflow-y-scroll"
+            class="prime-secondary-nav maxh-tablet-lg"
           >
             <div
               aria-owns="user-tab-3a4a221d-a8ca-42b3-aa03-37b93266025b user-tab-1029653e-24d9-428e-83b0-468319948902 user-tab-17656bad-08b6-4fd4-bb9a-ccac54e5ea0a user-tab-60bb9e3a-fe8a-4b81-b894-b01649c95e70 user-tab-0d3fa224-3d56-4382-b89c-9d8e415e59b3 user-tab-17656bad-07b6-4fd4-bb9a-ccbc54e5ea0a"

--- a/frontend/src/app/Settings/Users/operations.graphql
+++ b/frontend/src/app/Settings/Users/operations.graphql
@@ -29,23 +29,20 @@ query GetUsersAndStatus {
   }
 }
 
-query GetUsersAndStatusPage(
-  $pageNumber: Int,
-  $searchQuery: String
-) {
-  usersWithStatusPage(
-    pageNumber: $pageNumber,
-    searchQuery: $searchQuery
-  ) {
-    content {
-      id
-      firstName
-      middleName
-      lastName
-      email
-      status
+query GetUsersAndStatusPage($pageNumber: Int, $searchQuery: String) {
+  usersWithStatusPage(pageNumber: $pageNumber, searchQuery: $searchQuery) {
+    pageContent {
+      content {
+        id
+        firstName
+        middleName
+        lastName
+        email
+        status
+      }
+      totalElements
     }
-    totalElements
+    totalUsersInOrg
   }
 }
 

--- a/frontend/src/app/Settings/Users/operations.graphql
+++ b/frontend/src/app/Settings/Users/operations.graphql
@@ -29,6 +29,24 @@ query GetUsersAndStatus {
   }
 }
 
+query GetUsersAndStatusPage(
+  $pageNumber: Int
+) {
+  usersWithStatusPage(
+    pageNumber: $pageNumber
+  ) {
+    content {
+      id
+      firstName
+      middleName
+      lastName
+      email
+      status
+    }
+    totalElements
+  }
+}
+
 mutation ResendActivationEmail($id: ID!) {
   resendActivationEmail(id: $id) {
     id

--- a/frontend/src/app/Settings/Users/operations.graphql
+++ b/frontend/src/app/Settings/Users/operations.graphql
@@ -30,10 +30,12 @@ query GetUsersAndStatus {
 }
 
 query GetUsersAndStatusPage(
-  $pageNumber: Int
+  $pageNumber: Int,
+  $searchQuery: String
 ) {
   usersWithStatusPage(
-    pageNumber: $pageNumber
+    pageNumber: $pageNumber,
+    searchQuery: $searchQuery
   ) {
     content {
       id

--- a/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
+++ b/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SettingsNav displays the nav order correctly and defaults to 'Manage Us
       >
         <a
           class=""
-          href="/settings/1"
+          href="/settings/users/1"
         >
           Manage users
         </a>

--- a/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
+++ b/frontend/src/app/Settings/__snapshots__/SettingsNav.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SettingsNav displays the nav order correctly and defaults to 'Manage Us
       >
         <a
           class=""
-          href="/settings"
+          href="/settings/1"
         >
           Manage users
         </a>

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -203,7 +203,7 @@ const Header: React.FC<{}> = () => {
       mobileDisplay: false,
     },
     {
-      url: "/settings",
+      url: "/settings/users/1",
       displayPermissions: true,
       onClick: () => setMenuVisible(false),
       className: getNavItemClassName,

--- a/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Header displays correctly 1`] = `
               <a
                 class="prime-nav-link"
                 data-testid="mobile-settings-button"
-                href="/settings/1"
+                href="/settings/users/1"
                 id="mobile-settings-button"
                 role="link"
               >
@@ -272,7 +272,7 @@ exports[`Header displays correctly 1`] = `
             <a
               class="prime-nav-link"
               data-testid="desktop-settings-button"
-              href="/settings/1"
+              href="/settings/users/1"
               id="desktop-settings-button"
               role="link"
             >

--- a/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Header displays correctly 1`] = `
               <a
                 class="prime-nav-link"
                 data-testid="mobile-settings-button"
-                href="/settings"
+                href="/settings/1"
                 id="mobile-settings-button"
                 role="link"
               >
@@ -272,7 +272,7 @@ exports[`Header displays correctly 1`] = `
             <a
               class="prime-nav-link"
               data-testid="desktop-settings-button"
-              href="/settings"
+              href="/settings/1"
               id="desktop-settings-button"
               role="link"
             >

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1426,6 +1426,32 @@ export type GetUsersAndStatusQuery = {
   }> | null;
 };
 
+export type GetUsersAndStatusPageQueryVariables = Exact<{
+  pageNumber?: InputMaybe<Scalars["Int"]["input"]>;
+  searchQuery?: InputMaybe<Scalars["String"]["input"]>;
+}>;
+
+export type GetUsersAndStatusPageQuery = {
+  __typename?: "Query";
+  usersWithStatusPage: {
+    __typename?: "ApiUserWithStatusAndCountPage";
+    totalUsersInOrg: number;
+    pageContent: {
+      __typename?: "ApiUserWithStatusPage";
+      totalElements: number;
+      content?: Array<{
+        __typename?: "ApiUserWithStatus";
+        id: string;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName: string;
+        email: string;
+        status?: string | null;
+      }> | null;
+    };
+  };
+};
+
 export type ResendActivationEmailMutationVariables = Exact<{
   id: Scalars["ID"]["input"];
 }>;
@@ -3741,6 +3767,96 @@ export type GetUsersAndStatusSuspenseQueryHookResult = ReturnType<
 export type GetUsersAndStatusQueryResult = Apollo.QueryResult<
   GetUsersAndStatusQuery,
   GetUsersAndStatusQueryVariables
+>;
+export const GetUsersAndStatusPageDocument = gql`
+  query GetUsersAndStatusPage($pageNumber: Int, $searchQuery: String) {
+    usersWithStatusPage(pageNumber: $pageNumber, searchQuery: $searchQuery) {
+      pageContent {
+        content {
+          id
+          firstName
+          middleName
+          lastName
+          email
+          status
+        }
+        totalElements
+      }
+      totalUsersInOrg
+    }
+  }
+`;
+
+/**
+ * __useGetUsersAndStatusPageQuery__
+ *
+ * To run a query within a React component, call `useGetUsersAndStatusPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetUsersAndStatusPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetUsersAndStatusPageQuery({
+ *   variables: {
+ *      pageNumber: // value for 'pageNumber'
+ *      searchQuery: // value for 'searchQuery'
+ *   },
+ * });
+ */
+export function useGetUsersAndStatusPageQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetUsersAndStatusPageQuery,
+    GetUsersAndStatusPageQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetUsersAndStatusPageQuery,
+    GetUsersAndStatusPageQueryVariables
+  >(GetUsersAndStatusPageDocument, options);
+}
+export function useGetUsersAndStatusPageLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetUsersAndStatusPageQuery,
+    GetUsersAndStatusPageQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetUsersAndStatusPageQuery,
+    GetUsersAndStatusPageQueryVariables
+  >(GetUsersAndStatusPageDocument, options);
+}
+export function useGetUsersAndStatusPageSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetUsersAndStatusPageQuery,
+        GetUsersAndStatusPageQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetUsersAndStatusPageQuery,
+    GetUsersAndStatusPageQueryVariables
+  >(GetUsersAndStatusPageDocument, options);
+}
+export type GetUsersAndStatusPageQueryHookResult = ReturnType<
+  typeof useGetUsersAndStatusPageQuery
+>;
+export type GetUsersAndStatusPageLazyQueryHookResult = ReturnType<
+  typeof useGetUsersAndStatusPageLazyQuery
+>;
+export type GetUsersAndStatusPageSuspenseQueryHookResult = ReturnType<
+  typeof useGetUsersAndStatusPageSuspenseQuery
+>;
+export type GetUsersAndStatusPageQueryResult = Apollo.QueryResult<
+  GetUsersAndStatusPageQuery,
+  GetUsersAndStatusPageQueryVariables
 >;
 export const ResendActivationEmailDocument = gql`
   mutation ResendActivationEmail($id: ID!) {

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -9,7 +9,7 @@ ci:
       - https://localhost.simplereport.gov/app/results/1?facility=$FACILITY_ID
       - https://localhost.simplereport.gov/app/patients?facility=$FACILITY_ID
       - https://localhost.simplereport.gov/app/add-patient?facility=$FACILITY_ID
-      - https://localhost.simplereport.gov/app/settings?facility=$FACILITY_ID
+      - https://localhost.simplereport.gov/app/settings/users/1?facility=$FACILITY_ID
       - https://localhost.simplereport.gov/app/settings/facilities?facility=$FACILITY_ID
       - https://localhost.simplereport.gov/app/settings/add-facility/?facility=$FACILITY_ID
       - https://localhost.simplereport.gov/app/upload-patients?facility=$FACILITY_ID


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #8103 

## Changes Proposed

- Adds pagination to the Manage Users side nav
- Updates the routing for the default Settings page to use `settings/users/:pageNumber` so that the page number can be retrieved from the url params
- Adds a "No results found" message with a button to clear the search filter

## Testing

- Deployed on dev5
- Select `Access organization account` from the support admin dashboard
- Select `Big Organization`, type in "test" for justification, and click `Access data`
- Select either facility
- Go to the Settings page and it should bring you to Manage Users
- Test that pagination works as expected

## Screenshots

Page 1 of results
![image](https://github.com/user-attachments/assets/53e837ab-e60c-4d69-9fa6-e5b02ef0b470)

Page 5 of results
![image](https://github.com/user-attachments/assets/c672270b-e953-4efc-996b-8eedac4ecfa0)

Last page of results
![image](https://github.com/user-attachments/assets/b5ec8ce8-44a7-4ee8-8ea3-8e5859a8cf22)

Search results with multiple pages
![image](https://github.com/user-attachments/assets/4c3606a6-55cb-4e4c-ba38-dbbf4813c54c)

Search results with single result page
![image](https://github.com/user-attachments/assets/dd0da0b1-d76a-46ba-8e5a-9e2dd3492143)

No results found
![image](https://github.com/user-attachments/assets/012ccb86-f2e8-4a2f-b777-042cf2089e05)
