### PR TITLE
Adding dependabot PR number to dependabot issue title for title uniqueness and automated closeability

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -18,7 +18,8 @@ jobs:
         if: github.event.pull_request.user.login  == 'dependabot[bot]'
         env:
           pr_title: ${{github.event.pull_request.title}}
+          pr_number: ${{github.event.pull_request.number}}
         run: |
-          issue_title="Dependabot PR $pr_title opened"
+          issue_title="Dependabot PR #$pr_number $pr_title opened"
           issue=$(gh issue list --json number --jq '.[].number' --label "dependencies" --label "Dependabot" --search "is:issue is:open $issue_title")
           gh issue close "$issue"

--- a/.github/workflows/dependabotCreatePRIssue.yml
+++ b/.github/workflows/dependabotCreatePRIssue.yml
@@ -21,7 +21,7 @@ jobs:
           number: ${{github.event.pull_request.number}}
           url: ${{github.event.pull_request.url}}
         run: |
-          title="Dependabot PR $title opened"
+          title="Dependabot PR #$number $title opened"
           labels="dependencies,Dependabot"
           body="Dependabot has opened PR #$number
           Link: $url"


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- #8454

## Changes Proposed

- This adds the dependabot PR number to the dependabot issue title so that a unique result comes back when querying for the issue associated with the PR. With only one dependabot issue result coming back, the issue tied to the PR should now be closeable within the dependabotClosePRIssue.yml. 

## Testing

- I tested this by first manually updating the title of #8443 via adding the associated PR number 8442 so that the issue title would reflect what it would look like if the new dependabotCreatePRIssue.yml had created it. Then I ran the gh commands for closing the issue from my local computer.
- If you would like to test, you can find a dependabot issue that should have been closed and follow the same process.