### PR TITLE
Adding a branch filter to dependabot step trigger

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -2,6 +2,7 @@ name: Dependabot Close Issue
 on:
   pull_request:
     types: [closed]
+    branches: ['dependabot/**']
 
 jobs:
   issue:

--- a/.github/workflows/dependabotCreatePRIssue.yml
+++ b/.github/workflows/dependabotCreatePRIssue.yml
@@ -2,6 +2,7 @@ name: Dependabot Create Issue
 on:
   pull_request:
     types: [opened, reopened]
+    branches: ['dependabot/**']
 
 jobs:
   issue:


### PR DESCRIPTION
This adds a check higher up in the dependabot close/open issue yml files so that those steps only get run on dependabot branches. There's already a filter in those yml files for checking if the pull request user is `dependabot[bot]`, but this check effectively moves the check one level higher and should stop the action from spinning up altogether.