### PR TITLE
 6362 if "enter" is pressed then the page reloads.

### DIFF
--- a/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
+++ b/frontend/src/app/testQueue/addToQueue/AddToQueueSearch.tsx
@@ -180,6 +180,7 @@ const AddToQueueSearchBox = ({
         disabled={!allowQuery}
         placeholder={`Search for a ${PATIENT_TERM} to start their test`}
         showSubmitButton={false}
+        disableEnterSubmit={true}
       />
       <SearchResults
         page="queue"

--- a/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchInput.tsx
@@ -20,6 +20,7 @@ type Props = {
   showSubmitButton?: boolean;
   labeledBy?: string;
   dataCy?: string;
+  disableEnterSubmit?: boolean;
 };
 
 const SearchInput = ({
@@ -34,6 +35,7 @@ const SearchInput = ({
   showSubmitButton = true,
   labeledBy,
   dataCy,
+  disableEnterSubmit = false,
 }: Props) => {
   const classes = classnames(
     "usa-search",
@@ -49,9 +51,14 @@ const SearchInput = ({
     }
   }, [focusOnMount]);
 
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (disableEnterSubmit) {
+      e.preventDefault();
+    }
+  };
   return (
     <div className={classnames("prime-search-container", className)}>
-      <form className={classes} role="search">
+      <form className={classes} role="search" onSubmit={handleSubmit}>
         <label
           className={label ? "display-block" : "usa-sr-only"}
           htmlFor="search-field-small"


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/6362
## Changes Proposed


While searching for a user on the conduct test page, if "enter" is pressed then the page reloads. Make it so that when the user presses enter nothing happens. 

Changes Made:

I decided to add a new optional prop to the SearchInput component that, when enabled, prevents the form from submitting on Enter. 


## Testing



## Screenshots / Demos



<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
