### PR TITLE
Add PublicDeviceType view to additional fields

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/DeviceTypeDisease.java
@@ -25,6 +25,7 @@ public class DeviceTypeDisease extends IdentifiedEntity {
 
   @ManyToOne
   @JoinColumn(name = "supported_disease_id")
+  @JsonView(PublicDeviceType.class)
   private SupportedDisease supportedDisease;
 
   @Column

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/SupportedDisease.java
@@ -1,6 +1,8 @@
 package gov.cdc.usds.simplereport.db.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import gov.cdc.usds.simplereport.api.devicetype.PublicDeviceType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -18,9 +20,11 @@ import org.springframework.boot.context.properties.bind.ConstructorBinding;
 public class SupportedDisease extends IdentifiedEntity {
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String name;
 
   @Column(nullable = false)
+  @JsonView(PublicDeviceType.class)
   private String loinc;
 
   @JsonIgnore

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceTypeControllerTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/DeviceTypeControllerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.usds.simplereport.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -56,10 +57,35 @@ class DeviceTypeControllerTest extends BaseFullStackTest {
     assertThat(deviceType.getString("model")).isEqualTo("SFN");
     assertThat(deviceType.getString("name")).isEqualTo("Acme SuperFine");
     assertThat(deviceType.getInt("testLength")).isEqualTo(15);
-    assertThat(deviceType.getJSONArray("supportedDiseaseTestPerformed")).isEmpty();
     // ensure deviceType internalId is not returned
     assertTrue(deviceType.isNull("internalId"));
 
+    // has supportedDiseaseTestPerformed
+    JSONArray supportedDiseaseTestPerformedList =
+        deviceType.getJSONArray("supportedDiseaseTestPerformed");
+    assertThat(supportedDiseaseTestPerformedList.length()).isEqualTo(1);
+    JSONObject supportedDiseaseTestPerformed = supportedDiseaseTestPerformedList.getJSONObject(0);
+    assertFalse(supportedDiseaseTestPerformed.has("deviceTypeId"));
+    assertThat(supportedDiseaseTestPerformed.getString("testPerformedLoincCode"))
+        .isEqualTo("94500-6");
+    assertThat(supportedDiseaseTestPerformed.getString("testPerformedLoincLongName"))
+        .isEqualTo(
+            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection");
+    assertThat(supportedDiseaseTestPerformed.getString("equipmentUidType")).isEqualTo("MNI");
+    assertThat(supportedDiseaseTestPerformed.getString("testkitNameId"))
+        .isEqualTo("1copy COVID-19 qPCR Multi Kit_1drop Inc.");
+    assertThat(supportedDiseaseTestPerformed.getString("testOrderedLoincCode"))
+        .isEqualTo("94531-1");
+    assertThat(supportedDiseaseTestPerformed.getString("testOrderedLoincLongName"))
+        .isEqualTo(
+            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
+    // has supportedDisease
+    JSONObject supportedDisease = supportedDiseaseTestPerformed.getJSONObject("supportedDisease");
+    assertThat(supportedDisease.getString("name")).isEqualTo("COVID-19");
+    assertThat(supportedDisease.getString("loinc")).isEqualTo("96741-4");
+    assertFalse(supportedDisease.has("supportedDiseaseTestPerformed"));
+
+    // has swabTypes
     JSONArray swabTypes = deviceType.getJSONArray("swabTypes");
     assertThat(swabTypes.length()).isEqualTo(1);
     JSONObject swabType = swabTypes.getJSONObject(0);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -49,6 +49,7 @@ import gov.cdc.usds.simplereport.db.repository.PersonRepository;
 import gov.cdc.usds.simplereport.db.repository.PhoneNumberRepository;
 import gov.cdc.usds.simplereport.db.repository.ProviderRepository;
 import gov.cdc.usds.simplereport.db.repository.SpecimenTypeRepository;
+import gov.cdc.usds.simplereport.db.repository.SupportedDiseaseRepository;
 import gov.cdc.usds.simplereport.db.repository.TestEventRepository;
 import gov.cdc.usds.simplereport.db.repository.TestOrderRepository;
 import gov.cdc.usds.simplereport.db.repository.TestResultUploadRepository;
@@ -101,6 +102,7 @@ public class TestDataFactory {
   @Autowired private PatientLinkRepository patientLinkRepository;
   @Autowired private PatientRegistrationLinkRepository patientRegistrationLinkRepository;
   @Autowired private SpecimenTypeRepository specimenTypeRepository;
+  @Autowired private SupportedDiseaseRepository supportedDiseaseRepository;
   @Autowired private DemoOktaRepository oktaRepository;
   @Autowired private TestResultUploadRepository testResultUploadRepository;
   @Autowired private DeviceSpecimenTypeNewRepository deviceSpecimenTypeNewRepository;
@@ -131,6 +133,21 @@ public class TestDataFactory {
     deviceSpecimenTypeNewRepository.save(
         new DeviceTypeSpecimenTypeMapping(
             genericDeviceType.getInternalId(), genericSpecimenType.getInternalId()));
+
+    SupportedDisease covid = supportedDiseaseRepository.findByName("COVID-19").get();
+
+    DeviceTypeDisease genericDeviceTypeDisease =
+        new DeviceTypeDisease(
+            genericDeviceType.getInternalId(),
+            covid,
+            "94500-6",
+            "SARS coronavirus 2 RNA [Presence] in Respiratory specimen by NAA with probe detection",
+            "Rotor-Gene Q 5plex HRM_QIAGEN GmbH",
+            "MNI",
+            "1copy COVID-19 qPCR Multi Kit_1drop Inc.",
+            "94531-1",
+            "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection");
+    deviceTypeDiseaseRepository.save(genericDeviceTypeDisease);
   }
 
   public Organization saveOrganization(Organization org) {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Follow up to part II of #7492 

## Changes Proposed

- Add the `@JsonView` for additional fields (`SupportedDisease`) since I missed them in the last PR #8341 to ensure the device sync works

## Additional Information
- No internalIds should be returned

The following was being returned:
**BEFORE**
```
[
   {
        "name": "Abbott Alinity M",
        "manufacturer": "Abbott",
        "model": "Alinity m",
        "swabTypes": [
            {
                "name": "Swab of internal nose",
                "typeCode": "445297001",
                "collectionLocationName": "Internal nose structure",
                "collectionLocationCode": null
            }
        ],
        "testLength": 15,
        "supportedDiseaseTestPerformed": [
            {
                "testPerformedLoincCode": "85477-8",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": null,
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            },
            {
                "testPerformedLoincCode": "94500-6",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": null,
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            },
            {
                "testPerformedLoincCode": "85478-6",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": "3der",
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            }
        ]
    }
]
```

**AFTER**

```
[
   {
        "name": "Abbott Alinity M",
        "manufacturer": "Abbott",
        "model": "Alinity m",
        "swabTypes": [
            {
                "name": "Swab of internal nose",
                "typeCode": "445297001",
                "collectionLocationName": "Internal nose structure",
                "collectionLocationCode": null
            }
        ],
        "testLength": 15,
        "supportedDiseaseTestPerformed": [
            {
                "supportedDisease": {
                    "name": "Flu A",
                    "loinc": "LP14239-5"
                },
                "testPerformedLoincCode": "85477-8",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": null,
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            },
            {
                "supportedDisease": {
                    "name": "COVID-19",
                    "loinc": "96741-4"
                },
                "testPerformedLoincCode": "94500-6",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": null,
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            },
            {
                "supportedDisease": {
                    "name": "Flu B",
                    "loinc": "LP14240-3"
                },
                "testPerformedLoincCode": "85478-6",
                "testPerformedLoincLongName": null,
                "equipmentUid": "00884999048034",
                "equipmentUidType": "3der",
                "testkitNameId": "Alinity m Resp-4-Plex_Abbott Molecular Inc.",
                "testOrderedLoincCode": "95941-1",
                "testOrderedLoincLongName": null
            }
        ]
    },
]
```

## Testing
- deployed on dev2
- use an API testing tool of your choice to fetch the device list from dev2
e.g.
`curl --header "Sr-Prod-Devices-Token: REPLACE_TOKEN_HERE" https://dev2.simplereport.gov/api/devices`
you should see the entire list without any InternalIds and the `supportedDisease` field added


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->