### PR TITLE
edited regex to handle whitespace,added tests

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -25,7 +25,7 @@ public class DateTimeUtils {
       DateTimeFormatter.ofPattern("M/d/yyyy[ H:mm]");
 
   public static final String TIMEZONE_SUFFIX_REGEX =
-      "^(0?[1-9]|1[0-2])/(0?[1-9]|1\\d|2\\d|3[01])/\\d{4}( ([0-1]?\\d|2[0-3]):[0-5]\\d)( \\S+)$";
+      "^(0?[1-9]|1[0-2])\\s*/\\s*(0?[1-9]|1\\d|2\\d|3[01])\\s*/\\s*\\d{4}\\s+([0-1]?\\d|2[0-3])\\s*:\\s*[0-5]\\d\\s+(\\S+)\\s*$";
 
   public static final ZoneId FALLBACK_TIMEZONE_ID = ZoneId.of("US/Eastern");
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -98,7 +98,7 @@ public class CsvValidatorUtils {
    * @see gov.cdc.usds.simplereport.utils.DateTimeUtils
    */
   private static final String DATE_TIME_REGEX =
-      "^(0{0,1}[1-9]|1[0-2])\\/(0{0,1}[1-9]|1\\d|2\\d|3[01])\\/\\d{4}( ([0-1]?[0-9]|2[0-3]):[0-5][0-9]( \\S+)?)?$";
+      "^(0{0,1}[1-9]|1[0-2])\\s*/\\s*(0{0,1}[1-9]|1\\d|2\\d|3[01])\\s*/\\s*\\d{4}(\\s+([0-1]?[0-9]|2[0-3])\\s*:\\s*[0-5][0-9](\\s+\\S+)?)?\\s*$";
 
   private static final String LOINC_CODE_REGEX = "([0-9]{5})-[0-9]";
   private static final String EMAIL_REGEX = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$";
@@ -448,11 +448,16 @@ public class CsvValidatorUtils {
   }
 
   public static List<FeedbackMessage> validateDateTime(ValueOrError input) {
-    List<FeedbackMessage> errors = new ArrayList<>(validateRegex(input, DATE_TIME_REGEX));
+    ValueOrError trimmedInput =
+        new ValueOrError(
+            input.getValue() != null ? input.getValue().trim() : null,
+            input.getHeader(),
+            input.isRequired());
+    List<FeedbackMessage> errors = new ArrayList<>(validateRegex(trimmedInput, DATE_TIME_REGEX));
     if (input.getValue() != null
         && errors.isEmpty()
-        && input.getValue().matches(TIMEZONE_SUFFIX_REGEX)) {
-      errors.addAll(validateDateTimeZoneCode(input));
+        && trimmedInput.getValue().matches(TIMEZONE_SUFFIX_REGEX)) {
+      errors.addAll(validateDateTimeZoneCode(trimmedInput));
     }
     return errors;
   }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -191,6 +191,40 @@ class CsvValidatorUtilsTest {
   }
 
   @Test
+  void validDateTimeWithWhitespace() {
+    var validDateTimes = new ArrayList<ValueOrError>();
+    validDateTimes.add(new ValueOrError("01/01/2023 11:11", "datetime"));
+    validDateTimes.add(new ValueOrError(" 01/01/2023 11:11 ", "datetime"));
+    validDateTimes.add(new ValueOrError("01 / 01 / 2023 11 : 11", "datetime"));
+    validDateTimes.add(new ValueOrError("01/01/2023   11:11", "datetime"));
+    validDateTimes.add(new ValueOrError("01/01/2023 11:11 EST", "datetime"));
+    validDateTimes.add(new ValueOrError("01/01/2023 11:11  EST", "datetime"));
+    validDateTimes.add(new ValueOrError("01 / 01 / 2023 11 : 11 EST", "datetime"));
+    validDateTimes.add(new ValueOrError("01/01/2023   11:11   EST", "datetime"));
+    validDateTimes.add(new ValueOrError(" 01/01/2023 11:11 EST ", "datetime"));
+
+    for (var datetime : validDateTimes) {
+      assertThat(validateDateTime(datetime)).isEmpty();
+    }
+  }
+
+  @Test
+  void invalidDateTimeWithWhitespace() {
+    var invalidDateTimes = new ArrayList<ValueOrError>();
+    invalidDateTimes.add(
+        new ValueOrError("01/01/202311:11", "datetime")); // No space between date and time
+    invalidDateTimes.add(
+        new ValueOrError("01 01 2023 11:11", "datetime")); // Spaces instead of slashes
+    invalidDateTimes.add(
+        new ValueOrError("01/01/2023 11 11", "datetime")); // Space instead of colon
+    invalidDateTimes.add(
+        new ValueOrError("01/01/2023 11:11EST", "datetime")); // No space before timezone
+    for (var datetime : invalidDateTimes) {
+      assertThat(validateDateTime(datetime)).hasSize(1);
+    }
+  }
+
+  @Test
   void invalidDateFormat() {
     var invalidDates = new ArrayList<ValueOrError>();
     invalidDates.add(new ValueOrError("00/01/2023", "date"));


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue
https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8253

## Changes Proposed

extra whitespace (e.g. "10/18/2024 10:00" - passes but with extra whitespaces it fails)

## Additional Information
This ticket does not handle AM/PM. After researching more into this I believe this change would be more then 1-2 points. 

## Testing

- How should reviewers verify this PR?
https://github.com/CDCgov/prime-simplereport/pull/8225#issuecomment-2445401198 please see the steps here to reproduce as well as the csv. 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [x] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->