### PR TITLE
Dependabot - removing branch filter

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -2,8 +2,6 @@ name: Dependabot Close Issue
 on:
   pull_request:
     types: [closed]
-    branches:
-      - 'dependabot/**'
 
 jobs:
   issue:

--- a/.github/workflows/dependabotCreatePRIssue.yml
+++ b/.github/workflows/dependabotCreatePRIssue.yml
@@ -2,8 +2,6 @@ name: Dependabot Create Issue
 on:
   pull_request:
     types: [opened, reopened]
-    branches: 
-      - 'dependabot/**'
 
 jobs:
   issue:


### PR DESCRIPTION
Dependabot issues were not created for dependabot PRs while using the branch filter. This removes the filter to allow for issue creation/closing again.