### PR TITLE
Migrating Okta users to the DB with no facilities

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -875,7 +875,9 @@ public class ApiUserService {
               .map(IdentifiedEntity::getInternalId)
               .collect(Collectors.toList());
       Set<Facility> facilitiesToGiveAccessTo =
-          getFacilitiesToGiveAccess(org, roles, new HashSet<>(facilitiesInternalIds));
+          facilitiesInternalIds.isEmpty()
+              ? new HashSet<>()
+              : getFacilitiesToGiveAccess(org, roles, new HashSet<>(facilitiesInternalIds));
       apiUser.setFacilities(facilitiesToGiveAccessTo);
       apiUser.setRoles(roles, org);
     } catch (MisconfiguredUserException | PrivilegeUpdateFacilityAccessException e) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ApiUserService.java
@@ -880,7 +880,7 @@ public class ApiUserService {
               : getFacilitiesToGiveAccess(org, roles, new HashSet<>(facilitiesInternalIds));
       apiUser.setFacilities(facilitiesToGiveAccessTo);
       apiUser.setRoles(roles, org);
-    } catch (MisconfiguredUserException | PrivilegeUpdateFacilityAccessException e) {
+    } catch (MisconfiguredUserException e) {
       log.warn(
           "Could not migrate roles and facilities for user with id={}", apiUser.getInternalId());
     }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- https://github.com/CDCgov/prime-simplereport/issues/8258

## Changes Proposed

- This modifies the `setRolesAndFacilities` method to allow for a user to have no facilities assigned to them. When the `facilitiesInternalIds` list is empty, the method bypasses calling the `getFacilitiesToGiveAccess` method, which would throw this, `PrivilegeUpdateFacilityAccessException`, with an empty `facilitiesInternalIds` list.
- By changing the above, it fixes an error in the UI where a passive migration would fail and show a generic error message to the user.

## Testing
Feel free to reach out to me if any of the below process is unclear or if you think it's missing anything.

- Deployed in dev4
- Here are the testing steps:
  - Turn oktaMigrationEnabled flag off
  - Create a new user in the UI. At this point, the user's roles/facilities will be saved within both Okta and the DB, but functionally, the application will only look to Okta for the user's roles and facilities since oktaMigrationEnabled is off.
  - Delete the user's roles and facilities from the DB tables via Postman
  - Delete the user's facility group(s) in Okta so that they're not part of any facility
  - Trigger a passive migration by searching for the user on the "Manage Users" page
  - At that point, the user should be successfully migrated from Okta to the DB despite having no facilities assigned to them
  - Turn oktaMigrationEnabled flag on so that the app reads from the newly migrated user who has no facilities in the DB
  - Test that the UI still works in these user flows:
    - support admin -> search for user
    - org admin page (from org admin's view) -> click the gear button -> manage users
    - logging in as the user