### PR TITLE
Fix sendOrgAdminEmailCSV test

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationServiceTest.java
@@ -19,7 +19,6 @@ import gov.cdc.usds.simplereport.api.model.Role;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.api.model.errors.OrderingProviderRequiredException;
 import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
-import gov.cdc.usds.simplereport.config.simplereport.DemoUserConfiguration;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
 import gov.cdc.usds.simplereport.db.model.Facility;
 import gov.cdc.usds.simplereport.db.model.Organization;
@@ -34,7 +33,6 @@ import gov.cdc.usds.simplereport.db.repository.FacilityRepository;
 import gov.cdc.usds.simplereport.db.repository.OrganizationRepository;
 import gov.cdc.usds.simplereport.db.repository.PatientRegistrationLinkRepository;
 import gov.cdc.usds.simplereport.db.repository.PersonRepository;
-import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.idp.repository.OktaRepository;
 import gov.cdc.usds.simplereport.service.email.EmailService;
 import gov.cdc.usds.simplereport.test_util.SliceTestConfiguration.WithSimpleReportOrgAdminUser;
@@ -61,17 +59,15 @@ import org.springframework.security.access.AccessDeniedException;
 class OrganizationServiceTest extends BaseServiceTest<OrganizationService> {
 
   @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
-  @Autowired @SpyBean private FacilityRepository facilityRepository;
-  @Autowired @SpyBean private OrganizationRepository organizationRepository;
+  @SpyBean private FacilityRepository facilityRepository;
+  @SpyBean private OrganizationRepository organizationRepository;
   @Autowired private DeviceTypeRepository deviceTypeRepository;
-  @Autowired @SpyBean private OktaRepository oktaRepository;
-  @Autowired @SpyBean private PersonRepository personRepository;
-  @Autowired @SpyBean private ProviderRepository providerRepository;
+  @SpyBean private OktaRepository oktaRepository;
+  @SpyBean private PersonRepository personRepository;
   @Autowired ApiUserRepository _apiUserRepo;
-  @Autowired private DemoUserConfiguration userConfiguration;
-  @Autowired @SpyBean private EmailService emailService;
-  @Autowired @SpyBean private DbAuthorizationService dbAuthorizationService;
-  @Autowired @MockBean private FeatureFlagsConfig featureFlagsConfig;
+  @MockBean private EmailService emailService;
+  @SpyBean private DbAuthorizationService dbAuthorizationService;
+  @MockBean private FeatureFlagsConfig featureFlagsConfig;
 
   @BeforeEach
   void setupData() {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- 🙏 Follow up to a series of PRs to address the same backend flaky test:
  - #8398
  - #8390
  - #8251

## Changes Proposed
- Removes `@Autowired` annotation when using `@SpyBean` or `@MockBean` annotations
   - if you see the example in the docs for [MockBean](https://docs.spring.io/spring-boot//api/java/org/springframework/boot/test/mock/mockito/MockBean.html) and [SpyBean](https://docs.spring.io/spring-boot//api/java/org/springframework/boot/test/mock/mockito/SpyBean.html), it does not use both

## Additional Information
- ⚠️ I've noticed a couple of other places in our backend tests that we are using both `@Autowired` and `@SpyBean`/ `@MockBean` annotations. Let me know if this is something you'd like me to clean up and I can create a separate PR.

- Thank you @mpbrown and @mehansen for pairing on this with me 🙌 

## Testing
- backend tests should pass in CI ([passed 5 times!!](https://github.com/CDCgov/prime-simplereport/actions/runs/12898036688?pr=8427))

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
