### PR TITLE
Add Chlamydia support to test card

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -25,6 +25,7 @@ public class FeatureFlagsConfig {
   private final FeatureFlagRepository _repo;
 
   private boolean oktaMigrationEnabled;
+  private boolean chlamydiaEnabled;
   private boolean gonorrheaEnabled;
   private boolean hepatitisCEnabled;
   private boolean syphilisEnabled;
@@ -42,6 +43,7 @@ public class FeatureFlagsConfig {
   private void flagMapping(String flagName, Boolean flagValue) {
     switch (flagName) {
       case "oktaMigrationEnabled" -> setOktaMigrationEnabled(flagValue);
+      case "chlamydiaEnabled" -> setChlamydiaEnabled(flagValue);
       case "gonorrheaEnabled" -> setGonorrheaEnabled(flagValue);
       case "hepatitisCEnabled" -> setHepatitisCEnabled(flagValue);
       case "syphilisEnabled" -> setSyphilisEnabled(flagValue);

--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -24,6 +24,7 @@ twilio:
   from-number: "+14045312484"
 features:
   oktaMigrationEnabled: false
+  chlamydiaEnabled: false
   gonorrheaEnabled: false
   hepatitisCEnabled: false
   syphilisEnabled: false

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -180,6 +180,7 @@ datahub:
   csv-upload-api-fhir-client: "simple_report.fullelr-bulkuploader"
 features:
   oktaMigrationEnabled: false
+  chlamydiaEnabled: true
   gonorrheaEnabled: true
   hepatitisCEnabled: true
   syphilisEnabled: true

--- a/frontend/src/app/commonComponents/TestResultsList.tsx
+++ b/frontend/src/app/commonComponents/TestResultsList.tsx
@@ -33,6 +33,7 @@ const diseaseResultTitlePxpMap: Record<MULTIPLEX_DISEASES, string> = {
   [MULTIPLEX_DISEASES.SYPHILIS]: "constants.diseaseResultTitle.SYPHILIS",
   [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.diseaseResultTitle.HEPATITIS_C",
   [MULTIPLEX_DISEASES.GONORRHEA]: "constants.diseaseResultTitle.GONORRHEA",
+  [MULTIPLEX_DISEASES.CHLAMYDIA]: "constants.diseaseResultTitle.CHLAMYDIA",
 };
 
 const diseaseResultReportingAppMap: Record<MULTIPLEX_DISEASES, string> = {
@@ -45,6 +46,7 @@ const diseaseResultReportingAppMap: Record<MULTIPLEX_DISEASES, string> = {
   [MULTIPLEX_DISEASES.SYPHILIS]: "constants.disease.SYPHILIS",
   [MULTIPLEX_DISEASES.HEPATITIS_C]: "constants.disease.HEPATITIS_C",
   [MULTIPLEX_DISEASES.GONORRHEA]: "constants.disease.GONORRHEA",
+  [MULTIPLEX_DISEASES.CHLAMYDIA]: "constants.disease.CHLAMYDIA",
 };
 
 const setResult = (result: string, t: translateFn) => {

--- a/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedChlamydia.ts
+++ b/frontend/src/app/supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedChlamydia.ts
@@ -1,0 +1,15 @@
+const mockSupportedDiseaseTestPerformedChlamydia = [
+  {
+    supportedDisease: {
+      internalId: "6517fcbd-e094-4384-9eef-a5c7f373a015",
+      loinc: "LP14298-1",
+      name: "Chlamydia",
+    },
+    testPerformedLoincCode: "80124-8",
+    equipmentUid: "ChlamydiaEquipmentUid123",
+    testkitNameId: "ChlamydiaTestkitNameId123",
+    testOrderedLoincCode: "80124-8",
+  },
+];
+
+export default mockSupportedDiseaseTestPerformedChlamydia;

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.test.tsx
@@ -5,6 +5,8 @@ import { MockedProvider } from "@apollo/client/testing";
 import { MULTIPLEX_DISEASES, TEST_RESULTS } from "../../testResults/constants";
 import {
   asymptomaticTestOrderInfo,
+  chlamydiaDeviceId,
+  chlamydiaDeviceName,
   covidDeviceId,
   covidDeviceName,
   devicesMap,
@@ -218,6 +220,24 @@ describe("TestCardForm", () => {
             internalId: gonorrheaDeviceId,
             name: gonorrheaDeviceName,
             model: gonorrheaDeviceName,
+            testLength: 15,
+          },
+        },
+      };
+
+      expect(await renderTestCardForm({ props })).toMatchSnapshot();
+    });
+
+    it("matches snapshot for chlamydia device", async () => {
+      const props = {
+        ...testProps,
+        testOrder: {
+          ...testProps.testOrder,
+          results: [{ testResult: "POSITIVE", disease: { name: "CHLAMYDIA" } }],
+          deviceType: {
+            internalId: chlamydiaDeviceId,
+            name: chlamydiaDeviceName,
+            model: chlamydiaDeviceName,
             testLength: 15,
           },
         },

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -27,6 +27,7 @@ import {
   TestCorrectionReasons,
 } from "../../testResults/viewResults/actionMenuModals/TestResultCorrectionModal";
 import {
+  chlamydiaSymptomDefinitions,
   gonorrheaSymptomDefinitions,
   hepatitisCSymptomDefinitions,
   PregnancyCode,
@@ -637,6 +638,23 @@ const TestCardForm = ({
               }}
               diseaseSymptomDefinitions={gonorrheaSymptomDefinitions}
               diseaseNameForFormIds={"gonorrhea"}
+            />
+          </div>
+        )}
+        {whichAoeFormOption === AOEFormOption.CHLAMYDIA && (
+          <div className="grid-row grid-gap">
+            <STIGenericAOEForm
+              testOrder={testOrder}
+              responses={state.aoeResponses}
+              hasAttemptedSubmit={hasAttemptedSubmit}
+              onResponseChange={(responses) => {
+                dispatch({
+                  type: TestFormActionCase.UPDATE_AOE_RESPONSES,
+                  payload: responses,
+                });
+              }}
+              diseaseSymptomDefinitions={chlamydiaSymptomDefinitions}
+              diseaseNameForFormIds={"chlamydia"}
             />
           </div>
         )}

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.test.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.test.tsx
@@ -145,5 +145,28 @@ describe("TestCardForm.utils", () => {
         )
       ).toEqual(AoeValidationErrorMessages.COMPLETE);
     });
+
+    it("should return false if Chlamydia questions are unanswered", () => {
+      const positive: TestFormState = {
+        ...incompleteState,
+      };
+      expect(
+        generateAoeValidationState(positive, AOEFormOption.CHLAMYDIA)
+      ).toEqual(AoeValidationErrorMessages.INCOMPLETE);
+    });
+
+    it("should return true when Chlamydia positive is selected and questions are answered", () => {
+      const positiveChlamydiaStateCompleteAOE: TestFormState = {
+        ...completeStateWithSymptoms,
+      };
+      positiveChlamydiaStateCompleteAOE.aoeResponses.symptoms =
+        '{"77880009":true,"405729008":false,"301822002":false,"249301002":false,"49650001":false,"9957009":false,"162156001":false,"63901009":false,"438457000":false}';
+      expect(
+        generateAoeValidationState(
+          positiveChlamydiaStateCompleteAOE,
+          AOEFormOption.CHLAMYDIA
+        )
+      ).toEqual(AoeValidationErrorMessages.COMPLETE);
+    });
   });
 });

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -28,6 +28,7 @@ export enum AOEFormOption {
   SYPHILIS = "SYPHILIS",
   HEPATITIS_C = "HEPATITIS_C",
   GONORRHEA = "GONORRHEA",
+  CHLAMYDIA = "CHLAMYDIA",
   NONE = "NONE",
 }
 
@@ -67,6 +68,7 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
   const syphilisEnabled = useFeature("syphilisEnabled");
   const hepatitisCEnabled = useFeature("hepatitisCEnabled");
   const gonorrheaEnabled = useFeature("gonorrheaEnabled");
+  const chlamydiaEnabled = useFeature("chlamydiaEnabled");
 
   let deviceTypes = [...facility!.deviceTypes];
 
@@ -92,6 +94,12 @@ export function useFilteredDeviceTypes(facility: QueriedFacility) {
     deviceTypes = filterDiseaseFromAllDevices(
       deviceTypes,
       MULTIPLEX_DISEASES.GONORRHEA
+    );
+  }
+  if (!chlamydiaEnabled) {
+    deviceTypes = filterDiseaseFromAllDevices(
+      deviceTypes,
+      MULTIPLEX_DISEASES.CHLAMYDIA
     );
   }
   return deviceTypes;
@@ -215,6 +223,15 @@ export const useAOEFormOption = (
     devicesMap
       .get(testFormState.deviceId)
       ?.supportedDiseaseTestPerformed.filter(
+        (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.CHLAMYDIA
+      ).length === 1
+  ) {
+    return resultHasPositive ? AOEFormOption.CHLAMYDIA : AOEFormOption.NONE;
+  }
+  if (
+    devicesMap
+      .get(testFormState.deviceId)
+      ?.supportedDiseaseTestPerformed.filter(
         (x) => x.supportedDisease.name === MULTIPLEX_DISEASES.GONORRHEA
       ).length === 1
   ) {
@@ -305,6 +322,11 @@ export const REQUIRED_AOE_QUESTIONS_BY_DISEASE: {
     AoeQuestionName.NO_SYMPTOMS,
   ],
   [AOEFormOption.GONORRHEA]: [
+    AoeQuestionName.PREGNANCY,
+    AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
+    AoeQuestionName.NO_SYMPTOMS,
+  ],
+  [AOEFormOption.CHLAMYDIA]: [
     AoeQuestionName.PREGNANCY,
     AoeQuestionName.GENDER_OF_SEXUAL_PARTNERS,
     AoeQuestionName.NO_SYMPTOMS,

--- a/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
+++ b/frontend/src/app/testQueue/TestCardForm/__snapshots__/TestCardForm.test.tsx.snap
@@ -1,5 +1,1408 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TestCardForm initial state matches snapshot for chlamydia device 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-hidden="true"
+        class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+      >
+        <h4>
+          Submitting test data for 
+          Dixon, Althea Hedda Mclaughlin
+          ...
+        </h4>
+        <img
+          alt="submitting"
+          class="square-5"
+          src="loader.svg"
+        />
+      </div>
+      <div
+        class="grid-container sr-test-card-form-container"
+      >
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <label
+              class="usa-label margin-top-3"
+              data-testid="label"
+              for="current-date-time"
+            >
+              Test date and time
+               
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                *
+              </abbr>
+            </label>
+            <div
+              class="usa-checkbox"
+              data-testid="checkbox"
+            >
+              <input
+                checked=""
+                class="usa-checkbox__input"
+                id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="current-date-time"
+                type="checkbox"
+              />
+              <label
+                class="usa-checkbox__label"
+                for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              >
+                Current date and time
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+          data-testid="device-type-dropdown-container"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <div
+              class="usa-form-group prime-dropdown  card-dropdown"
+            >
+              <label
+                class="usa-label"
+                for="34"
+              >
+                <span
+                  class="usa-tooltip usa-text-with-tooltip"
+                  data-testid="tooltipWrapper"
+                >
+                  <button
+                    aria-describedby="tooltip-1000000"
+                    aria-label=""
+                    class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                    data-testid="triggerElement"
+                    position="right"
+                    tabindex="0"
+                    title=""
+                    wrapperclasses="usa-text-with-tooltip"
+                  >
+                    Test device
+                    <svg
+                      alt-text="info"
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-circle-info info-circle-icon"
+                      data-icon="circle-info"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <span
+                    aria-hidden="true"
+                    class="usa-tooltip__body"
+                    data-testid="tooltipBody"
+                    id="tooltip-1000000"
+                    role="tooltip"
+                    title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                  >
+                    Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                  </span>
+                </span>
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <select
+                aria-label="Test device"
+                aria-required="true"
+                class="usa-select"
+                data-testid="device-type-dropdown"
+                id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="testDevice"
+              >
+                <option
+                  aria-selected="false"
+                  value="FLU-DEVICE-ID"
+                >
+                  FLU
+                </option>
+                <option
+                  aria-selected="false"
+                  value="COVID-DEVICE-ID"
+                >
+                  LumiraDX
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-DEVICE-ID"
+                >
+                  Multiplex
+                </option>
+                <option
+                  aria-selected="false"
+                  value="MULTIPLEX-COVID-DEVICE-ID"
+                >
+                  MultiplexAndCovidOnly
+                </option>
+              </select>
+            </div>
+          </div>
+          <div
+            class="grid-col-auto"
+            data-testid="specimen-type-dropdown-container"
+          >
+            <div
+              class="usa-form-group prime-dropdown  card-dropdown"
+            >
+              <label
+                class="usa-label"
+                for="35"
+              >
+                Specimen type
+                <abbr
+                  class="usa-hint usa-hint--required"
+                  title="required"
+                >
+                   
+                  *
+                </abbr>
+              </label>
+              <select
+                aria-label="Specimen type"
+                aria-required="true"
+                class="usa-select"
+                data-testid="specimen-type-dropdown"
+                id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+                name="specimenType"
+              >
+                <option
+                  aria-selected="true"
+                  value="SPECIMEN-1-ID"
+                >
+                  Swab of internal nose
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="usa-form-group"
+            data-testid="formGroup"
+          >
+            <div
+              class="usa-alert usa-alert--error"
+              data-testid="alert"
+            >
+              <div
+                class="usa-alert__body"
+              >
+                <p
+                  class="usa-alert__text"
+                >
+                  This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap"
+        >
+          <div
+            class="grid-col"
+            id="chlamydia-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+          >
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <label
+                    class="usa-label"
+                    for="36"
+                    id="label-for-36"
+                  >
+                    What is the gender of their sexual partners?
+                     
+                    <span
+                      class="text-base-dark"
+                    >
+                      (Select all that apply.)
+                    </span>
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </label>
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled margin-top-05em"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        alt-text="info"
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+                        data-icon="circle-info"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <strong
+                        class="font-body-2xs"
+                      >
+                        Why SimpleReport asks about sensitive topics like this
+                      </strong>
+                    </button>
+                  </span>
+                  <div
+                    class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
+                    data-testid="multi-select"
+                    id="36"
+                  >
+                    <input
+                      aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      aria-labelledby="label-for-36"
+                      aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      aria-required="true"
+                      autocapitalize="off"
+                      autocomplete="off"
+                      class="usa-combo-box__input"
+                      data-testid="multi-select-input"
+                      role="combobox"
+                      type="text"
+                      value=""
+                    />
+                    <span
+                      class="usa-combo-box__input-button-separator"
+                    >
+                       
+                    </span>
+                    <span
+                      class="usa-combo-box__toggle-list__wrapper"
+                      tabindex="-1"
+                    >
+                      <button
+                        aria-hidden="true"
+                        class="usa-combo-box__toggle-list"
+                        data-testid="multi-select-toggle"
+                        tabindex="-1"
+                        type="button"
+                      >
+                         
+                      </button>
+                    </span>
+                    <ul
+                      class="usa-combo-box__list"
+                      data-testid="multi-select-option-list"
+                      hidden=""
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                      role="listbox"
+                      tabindex="-1"
+                    >
+                      <li
+                        aria-posinset="1"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-female"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-0"
+                        role="option"
+                        tabindex="-1"
+                        value="female"
+                      >
+                        Female
+                      </li>
+                      <li
+                        aria-posinset="2"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-other"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-1"
+                        role="option"
+                        tabindex="-1"
+                        value="other"
+                      >
+                        Gender identity not listed here
+                      </li>
+                      <li
+                        aria-posinset="3"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-male"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-2"
+                        role="option"
+                        tabindex="-1"
+                        value="male"
+                      >
+                        Male
+                      </li>
+                      <li
+                        aria-posinset="4"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-nonbinary"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-3"
+                        role="option"
+                        tabindex="-1"
+                        value="nonbinary"
+                      >
+                        Nonbinary or gender non-conforming
+                      </li>
+                      <li
+                        aria-posinset="5"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-refused"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-4"
+                        role="option"
+                        tabindex="-1"
+                        value="refused"
+                      >
+                        Prefer not to answer
+                      </li>
+                      <li
+                        aria-posinset="6"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-transman"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-5"
+                        role="option"
+                        tabindex="-1"
+                        value="transman"
+                      >
+                        Transman
+                      </li>
+                      <li
+                        aria-posinset="7"
+                        aria-selected="false"
+                        aria-setsize="64"
+                        class="usa-combo-box__list-option"
+                        data-testid="multi-select-option-transwoman"
+                        id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-6"
+                        role="option"
+                        tabindex="-1"
+                        value="transwoman"
+                      >
+                        Transwoman
+                      </li>
+                    </ul>
+                    <div
+                      class="usa-combo-box__status usa-sr-only"
+                      role="status"
+                    />
+                  </div>
+                  <fieldset
+                    class="fieldset--unstyled pill-container pill-container--hidden"
+                    data-testid="pill-container"
+                  >
+                    <legend
+                      class="usa-sr-only"
+                    >
+                      Selected [object Object]
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient pregnant?
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="37-val-77386006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="77386006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                          for="37-val-77386006"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="37-val-60001007"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="60001007"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                          for="37-val-60001007"
+                        >
+                          No
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="37-val-261665006"
+                          name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="261665006"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                          for="37-val-261665006"
+                        >
+                          Prefer not to answer
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              class="grid-row"
+            >
+              <div
+                class="grid-col-auto"
+              >
+                <div
+                  class="usa-form-group"
+                >
+                  <fieldset
+                    class="usa-fieldset prime-radios"
+                    data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                    id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  >
+                    <legend
+                      class="usa-legend"
+                    >
+                      Is the patient currently experiencing or showing signs of symptoms?
+                      <abbr
+                        class="usa-hint usa-hint--required"
+                        title="required"
+                      >
+                         
+                        *
+                      </abbr>
+                    </legend>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="38-val-YES"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="YES"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                          for="38-val-YES"
+                        >
+                          Yes
+                        </label>
+                      </div>
+                      <div
+                        class="usa-radio"
+                      >
+                        <input
+                          checked=""
+                          class="usa-radio__input"
+                          data-required="true"
+                          id="38-val-NO"
+                          name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                          type="radio"
+                          value="NO"
+                        />
+                        <label
+                          class="usa-radio__label"
+                          data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                          for="38-val-NO"
+                        >
+                          No
+                        </label>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-4"
+        >
+          <div
+            class="grid-col-auto"
+          >
+            <button
+              class="usa-button"
+              data-testid="button"
+              type="button"
+            >
+              Submit results
+            </button>
+          </div>
+        </div>
+        <div
+          class="grid-row margin-top-1"
+        >
+          <button
+            class="usa-button usa-button--unstyled margin-top-05em"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              alt-text="info"
+              aria-hidden="true"
+              class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+              data-icon="circle-info"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                fill="currentColor"
+              />
+            </svg>
+            <strong
+              class="font-body-2xs"
+            >
+              Where results are sent
+            </strong>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="modal--basic"
+    />
+    <div
+      class="modal--basic"
+    />
+    <div
+      class="modal--basic"
+    />
+  </body>,
+  "container": <div>
+    <div
+      aria-hidden="true"
+      class="sr-queue-item-submit-loader z-top position-absolute height-full width-full text-center test-card-submit-loader"
+    >
+      <h4>
+        Submitting test data for 
+        Dixon, Althea Hedda Mclaughlin
+        ...
+      </h4>
+      <img
+        alt="submitting"
+        class="square-5"
+        src="loader.svg"
+      />
+    </div>
+    <div
+      class="grid-container sr-test-card-form-container"
+    >
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <label
+            class="usa-label margin-top-3"
+            data-testid="label"
+            for="current-date-time"
+          >
+            Test date and time
+             
+            <abbr
+              class="usa-hint usa-hint--required"
+              title="required"
+            >
+              *
+            </abbr>
+          </label>
+          <div
+            class="usa-checkbox"
+            data-testid="checkbox"
+          >
+            <input
+              checked=""
+              class="usa-checkbox__input"
+              id="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="current-date-time"
+              type="checkbox"
+            />
+            <label
+              class="usa-checkbox__label"
+              for="current-date-time-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+            >
+              Current date and time
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+        data-testid="device-type-dropdown-container"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <div
+            class="usa-form-group prime-dropdown  card-dropdown"
+          >
+            <label
+              class="usa-label"
+              for="34"
+            >
+              <span
+                class="usa-tooltip usa-text-with-tooltip"
+                data-testid="tooltipWrapper"
+              >
+                <button
+                  aria-describedby="tooltip-1000000"
+                  aria-label=""
+                  class="usa-button usa-button--unstyled usa-tooltip__trigger"
+                  data-testid="triggerElement"
+                  position="right"
+                  tabindex="0"
+                  title=""
+                  wrapperclasses="usa-text-with-tooltip"
+                >
+                  Test device
+                  <svg
+                    alt-text="info"
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-circle-info info-circle-icon"
+                    data-icon="circle-info"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+                <span
+                  aria-hidden="true"
+                  class="usa-tooltip__body"
+                  data-testid="tooltipBody"
+                  id="tooltip-1000000"
+                  role="tooltip"
+                  title="Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here."
+                >
+                  Don’t see the test you’re using? Ask your organization admin to add the correct test and it'll show up here.
+                </span>
+              </span>
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <select
+              aria-label="Test device"
+              aria-required="true"
+              class="usa-select"
+              data-testid="device-type-dropdown"
+              id="test-device-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="testDevice"
+            >
+              <option
+                aria-selected="false"
+                value="FLU-DEVICE-ID"
+              >
+                FLU
+              </option>
+              <option
+                aria-selected="false"
+                value="COVID-DEVICE-ID"
+              >
+                LumiraDX
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-DEVICE-ID"
+              >
+                Multiplex
+              </option>
+              <option
+                aria-selected="false"
+                value="MULTIPLEX-COVID-DEVICE-ID"
+              >
+                MultiplexAndCovidOnly
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-col-auto"
+          data-testid="specimen-type-dropdown-container"
+        >
+          <div
+            class="usa-form-group prime-dropdown  card-dropdown"
+          >
+            <label
+              class="usa-label"
+              for="35"
+            >
+              Specimen type
+              <abbr
+                class="usa-hint usa-hint--required"
+                title="required"
+              >
+                 
+                *
+              </abbr>
+            </label>
+            <select
+              aria-label="Specimen type"
+              aria-required="true"
+              class="usa-select"
+              data-testid="specimen-type-dropdown"
+              id="specimen-type-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+              name="specimenType"
+            >
+              <option
+                aria-selected="true"
+                value="SPECIMEN-1-ID"
+              >
+                Swab of internal nose
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="usa-form-group"
+          data-testid="formGroup"
+        >
+          <div
+            class="usa-alert usa-alert--error"
+            data-testid="alert"
+          >
+            <div
+              class="usa-alert__body"
+            >
+              <p
+                class="usa-alert__text"
+              >
+                This device doesn't have any supported disease tests configured. Please ask your organization admin to add the correct test.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row grid-gap"
+      >
+        <div
+          class="grid-col"
+          id="chlamydia-aoe-form-72b3ce1e-9d5a-4ad2-9ae8-e1099ed1b7e0"
+        >
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <label
+                  class="usa-label"
+                  for="36"
+                  id="label-for-36"
+                >
+                  What is the gender of their sexual partners?
+                   
+                  <span
+                    class="text-base-dark"
+                  >
+                    (Select all that apply.)
+                  </span>
+                  <abbr
+                    class="usa-hint usa-hint--required"
+                    title="required"
+                  >
+                     
+                    *
+                  </abbr>
+                </label>
+                <span
+                  class=""
+                >
+                  <button
+                    class="usa-button usa-button--unstyled margin-top-05em"
+                    data-testid="button"
+                    type="button"
+                  >
+                    <svg
+                      alt-text="info"
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+                      data-icon="circle-info"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <strong
+                      class="font-body-2xs"
+                    >
+                      Why SimpleReport asks about sensitive topics like this
+                    </strong>
+                  </button>
+                </span>
+                <div
+                  class="usa-combo-box usa-combo-box--pristine multi-select-dropdown"
+                  data-testid="multi-select"
+                  id="36"
+                >
+                  <input
+                    aria-controls="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    aria-labelledby="label-for-36"
+                    aria-owns="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    aria-required="true"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    class="usa-combo-box__input"
+                    data-testid="multi-select-input"
+                    role="combobox"
+                    type="text"
+                    value=""
+                  />
+                  <span
+                    class="usa-combo-box__input-button-separator"
+                  >
+                     
+                  </span>
+                  <span
+                    class="usa-combo-box__toggle-list__wrapper"
+                    tabindex="-1"
+                  >
+                    <button
+                      aria-hidden="true"
+                      class="usa-combo-box__toggle-list"
+                      data-testid="multi-select-toggle"
+                      tabindex="-1"
+                      type="button"
+                    >
+                       
+                    </button>
+                  </span>
+                  <ul
+                    class="usa-combo-box__list"
+                    data-testid="multi-select-option-list"
+                    hidden=""
+                    id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list"
+                    role="listbox"
+                    tabindex="-1"
+                  >
+                    <li
+                      aria-posinset="1"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-female"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-0"
+                      role="option"
+                      tabindex="-1"
+                      value="female"
+                    >
+                      Female
+                    </li>
+                    <li
+                      aria-posinset="2"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-other"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-1"
+                      role="option"
+                      tabindex="-1"
+                      value="other"
+                    >
+                      Gender identity not listed here
+                    </li>
+                    <li
+                      aria-posinset="3"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-male"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-2"
+                      role="option"
+                      tabindex="-1"
+                      value="male"
+                    >
+                      Male
+                    </li>
+                    <li
+                      aria-posinset="4"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-nonbinary"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-3"
+                      role="option"
+                      tabindex="-1"
+                      value="nonbinary"
+                    >
+                      Nonbinary or gender non-conforming
+                    </li>
+                    <li
+                      aria-posinset="5"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-refused"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-4"
+                      role="option"
+                      tabindex="-1"
+                      value="refused"
+                    >
+                      Prefer not to answer
+                    </li>
+                    <li
+                      aria-posinset="6"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-transman"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-5"
+                      role="option"
+                      tabindex="-1"
+                      value="transman"
+                    >
+                      Transman
+                    </li>
+                    <li
+                      aria-posinset="7"
+                      aria-selected="false"
+                      aria-setsize="64"
+                      class="usa-combo-box__list-option"
+                      data-testid="multi-select-option-transwoman"
+                      id="multi-select-sexual-partner-gender-1b02363b-ce71-4f30-a2d6-d82b56a91b39-list--option-6"
+                      role="option"
+                      tabindex="-1"
+                      value="transwoman"
+                    >
+                      Transwoman
+                    </li>
+                  </ul>
+                  <div
+                    class="usa-combo-box__status usa-sr-only"
+                    role="status"
+                  />
+                </div>
+                <fieldset
+                  class="fieldset--unstyled pill-container pill-container--hidden"
+                  data-testid="pill-container"
+                >
+                  <legend
+                    class="usa-sr-only"
+                  >
+                    Selected [object Object]
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient pregnant?
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="37-val-77386006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="77386006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-77386006"
+                        for="37-val-77386006"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="37-val-60001007"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="60001007"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-60001007"
+                        for="37-val-60001007"
+                      >
+                        No
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="37-val-261665006"
+                        name="pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="261665006"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-pregnancy-1b02363b-ce71-4f30-a2d6-d82b56a91b39-261665006"
+                        for="37-val-261665006"
+                      >
+                        Prefer not to answer
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            class="grid-row"
+          >
+            <div
+              class="grid-col-auto"
+            >
+              <div
+                class="usa-form-group"
+              >
+                <fieldset
+                  class="usa-fieldset prime-radios"
+                  data-testid="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                  id="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                >
+                  <legend
+                    class="usa-legend"
+                  >
+                    Is the patient currently experiencing or showing signs of symptoms?
+                    <abbr
+                      class="usa-hint usa-hint--required"
+                      title="required"
+                    >
+                       
+                      *
+                    </abbr>
+                  </legend>
+                  <div
+                    class=""
+                  >
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="38-val-YES"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="YES"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-YES"
+                        for="38-val-YES"
+                      >
+                        Yes
+                      </label>
+                    </div>
+                    <div
+                      class="usa-radio"
+                    >
+                      <input
+                        checked=""
+                        class="usa-radio__input"
+                        data-required="true"
+                        id="38-val-NO"
+                        name="has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39"
+                        type="radio"
+                        value="NO"
+                      />
+                      <label
+                        class="usa-radio__label"
+                        data-cy="radio-group-option-has-any-symptoms-1b02363b-ce71-4f30-a2d6-d82b56a91b39-NO"
+                        for="38-val-NO"
+                      >
+                        No
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-4"
+      >
+        <div
+          class="grid-col-auto"
+        >
+          <button
+            class="usa-button"
+            data-testid="button"
+            type="button"
+          >
+            Submit results
+          </button>
+        </div>
+      </div>
+      <div
+        class="grid-row margin-top-1"
+      >
+        <button
+          class="usa-button usa-button--unstyled margin-top-05em"
+          data-testid="button"
+          type="button"
+        >
+          <svg
+            alt-text="info"
+            aria-hidden="true"
+            class="svg-inline--fa fa-circle-info info-circle-icon margin-right-05em"
+            data-icon="circle-info"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"
+              fill="currentColor"
+            />
+          </svg>
+          <strong
+            class="font-body-2xs"
+          >
+            Where results are sent
+          </strong>
+        </button>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+  "user": Object {
+    "clear": [Function],
+    "click": [Function],
+    "copy": [Function],
+    "cut": [Function],
+    "dblClick": [Function],
+    "deselectOptions": [Function],
+    "hover": [Function],
+    "keyboard": [Function],
+    "paste": [Function],
+    "pointer": [Function],
+    "selectOptions": [Function],
+    "setup": [Function],
+    "tab": [Function],
+    "tripleClick": [Function],
+    "type": [Function],
+    "unhover": [Function],
+    "upload": [Function],
+  },
+}
+`;
+
 exports[`TestCardForm initial state matches snapshot for covid device 1`] = `
 Object {
   "asFragment": [Function],

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.test.ts
@@ -1,4 +1,6 @@
 import {
+  chlamydiaSymptomDefinitions,
+  chlamydiaSymptomOrder,
   gonorrheaSymptomDefinitions,
   gonorrheaSymptomOrder,
   hepatitisCSymptomDefinitions,
@@ -40,6 +42,17 @@ describe("mapSymptomBoolLiteralsToBool", () => {
       gonorrheaSymptomDefinitions
     );
     gonorrheaSymptomOrder.forEach((symptomKey) => {
+      expect(parsedPayload[symptomKey]).toEqual(false);
+    });
+  });
+  it("takes a JSON payload of {'Chlamydia symptom SNOMEDS' : boolean strings} and parses the strings into booleans", () => {
+    const chlamydiaSymptomPayload =
+      '{"77880009":false,"405729008":false,"301822002":false,"249301002":false,"49650001":false,"9957009":false,"162156001":false,"63901009":false,"438457000":false}\n';
+    const parsedPayload = mapSymptomBoolLiteralsToBool(
+      chlamydiaSymptomPayload,
+      chlamydiaSymptomDefinitions
+    );
+    chlamydiaSymptomOrder.forEach((symptomKey) => {
       expect(parsedPayload[symptomKey]).toEqual(false);
     });
   });

--- a/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
+++ b/frontend/src/app/testQueue/TestCardForm/diseaseSpecificComponents/aoeUtils.ts
@@ -4,6 +4,8 @@ import _ from "lodash";
 
 import { AoeQuestionResponses } from "../TestCardFormReducer";
 import {
+  chlamydiaSymptomDefinitions,
+  chlamydiaSymptomsMap,
   gonorrheaSymptomDefinitions,
   gonorrheaSymptomsMap,
   hepatitisCSymptomDefinitions,
@@ -190,6 +192,11 @@ export function stringifySymptomJsonForAoeUpdate(
       mapSymptomBoolLiteralsToBool(symptomJson, gonorrheaSymptomDefinitions)
     );
   }
+  if (_.isEqual(symptomKeys, Object.keys(chlamydiaSymptomsMap))) {
+    symptomPayload = JSON.stringify(
+      mapSymptomBoolLiteralsToBool(symptomJson, chlamydiaSymptomDefinitions)
+    );
+  }
   return symptomPayload;
 }
 
@@ -209,6 +216,9 @@ export function mapSpecifiedSymptomBoolLiteralsToBool(
   }
   if (disease === AOEFormOption.GONORRHEA) {
     symptomDefinitionToParse = gonorrheaSymptomDefinitions;
+  }
+  if (disease === AOEFormOption.CHLAMYDIA) {
+    symptomDefinitionToParse = chlamydiaSymptomDefinitions;
   }
   // there are no symptoms for that test card, so return true
   if (!symptomDefinitionToParse) return { shouldReturn: true };

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -36,6 +36,8 @@ export const hepatitisCDeviceName = "HEPATITIS C";
 export const hepatitisCDeviceId = "HEPATITIS C-DEVICE-ID";
 export const gonorrheaDeviceName = "GONORRHEA";
 export const gonorrheaDeviceId = "GONORRHEA-DEVICE-ID";
+export const chlamydiaDeviceName = "Chlamydia device";
+export const chlamydiaDeviceId = "CHLAMYDIA-DEVICE-ID";
 
 // 6 instead of 7 because HIV devices are filtered out when HIV feature flag is disabled
 export const DEFAULT_DEVICE_OPTIONS_LENGTH = 6;
@@ -50,7 +52,6 @@ export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
 export const device9Name = "Hepatitis C device";
 export const device10Name = "Gonorrhea device";
-export const chlamydiaDeviceName = "Chlamydia device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -62,7 +63,6 @@ export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
 export const device9Id = "DEVICE-9-ID";
 export const device10Id = "DEVICE-10-ID";
-export const chlamydiaDeviceId = "CHLAMYDIA-DEVICE-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -10,6 +10,7 @@ import {
 import mockSupportedDiseaseTestPerformedHIV from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedHIV";
 import mockSupportedDiseaseTestPerformedSyphilis from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedSyphilis";
 import mockSupportedDiseaseTestPerformedGonorrhea from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedGonorrhea";
+import mockSupportedDiseaseTestPerformedChlamydia from "../supportAdmin/DeviceType/mocks/mockSupportedDiseaseTestPerformedChlamydia";
 
 import { QueriedFacility, QueriedTestOrder } from "./TestCardForm/types";
 import mockSupportedDiseaseCovid from "./mocks/mockSupportedDiseaseCovid";
@@ -49,6 +50,7 @@ export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
 export const device9Name = "Hepatitis C device";
 export const device10Name = "Gonorrhea device";
+export const chlamydiaDeviceName = "Chlamydia device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -60,6 +62,7 @@ export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
 export const device9Id = "DEVICE-9-ID";
 export const device10Id = "DEVICE-10-ID";
+export const chlamydiaDeviceId = "CHLAMYDIA-DEVICE-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";
@@ -424,6 +427,21 @@ export const facilityInfo: QueriedFacility = {
       testLength: 15,
       supportedDiseaseTestPerformed: [
         ...mockSupportedDiseaseTestPerformedGonorrhea,
+      ],
+      swabTypes: [
+        {
+          name: specimen1Name,
+          internalId: specimen1Id,
+          typeCode: "445297001",
+        },
+      ],
+    },
+    {
+      internalId: chlamydiaDeviceId,
+      name: chlamydiaDeviceName,
+      testLength: 15,
+      supportedDiseaseTestPerformed: [
+        ...mockSupportedDiseaseTestPerformedChlamydia,
       ],
       swabTypes: [
         {

--- a/frontend/src/app/testResults/constants.ts
+++ b/frontend/src/app/testResults/constants.ts
@@ -8,6 +8,7 @@ export enum MULTIPLEX_DISEASES {
   FLU_A_AND_B = "Flu A and B",
   HEPATITIS_C = "Hepatitis C",
   GONORRHEA = "Gonorrhea",
+  CHLAMYDIA = "Chlamydia",
 }
 
 export enum TEST_RESULTS {

--- a/frontend/src/app/utils/disease.ts
+++ b/frontend/src/app/utils/disease.ts
@@ -22,6 +22,10 @@ export const useSupportedDiseaseList = () => {
   if (!gonorrheaEnabled) {
     allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.GONORRHEA);
   }
+  const chlamydiaEnabled = Boolean(useFeature("chlamydiaEnabled"));
+  if (!chlamydiaEnabled) {
+    allDiseases = allDiseases.filter((d) => d !== MULTIPLEX_DISEASES.CHLAMYDIA);
+  }
   return allDiseases;
 };
 

--- a/frontend/src/patientApp/timeOfTest/constants.ts
+++ b/frontend/src/patientApp/timeOfTest/constants.ts
@@ -181,6 +181,31 @@ export const gonorrheaSymptomDefinitions: SymptomDefinitionMap[] =
     label: gonorrheaSymptomsMap[value],
   }));
 
+export const chlamydiaSymptomsMap = {
+  "77880009": "Pain in rectum",
+  "405729008": "Rectal bleeding",
+  "301822002": "Abnormal vaginal bleeding",
+  "249301002": "Bleeding from urethra",
+  "49650001": "Burning sensation when urinating",
+  "9957009": "Urethral discharge",
+  "162156001": "Vaginal discharge",
+  "63901009": "Testicular pain",
+  "438457000": "Swelling of testicles",
+} as const;
+
+export type ChlamydiaSymptoms = typeof chlamydiaSymptomsMap;
+export type ChlamydiaSymptomCode = keyof ChlamydiaSymptoms;
+export type ChlamydiaSymptomName = ChlamydiaSymptoms[ChlamydiaSymptomCode];
+
+export const chlamydiaSymptomOrder: ChlamydiaSymptomCode[] =
+  alphabetizeSymptomKeysFromMapValues(chlamydiaSymptomsMap);
+
+export const chlamydiaSymptomDefinitions: SymptomDefinitionMap[] =
+  chlamydiaSymptomOrder.map((value) => ({
+    value,
+    label: chlamydiaSymptomsMap[value],
+  }));
+
 export const SYMPTOM_SUBQUESTION_ERROR =
   "This question is required if the patient has symptoms.";
 export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";
@@ -188,14 +213,17 @@ export const ONSET_DATE_LABEL = "When did the patient's symptoms start?";
 export type AllSymptomsCode = keyof RespiratorySymptoms &
   keyof SyphilisSymptoms &
   keyof HepatitisCSymptoms &
-  keyof GonorrheaSymptoms;
+  keyof GonorrheaSymptoms &
+  keyof ChlamydiaSymptoms;
 export type AllSymptomsName = RespiratorySymptomName &
   SyphilisSymptomName &
   HepatitisCSymptomName &
-  GonorrheaSymptomName;
+  GonorrheaSymptomName &
+  ChlamydiaSymptomName;
 export const allSymptomsMap = {
   ...syphilisSymptomsMap,
   ...respiratorySymptomsMap,
   ...hepatitisCSymptomsMap,
   ...gonorrheaSymptomsMap,
+  ...chlamydiaSymptomsMap,
 };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7435 

## Changes Proposed

- Adds support for Chlamydia to the test card
- Refactors some of the unit testing common among the generic STI AOE questions

## Additional Information

- Might be nice to refactor some of files with `mockSupportedDiseaseTestPerformed[diseaseNameHere]` to mostly export from the same file instead of creating a new one for each new disease. Not terribly urgent though
- Definitely getting to the point with adding new STI support that we can start to identify other ways to make supported diseases more data-driven, particularly once we start implementing the designs for multi-condition test card

## Testing

- Deployed on dev5
- Chlamydia device has been added to `Big Organization`, `Test Facility`

## Screenshots / Demos

![image](https://github.com/user-attachments/assets/8e7495f2-54d1-4dae-8eb5-74a4d09782d9)
