### PR TITLE
Chlamydia Results Page 

### DIFF
--- a/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+
+import "../../../i18n";
+
+import ChlamydiaResultGuidance from "./ChlamydiaResultGuidance";
+
+describe("ChlamydiaResultGuidance", () => {
+  it("displays guidance for a Gonorrhea result", () => {
+    const { container } = render(<ChlamydiaResultGuidance />);
+    expect(screen.getByText("For Chlamydia:")).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.test.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.test.tsx
@@ -5,7 +5,7 @@ import "../../../i18n";
 import ChlamydiaResultGuidance from "./ChlamydiaResultGuidance";
 
 describe("ChlamydiaResultGuidance", () => {
-  it("displays guidance for a Gonorrhea result", () => {
+  it("displays guidance for a Chlamydia result", () => {
     const { container } = render(<ChlamydiaResultGuidance />);
     expect(screen.getByText("For Chlamydia:")).toBeInTheDocument();
     expect(container).toMatchSnapshot();

--- a/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.tsx
+++ b/frontend/src/app/commonComponents/TestResultGuidance/ChlamydiaResultGuidance.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+
+const ChlamydiaResultGuidance = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p className="text-bold sr-guidance-heading">
+        {t("testResult.chlamydiaNotes.h1")}
+      </p>
+      <p>{t("testResult.chlamydiaNotes.positive.p0")}</p>
+      <Trans
+        parent="p"
+        i18nKey="testResult.chlamydiaNotes.positive.p1"
+        components={[
+          <a
+            href={t("testResult.chlamydiaNotes.positive.treatmentLink")}
+            target="_blank"
+            rel="noopener noreferrer"
+            key="chlamydia-treatment-link"
+          >
+            chlamydia treatment link
+          </a>,
+        ]}
+      />
+    </>
+  );
+};
+
+export default ChlamydiaResultGuidance;

--- a/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/ChlamydiaResultGuidance.test.tsx.snap
+++ b/frontend/src/app/commonComponents/TestResultGuidance/__snapshots__/ChlamydiaResultGuidance.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChlamydiaResultGuidance displays guidance for a Chlamydia result 1`] = `
+<div>
+  <p
+    class="text-bold sr-guidance-heading"
+  >
+    For Chlamydia:
+  </p>
+  <p>
+    If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.
+  </p>
+  <p>
+    <a
+      href="https://www.cdc.gov/chlamydia/about/index.html"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Visit the CDC website to learn more about a positive Chlamydia result.
+    </a>
+     (cdc.gov/chlamydia/about).
+  </p>
+</div>
+`;

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -52,6 +52,7 @@ export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
 export const device9Name = "Hepatitis C device";
 export const device10Name = "Gonorrhea device";
+export const chlamydiaDeviceName = "Chlamydia device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -63,6 +64,7 @@ export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
 export const device9Id = "DEVICE-9-ID";
 export const device10Id = "DEVICE-10-ID";
+export const chlamydiaDeviceId = "CHLAMYDIA-DEVICE-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";

--- a/frontend/src/app/testQueue/testCardTestConstants.ts
+++ b/frontend/src/app/testQueue/testCardTestConstants.ts
@@ -52,7 +52,6 @@ export const device7Name = "HIV device";
 export const device8Name = "Syphilis device";
 export const device9Name = "Hepatitis C device";
 export const device10Name = "Gonorrhea device";
-export const chlamydiaDeviceName = "Chlamydia device";
 
 export const device1Id = "DEVICE-1-ID";
 export const device2Id = "DEVICE-2-ID";
@@ -64,7 +63,6 @@ export const device7Id = "DEVICE-7-ID";
 export const device8Id = "DEVICE-8-ID";
 export const device9Id = "DEVICE-9-ID";
 export const device10Id = "DEVICE-10-ID";
-export const chlamydiaDeviceId = "CHLAMYDIA-DEVICE-ID";
 
 export const deletedDeviceId = "DELETED-DEVICE-ID";
 export const deletedDeviceName = "Deleted";

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultDetailsModal.tsx
@@ -65,8 +65,16 @@ export const DetachedTestResultDetailsModal = ({
     data?.testResult.results,
     MULTIPLEX_DISEASES.GONORRHEA
   );
+  const isChlamydiaResult = !!getResultForDisease(
+    data?.testResult.results,
+    MULTIPLEX_DISEASES.CHLAMYDIA
+  );
   const showGenderOfSexualPartners =
-    isHIVResult || isSyphilisResult || isHepatitisCResult || isGonorrheaResult;
+    isHIVResult ||
+    isSyphilisResult ||
+    isHepatitisCResult ||
+    isGonorrheaResult ||
+    isChlamydiaResult;
 
   const dateTested = data?.testResult.dateTested;
 

--- a/frontend/src/app/utils/testResults.tsx
+++ b/frontend/src/app/utils/testResults.tsx
@@ -7,6 +7,7 @@ import RsvResultGuidance from "../commonComponents/TestResultGuidance/RsvResultG
 import SyphilisResultGuidance from "../commonComponents/TestResultGuidance/SyphilisResultGuidance";
 import HepatitisCResultGuidance from "../commonComponents/TestResultGuidance/HepatitisCResultGuidance";
 import GonorrheaResultGuidance from "../commonComponents/TestResultGuidance/GonorrheaResultGuidance";
+import ChlamydiaResultGuidance from "../commonComponents/TestResultGuidance/ChlamydiaResultGuidance";
 
 export function getResultByDiseaseName(
   results: MultiplexResults,
@@ -110,6 +111,11 @@ export const getGuidanceForResults = (
   match = getResultForDisease(results, MULTIPLEX_DISEASES.GONORRHEA);
   if (match) {
     guidance.push(<GonorrheaResultGuidance />);
+  }
+
+  match = getResultForDisease(results, MULTIPLEX_DISEASES.CHLAMYDIA);
+  if (match) {
+    guidance.push(<ChlamydiaResultGuidance />);
   }
 
   return guidance;

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -42,6 +42,7 @@ export const en = {
         SYPHILIS: "Syphilis",
         HEPATITIS_C: "Hepatitis C",
         GONORRHEA: "Gonorrhea",
+        CHLAMYDIA: "Chlamydia",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 result",
@@ -53,6 +54,7 @@ export const en = {
         SYPHILIS: "Syphilis result",
         HEPATITIS_C: "Hepatitis C result",
         GONORRHEA: "Gonorrhea result",
+        CHLAMYDIA: "Chlamydia result",
       },
       role: {
         STAFF: "Staff",
@@ -439,6 +441,14 @@ export const en = {
           p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
           p1: "<0>Visit the CDC website to learn more about a positive Gonorrhea result.</0> (cdc.gov/gonorrhea/about).",
           treatmentLink: "https://www.cdc.gov/gonorrhea/about/index.html",
+        },
+      },
+      chlamydiaNotes: {
+        h1: "For Chlamydia:",
+        positive: {
+          p0: "If you have a positive result, you will need a follow-up test to confirm your results. The organization that provided your test should be able to answer questions and provide referrals for follow-up testing.",
+          p1: "<0>Visit the CDC website to learn more about a positive Chlamydia result.</0> (cdc.gov/chlamydia/about).",
+          treatmentLink: "https://www.cdc.gov/chlamydia/about/index.html",
         },
       },
       tos: {

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -471,7 +471,7 @@ export const es: LanguageConfig = {
         h1: "Para Clamidia:",
         positive: {
           p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
-          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de clamidia.</0> (cdc.gov/chlamydia/es/about/acerca-de-la-gonorrea.html).",
+          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de clamidia.</0> (cdc.gov/chlamydia/es/about/acerca-de-las-infecciones-por-clamidia.html).",
           treatmentLink:
             "https://www.cdc.gov/chlamydia/es/about/acerca-de-las-infecciones-por-clamidia.html",
         },

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -45,6 +45,7 @@ export const es: LanguageConfig = {
         SYPHILIS: "Sífilis",
         HEPATITIS_C: "Hepatitis C",
         GONORRHEA: "Gonorrea",
+        CHLAMYDIA: "Clamdia",
       },
       diseaseResultTitle: {
         COVID19: "COVID-19 resultado",
@@ -56,6 +57,7 @@ export const es: LanguageConfig = {
         SYPHILIS: "Sífilis resultado",
         HEPATITIS_C: "Hepatitis C resultado",
         GONORRHEA: "Gonorrea resultado",
+        CHLAMYDIA: "Clamdia resultado",
       },
       role: {
         STAFF: "Personal",
@@ -463,6 +465,15 @@ export const es: LanguageConfig = {
           p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de gonorrea.</0> (cdc.gov/gonorrhea/es/about/acerca-de-la-gonorrea.html).",
           treatmentLink:
             "https://www.cdc.gov/gonorrhea/es/about/acerca-de-la-gonorrea.html",
+        },
+      },
+      chlamydiaNotes: {
+        h1: "Para Clamidia:",
+        positive: {
+          p0: "Si obtiene un resultado positivo, deberá hacerse una prueba de seguimiento para confirmarlo. La organización que realizó su prueba debería poder contestar las preguntas que tenga y proporcionarle remisiones para una prueba de seguimiento.",
+          p1: "<0>Visite el sitio web de los CDC para obtener más información sobre un resultado positivo de clamidia.</0> (cdc.gov/chlamydia/es/about/acerca-de-la-gonorrea.html).",
+          treatmentLink:
+            "https://www.cdc.gov/chlamydia/es/about/acerca-de-las-infecciones-por-clamidia.html",
         },
       },
       tos: {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #7439 

## Changes Proposed

- Add English and Spanish copy for a Chlamydia result and logic to display said copy to the user pending a positive result
- 
## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- Live for testing in dev1 with send grid enabled
- Ensure that for a positive chlamydia result that the pxp flow works as excepted and can be viewed in the admin results view as well.

## Screenshots / Demos
<img width="590" alt="Screenshot 2025-01-16 at 1 53 54 PM" src="https://github.com/user-attachments/assets/a7f4d61b-f8d8-49c1-bb04-f75ecea796fc" />
<img width="579" alt="Screenshot 2025-01-16 at 1 54 12 PM" src="https://github.com/user-attachments/assets/b400b371-811b-4fe1-a11a-b5abdf47c9f0" />
<img width="758" alt="Screenshot 2025-01-16 at 1 55 18 PM" src="https://github.com/user-attachments/assets/2b7cb6c2-2198-40e2-843c-08498c8b079d" />
<img width="743" alt="Screenshot 2025-01-16 at 1 55 29 PM" src="https://github.com/user-attachments/assets/328a096b-75ab-4f92-a90c-8dda93c311bc" />

