### PR TITLE
added HepC feature flag logic

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderDeviceService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderDeviceService.java
@@ -75,6 +75,12 @@ public class ResultsUploaderDeviceService {
     if (supportedDiseaseNamesToCheck.contains("HIV")) {
       return featureFlagsConfig.isHivBulkUploadEnabled();
     }
+    if (supportedDiseaseNamesToCheck.contains("gonorrhea")) {
+      return featureFlagsConfig.isGonorrheaEnabled();
+    }
+    if (supportedDiseaseNamesToCheck.contains("Hepatitis C")) {
+      return featureFlagsConfig.isHepatitisCEnabled();
+    }
     return true;
   }
 }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ResultsUploaderDeviceServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ResultsUploaderDeviceServiceTest.java
@@ -110,6 +110,37 @@ class ResultsUploaderDeviceServiceTest extends BaseServiceTest<ResultsUploaderCa
     assertThat(validationResult).isTrue();
   }
 
+  @Test
+  void validateOnlyIncludeActiveDiseases_returnsFalseWhenHepCIsOff() {
+    // GIVEN
+    when(featureFlagsConfig.isHepatitisCEnabled()).thenReturn(false);
+    createDeviceType(
+        "hepatitisC device", List.of("5010-4"), diseaseService.hepatitisC().getInternalId());
+
+    // WHEN
+    boolean validationResult =
+        deviceService.validateResultsOnlyIncludeActiveDiseases("hepatitisC device", "5010-4");
+    System.out.println("Hepatitis C disease name: " + diseaseService.hepatitisC().getName());
+
+    // THEN
+    assertThat(validationResult).isFalse();
+  }
+
+  @Test
+  void validateOnlyIncludeActiveDiseases_returnsTrueWhenHepCIsOn() {
+    // GIVEN
+    when(featureFlagsConfig.isHepatitisCEnabled()).thenReturn(true);
+    createDeviceType(
+        "hepatitisC device", List.of("5010-4"), diseaseService.hepatitisC().getInternalId());
+
+    // WHEN
+    boolean validationResult =
+        deviceService.validateResultsOnlyIncludeActiveDiseases("hepatitisC device", "5010-4");
+
+    // THEN
+    assertThat(validationResult).isTrue();
+  }
+
   private DeviceType createDeviceType(
       String model, List<String> testPerformedCodes, UUID diseaseUUID) {
     SpecimenType specimenType =

--- a/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
+++ b/frontend/src/app/uploads/DeviceLookup/DeviceLookup.tsx
@@ -47,6 +47,12 @@ export const searchDevices = (
 
 const DeviceLookup = (props: Props) => {
   const hivBulkUploadEnabled = useFeature("hivBulkUploadEnabled") as boolean;
+  const gonorrheaBulkUploadEnabled = useFeature(
+    "gonorrheaBulkUploadEnabled"
+  ) as boolean;
+  const hepatitisCBulkUploadEnabled = useFeature(
+    "hepatitisCBulkUploadEnabled"
+  ) as boolean;
 
   let deviceDisplayOptions = props.deviceOptions;
   if (!hivBulkUploadEnabled) {
@@ -56,6 +62,26 @@ const DeviceLookup = (props: Props) => {
           .map((s) => s.supportedDisease)
           .map((sup) => sup.name)
           .includes("HIV")
+    );
+  }
+
+  if (!gonorrheaBulkUploadEnabled) {
+    deviceDisplayOptions = deviceDisplayOptions.filter(
+      (d) =>
+        !d.supportedDiseaseTestPerformed
+          .map((s) => s.supportedDisease)
+          .map((sup) => sup.name)
+          .includes("Gonorrhea")
+    );
+  }
+
+  if (!hepatitisCBulkUploadEnabled) {
+    deviceDisplayOptions = deviceDisplayOptions.filter(
+      (d) =>
+        !d.supportedDiseaseTestPerformed
+          .map((s) => s.supportedDisease)
+          .map((sup) => sup.name)
+          .includes("Hepatitis C")
     );
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

We need to ensure that all feature flags for all device types are operating as intented. 

## Changes Proposed

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8493

## Additional Information






## Testing


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

# DATABASE PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?
<!---

## Checklist for Primary Reviewer

- [ ] Only database changes are included in this PR
- [ ] Any new tables or columns that do not contain PII are accompanied by a GRANT SELECT to the no-PHI user
- [ ] Any changes to tables that have custom no-PHI views are accompanied by changes to those views (including re-granting permission to the no-PHI user if need be)
- [ ] Each new changeset has a corresponding [tag](https://docs.liquibase.com/change-types/community/tag-database.html)
- [ ] Rollback has been verifed locally and in a deployed environment
- [ ] Any changes to the startup configuration have been documented in the README
      -->

---

# DEVOPS PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

---

# FRONTEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
