### PR TITLE
Updating CSV Template Name

### DIFF
--- a/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
+++ b/frontend/src/app/testResults/uploads/CsvSchemaDocumentation.tsx
@@ -309,7 +309,7 @@ const CsvSchemaDocumentation: React.FC<CsvSchemaDocumentationProps> = ({
           <ul>
             <li>
               <a
-                href="/assets/resources/test_results_example_10-3-2022.csv"
+                href="/assets/resources/test_results_example_10-31-2023.csv"
                 className="usa-link"
                 onClick={() => {
                   appInsights?.trackEvent({
@@ -523,7 +523,7 @@ const CsvSchemaDocumentation: React.FC<CsvSchemaDocumentationProps> = ({
                 results, you need to adjust it to match the SimpleReport
                 template. If you don’t have one, use the{" "}
                 <a
-                  href="/assets/resources/test_results_example_10-3-2022.csv"
+                  href="/assets/resources/test_results_example_10-31-2023.csv"
                   className="usa-link"
                   onClick={() => {
                     appInsights?.trackEvent({

--- a/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
+++ b/frontend/src/app/testResults/uploads/DiseaseSpecificUploadContainer.tsx
@@ -58,7 +58,7 @@ const DiseaseSpecificUploadContainer = () => {
       uploadResults={FileUploadService.uploadResults}
       uploadType={"Disease Specific"}
       spreadsheetTemplateLocation={
-        "/assets/resources/test_results_example_10-3-2022.csv"
+        "/assets/resources/test_results_example_10-31-2023.csv"
       }
       uploadGuideLocation={"/results/upload/submit/guide"}
     />

--- a/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/CsvSchemaDocumentation.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 1`
           <li>
             <a
               class="usa-link"
-              href="/assets/resources/test_results_example_10-3-2022.csv"
+              href="/assets/resources/test_results_example_10-31-2023.csv"
             >
               SimpleReport spreadsheet template with example data [CSV download]
             </a>
@@ -6762,7 +6762,7 @@ exports[`CsvSchemaDocumentation tests CsvSchemaDocumentation matches snapshot 1`
                
               <a
                 class="usa-link"
-                href="/assets/resources/test_results_example_10-3-2022.csv"
+                href="/assets/resources/test_results_example_10-31-2023.csv"
               >
                 spreadsheet template
               </a>

--- a/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
+++ b/frontend/src/app/testResults/uploads/__snapshots__/DiseaseSpecificUploadContainer.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`Disease specific upload container test passes axe tests 1`] = `
                   Download the
                    
                   <a
-                    href="/assets/resources/test_results_example_10-3-2022.csv"
+                    href="/assets/resources/test_results_example_10-31-2023.csv"
                   >
                     spreadsheet template
                   </a>


### PR DESCRIPTION


## Please DO NOT merge until we figure out what's going on with the static site [here](https://skylight-hq.slack.com/archives/C064P7MHM47/p1736955112198089)

## Related Issue

- https://github.com/CDCgov/prime-simplereport/issues/8364

## Changes Proposed

- This updates the CSV template file name in this repo to match [the new CSV template file name in the static site repo](https://github.com/CDCgov/prime-simplereport-site/tree/main/assets/resources)

## Testing

- This builds and runs locally, but it will need to be tested in the demo environment once it's deployed