### PR TITLE
Different branch listing format

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -2,7 +2,8 @@ name: Dependabot Close Issue
 on:
   pull_request:
     types: [closed]
-    branches: ['dependabot/**']
+    branches:
+      - 'dependabot/**'
 
 jobs:
   issue:

--- a/.github/workflows/dependabotCreatePRIssue.yml
+++ b/.github/workflows/dependabotCreatePRIssue.yml
@@ -2,7 +2,8 @@ name: Dependabot Create Issue
 on:
   pull_request:
     types: [opened, reopened]
-    branches: ['dependabot/**']
+    branches: 
+      - 'dependabot/**'
 
 jobs:
   issue:


### PR DESCRIPTION
# BACKEND PULL REQUEST

- It looks like dependabot issues were not being created for their associated PRs after this branch filter was added in [this PR](https://github.com/CDCgov/prime-simplereport/pull/8494). This is to see if formatting the branches list to filter will solve the issue.