### PR TITLE
Add gonorrhea test result guidance

### DIFF
--- a/frontend/src/app/commonComponents/TestResultGuidance/GonorrheaResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/GonorrheaResultGuidance.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+
+import "../../../i18n";
+
+import GonorrheaResultGuidance from "./GonorrheaResultGuidance";
+
+describe("GonorrheaResultGuidance", () => {
+  it("displays guidance for a Gonorrhea result", () => {
+    const { container } = render(<GonorrheaResultGuidance />);
+    expect(screen.getByText("For Gonorrhea:")).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/commonComponents/TestResultGuidance/GonorrheaResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/GonorrheaResultGuidance.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+
+const GonorrheaResultGuidance = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p className="text-bold sr-guidance-heading">
+        {t("testResult.gonorrheaNotes.h1")}
+      </p>
+      <p>{t("testResult.gonorrheaNotes.positive.p0")}</p>
+      <Trans
+        parent="p"
+        i18nKey="testResult.gonorrheaNotes.positive.p1"
+        components={[
+          <a
+            href={t("testResult.gonorrheaNotes.positive.treatmentLink")}
+            target="_blank"
+            rel="noopener noreferrer"
+            key="gonorrhea-treatment-link"
+          >
+            gonorrhea treatment link
+          </a>,
+        ]}
+      />
+    </>
+  );
+};
+
+export default GonorrheaResultGuidance;

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/GonorrheaResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/GonorrheaResultGuidance.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GonorrheaResultGuidance displays guidance for a Gonorrhea result 1`] = `
+<div>
+  <p
+    class="text-bold sr-guidance-heading"
+  >
+    For Gonorrhea:
+  </p>
+  <p>
+    If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.
+  </p>
+  <p>
+    <a
+      href="https://www.cdc.gov/gonorrhea/about/index.html"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Visit the CDC website to learn more about a positive Gonorrhea result.
+    </a>
+     (cdc.gov/gonorrhea/about).
+  </p>
+</div>
+`;

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
@@ -61,8 +61,12 @@ export const DetachedTestResultDetailsModal = ({
     data?.testResult.results,
     MULTIPLEX_DISEASES.HEPATITIS_C
   );
+  const isGonorrheaResult = !!getResultForDisease(
+    data?.testResult.results,
+    MULTIPLEX_DISEASES.GONORRHEA
+  );
   const showGenderOfSexualPartners =
-    isHIVResult || isSyphilisResult || isHepatitisCResult;
+    isHIVResult || isSyphilisResult || isHepatitisCResult || isGonorrheaResult;
 
   const dateTested = data?.testResult.dateTested;
 

--- a/frontend/src/app/utils/testResults.tsx
+++ b/frontend/src/app/utils/testResults.tsx
@@ -6,6 +6,7 @@ import HivResultGuidance from "../commonComponents/TestResultGuidance/HivResultG
 import RsvResultGuidance from "../commonComponents/TestResultGuidance/RsvResultGuidance";
 import SyphilisResultGuidance from "../commonComponents/TestResultGuidance/SyphilisResultGuidance";
 import HepatitisCResultGuidance from "../commonComponents/TestResultGuidance/HepatitisCResultGuidance";
+import GonorrheaResultGuidance from "../commonComponents/TestResultGuidance/GonorrheaResultGuidance";
 
 export function getResultByDiseaseName(
   results: MultiplexResults,
@@ -104,6 +105,11 @@ export const getGuidanceForResults = (
   match = getResultForDisease(results, MULTIPLEX_DISEASES.HEPATITIS_C);
   if (match) {
     guidance.push(<HepatitisCResultGuidance />);
+  }
+
+  match = getResultForDisease(results, MULTIPLEX_DISEASES.GONORRHEA);
+  if (match) {
+    guidance.push(<GonorrheaResultGuidance />);
   }
 
   return guidance;

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -41,6 +41,7 @@ export const en = {
         HIV: "HIV",
         SYPHILIS: "Syphilis",
         HEPATITIS_C: "Hepatitis C",
+        GONORRHEA: "Gonorrhea",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 result",
@@ -51,6 +52,7 @@ export const en = {
         HIV: "HIV result",
         SYPHILIS: "Syphilis result",
         HEPATITIS_C: "Hepatitis C result",
+        GONORRHEA: "Gonorrhea result",
       },
       role: {
         STAFF: "Staff",
@@ -429,6 +431,14 @@ export const en = {
           p1: "<0>Visit the CDC website to learn more about a positive Hepatitis C result</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
           treatmentLink:
             "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
+        },
+      },
+      gonorrheaNotes: {
+        h1: "For Gonorrhea:",
+        positive: {
+          p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
+          p1: "<0>Visit the CDC website to learn more about a positive Gonorrhea result.</0> (cdc.gov/gonorrhea/about).",
+          treatmentLink: "https://www.cdc.gov/gonorrhea/about/index.html",
         },
       },
       tos: {

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -460,8 +460,9 @@ export const es: LanguageConfig = {
         h1: "Para Gonorrea:",
         positive: {
           p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
-          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de gonorrea.</0> (cdc.gov/gonorrhea/about).",
-          treatmentLink: "https://www.cdc.gov/gonorrhea/about/index.html",
+          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de gonorrea.</0> (cdc.gov/gonorrhea/es/about/acerca-de-la-gonorrea.html).",
+          treatmentLink:
+            "https://www.cdc.gov/gonorrhea/es/about/acerca-de-la-gonorrea.html",
         },
       },
       tos: {

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -44,6 +44,7 @@ export const es: LanguageConfig = {
         HIV: "VIH",
         SYPHILIS: "Sífilis",
         HEPATITIS_C: "Hepatitis C",
+        GONORRHEA: "Gonorrea",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 resultado",
@@ -54,6 +55,7 @@ export const es: LanguageConfig = {
         HIV: "Resultado de la prueba del VIH",
         SYPHILIS: "Sífilis resultado",
         HEPATITIS_C: "Hepatitis C resultado",
+        GONORRHEA: "Gonorrea resultado",
       },
       role: {
         STAFF: "Personal",
@@ -452,6 +454,14 @@ export const es: LanguageConfig = {
           p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo en la prueba del hepatitis C.</0> (cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results).",
           treatmentLink:
             "https://www.cdc.gov/hepatitis-c/testing/index.html#cdc_testing_results-testing-results",
+        },
+      },
+      gonorrheaNotes: {
+        h1: "Para Gonorrea:",
+        positive: {
+          p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
+          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de gonorrea.</0> (cdc.gov/gonorrhea/about).",
+          treatmentLink: "https://www.cdc.gov/gonorrhea/about/index.html",
         },
       },
       tos: {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7438 

## Changes Proposed

- Adds result guidance for positive gonorrhea test results

## Additional Information

- The other acceptance criteria are already fulfilled from previous work

## Testing

- Deployed on dev5

## Screenshots / Demos

Print modal

![Screenshot 2025-01-02 121334](https://github.com/user-attachments/assets/f5c05148-f6f8-4b90-b3ae-2697cb7743d0)
![Screenshot 2025-01-02 121344](https://github.com/user-attachments/assets/867677b9-287e-484d-a55d-1d61a50e0d2c)

Dropdown

![Screenshot 2025-01-02 121400](https://github.com/user-attachments/assets/a71f6788-0d04-4e9d-a548-41eaa7884797)

CSV Download

![Screenshot 2025-01-02 121416](https://github.com/user-attachments/assets/19045ac8-c0af-4a54-a18a-a8b7952271f9)

View Details modal

![Screenshot 2025-01-02 121604](https://github.com/user-attachments/assets/44b400bf-f549-4139-8828-26edb13aff82)

PXP View Results

![Screenshot 2025-01-02 121730](https://github.com/user-attachments/assets/322f0e9c-6567-440a-807c-8ba7b9672262)
![Screenshot 2025-01-02 121737](https://github.com/user-attachments/assets/c22888f9-0ef1-45b9-ae68-ac8ad87ec92e)
