### PR TITLE
Enable okta migration flag in dev2 and dev4

### DIFF
--- a/backend/src/main/resources/application-azure-dev2.yaml
+++ b/backend/src/main/resources/application-azure-dev2.yaml
@@ -15,3 +15,5 @@ simple-report:
       - https://dev2.simplereport.gov
 twilio:
   enabled: true
+features:
+  oktaMigrationEnabled: true

--- a/backend/src/main/resources/application-azure-dev4.yaml
+++ b/backend/src/main/resources/application-azure-dev4.yaml
@@ -15,3 +15,5 @@ simple-report:
       - https://dev4.simplereport.gov
 twilio:
   enabled: true
+features:
+  oktaMigrationEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #8180 

## Changes Proposed

- Turns on the `oktaMigrationEnabled` feature flag in dev2 and dev4

## Testing

- Will deploy this branch to dev2 and dev4
- https://dev2.simplereport.gov/api/feature-flags
- https://dev4.simplereport.gov/api/feature-flags