### PR TITLE
Rename DeviceSyncService

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/devicetype/DeviceTypeController.java
@@ -3,9 +3,9 @@ package gov.cdc.usds.simplereport.api.devicetype;
 import com.fasterxml.jackson.annotation.JsonView;
 import gov.cdc.usds.simplereport.api.model.errors.DryRunException;
 import gov.cdc.usds.simplereport.db.model.DeviceType;
+import gov.cdc.usds.simplereport.service.DeviceTypeLIVDSyncService;
 import gov.cdc.usds.simplereport.service.DeviceTypeProdSyncService;
 import gov.cdc.usds.simplereport.service.DeviceTypeService;
-import gov.cdc.usds.simplereport.service.DeviceTypeSyncService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 public class DeviceTypeController {
-  @Autowired private DeviceTypeSyncService deviceTypeSyncService;
+  @Autowired private DeviceTypeLIVDSyncService deviceTypeLIVDSyncService;
   @Autowired private DeviceTypeProdSyncService deviceTypeProdSyncService;
   @Autowired private DeviceTypeService deviceTypeService;
 
   @GetMapping("/devices/sync")
   public void syncDevices(@RequestParam boolean dryRun) {
     try {
-      deviceTypeSyncService.syncDevices(dryRun);
+      deviceTypeLIVDSyncService.syncDevices(dryRun);
     } catch (DryRunException e) {
       log.info("Dry run");
     }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncService.java
@@ -40,7 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional(readOnly = true)
-public class DeviceTypeSyncService {
+public class DeviceTypeLIVDSyncService {
   private static final Set<String> FluA_DEVICE_SYNC_BLOCK_LIST =
       Set.of(
           "BioCode CoV-2 Flu Plus Assay|Applied BioCode, Inc.",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncServiceIntegrationTest.java
@@ -38,7 +38,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = {"spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true"})
-class DeviceTypeServiceIntegrationTest extends BaseServiceTest<DeviceTypeSyncService> {
+class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTypeLIVDSyncService> {
   @Autowired private DeviceTypeService deviceTypeService;
   @Autowired private DeviceTypeRepository deviceTypeRepo;
   @Autowired private SpecimenTypeRepository specimenTypeRepository;

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncServiceIntegrationTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/DeviceTypeLIVDSyncServiceIntegrationTest.java
@@ -52,11 +52,11 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
   private SpecimenType swab3;
   private DeviceType devA;
   private DeviceType devB;
-  private final String SPECIMEN_DESCRIPTION_ONE =
+  private final String specimenDescriptionOne =
       "anterior nasal swabs (697989009^Anterior nares swab^SCT)\r";
-  private final String SPECIMEN_DESCRIPTION_TWO =
+  private final String specimenDescriptionTwo =
       "nasopharyngeal swabs (258500001^Nasopharyngeal swab^SCT)\r";
-  private final String SPECIMEN_DESCRIPTION_THREE = "to be added (999999999^To Be Added^SCT)\r";
+  private final String specimenDescriptionThree = "to be added (999999999^To Be Added^SCT)\r";
 
   @BeforeEach
   void setup() {
@@ -120,7 +120,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("Manufacturer A")
             .model("Model A")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("influenza A RNA Result")
             .testPerformedLoincCode("7777777")
             .testPerformedLoincLongName("7777777 plus some extra stuff")
@@ -161,7 +161,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("New Device Manufacturer")
             .model("New Device Model")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName(vendorAnalyteName)
             .testPerformedLoincCode("8888888")
             .testPerformedLoincLongName("8888888 plus some extra stuff")
@@ -205,7 +205,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer(devA.getManufacturer())
             .model(devA.getModel())
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_TWO))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne, specimenDescriptionTwo))
             .vendorAnalyteName("influenza A RNA Result")
             .testPerformedLoincCode("0123456")
             .testPerformedLoincLongName("0123456 plus some extra stuff")
@@ -220,8 +220,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer(devB.getManufacturer())
             .model(devB.getModel())
-            .vendorSpecimenDescription(
-                List.of(SPECIMEN_DESCRIPTION_ONE, SPECIMEN_DESCRIPTION_THREE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne, specimenDescriptionThree))
             .vendorAnalyteName("influenza A RNA Result")
             .testPerformedLoincCode("0123456")
             .testPerformedLoincLongName("0123456 plus some extra stuff")
@@ -274,7 +273,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("Manufacturer A")
             .model("Model A")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("influenza A RNA Result")
             .testPerformedLoincCode("7777777")
             .testPerformedLoincLongName("7777777 plus some extra stuff")
@@ -312,7 +311,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer(existingDevice.getManufacturer())
             .model(existingDevice.getModel())
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("covid")
             .testPerformedLoincCode("000000000")
             .testPerformedLoincLongName("000000000 plus some extra stuff")
@@ -340,7 +339,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("Some manufacturer")
             .model("Some model")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("invalid disease!")
             .testPerformedLoincCode("000000000")
             .testPerformedLoincLongName("000000000 plus some extra stuff")
@@ -368,7 +367,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("Shiny New Manufacturer")
             .model("Device A")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("fluA")
             .testPerformedLoincCode("000000000")
             .testPerformedLoincLongName("000000000 plus some extra stuff")
@@ -395,7 +394,7 @@ class DeviceTypeLIVDSyncServiceIntegrationTest extends BaseServiceTest<DeviceTyp
         LIVDResponse.builder()
             .manufacturer("Applied BioCode, Inc.")
             .model("BioCode CoV-2 Flu Plus Assay")
-            .vendorSpecimenDescription(List.of(SPECIMEN_DESCRIPTION_ONE))
+            .vendorSpecimenDescription(List.of(specimenDescriptionOne))
             .vendorAnalyteName("fluA")
             .testPerformedLoincCode("000000000")
             .testPerformedLoincLongName("000000000 plus some extra stuff")


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Follow up to [this comment ](https://github.com/CDCgov/prime-simplereport/pull/8341#discussion_r1887543302) as part of addressing #7492 

## Changes Proposed

- rename `DeviceSyncService` to `DeviceSyncLIVDService` and any related test files to differentiate that class when the `DeviceSyncProdService` is introduced in a future PR

## Additional Information
- N/A

## Testing
- tests should pass
- LIVD sync should continue to work

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
