### PR TITLE
Update Field Highlighting in Error Handling for Bulk Upload

### DIFF
--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -61,7 +61,10 @@ export function groupErrors(
 export function getErrorMessage(error: EnhancedFeedbackMessage) {
   if (error.message) {
     const header = error.fieldHeader;
-    const headerRegex = new RegExp(`(${header})`, "g");
+    const headerRegex = new RegExp(
+      `(${header} | [a-z0-9]+(?:_[a-z0-9]+){1,7})`,
+      "g"
+    );
     return (
       <span data-testid="error-message">
         {error.message.split(headerRegex).map((value) => (

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -62,7 +62,7 @@ export function getErrorMessage(error: EnhancedFeedbackMessage) {
   if (error.message) {
     const header = error.fieldHeader;
     const headerRegex = new RegExp(
-      `(${header} | [a-z0-9]+(?:_[a-z0-9]+){1,7})`,
+      `(${header}|[a-z0-9]+(?:_[a-z0-9]+){1,7})`,
       "g"
     );
     return (

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -60,9 +60,8 @@ export function groupErrors(
 
 export function getErrorMessage(error: EnhancedFeedbackMessage) {
   if (error.message) {
-    const headerRegex =
-      /([a-z0-9]+(?:_[a-z0-9]+){1,7}|icu|comment|hospitalized|pregnant)/g;
-    //could hard code list of one word cols?
+    const header = error.fieldHeader;
+    const headerRegex = new RegExp(`(${header})`, "g");
     return (
       <span data-testid="error-message">
         {error.message.split(headerRegex).map((value) => (

--- a/frontend/src/app/testResults/uploads/UploadForm.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.tsx
@@ -60,7 +60,9 @@ export function groupErrors(
 
 export function getErrorMessage(error: EnhancedFeedbackMessage) {
   if (error.message) {
-    const headerRegex = /([a-z0-9]+(?:_[a-z0-9]+){1,7})/g;
+    const headerRegex =
+      /([a-z0-9]+(?:_[a-z0-9]+){1,7}|icu|comment|hospitalized|pregnant)/g;
+    //could hard code list of one word cols?
     return (
       <span data-testid="error-message">
         {error.message.split(headerRegex).map((value) => (


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- Resolves #8278 

## Changes Proposed

- Update regex to target the header of the column in question, instead of the original logic that only target strings with an underscore.

## Testing

- Live for testing on `dev1` with [test_results_example_10-3-2022.csv](https://github.com/user-attachments/files/18759018/test_results_example_10-3-2022.csv) under the apple organization. 

## Screenshots / Demos
- Current Behavior:

![385361281-24eaacd5-7bc5-4138-b3b6-6d1207b5a2e9](https://github.com/user-attachments/assets/2096a0e2-a5af-410a-9957-b859acdcd036)

- Updated Behavior: 

<img width="645" alt="Screenshot 2025-02-11 at 2 26 37 PM" src="https://github.com/user-attachments/assets/c778e907-6686-4d6b-9e65-35b3d42f4fc6" />

 
