### PR TITLE
Disable HIV feature flag

### DIFF
--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -28,7 +28,7 @@ features:
   gonorrheaEnabled: false
   hepatitisCEnabled: false
   syphilisEnabled: false
-  hivBulkUploadEnabled: true
-  hivEnabled: true
+  hivBulkUploadEnabled: false
+  hivEnabled: false
   agnosticEnabled: false
   agnosticBulkUploadEnabled: false


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

On 2/12/2025 the team discussed the `hivEnabled` and `hivBulkUploadEnabled` feature flags and decided it would be best to turn those off for now as we continue to refine data collection and retention policies for the rest of the STI diseases.

## Changes Proposed

- Disables HIV feature flag

## Additional Information

- As of 2/12/2025, there have been no results submitted for HIV devices in single entry or bulk upload.

## Testing

- After merging, verify feature flag status

https://www.simplereport.gov/api/feature-flags