### PR TITLE
Esperanto and Multi-Language Foundations

### DIFF
--- a/frontend/src/app/constants/constants.d.ts
+++ b/frontend/src/app/constants/constants.d.ts
@@ -621,6 +621,7 @@ interface PersonFormData extends Person {
 type Language =
   | "English"
   | "Spanish"
+  | "Esperanto"
   | "Unknown"
   | "Afrikaans"
   | "Amaric"

--- a/frontend/src/app/patients/Components/ManageEmails.test.tsx
+++ b/frontend/src/app/patients/Components/ManageEmails.test.tsx
@@ -4,8 +4,11 @@ import userEvent from "@testing-library/user-event";
 
 import i18n from "../../../i18n";
 import { es } from "../../../lang/es";
+import { eo } from "../../../lang/eo";
 
 import ManageEmails from "./ManageEmails";
+
+const langs = { es, eo };
 
 const patient = {
   facilityId: "facility-id",
@@ -103,26 +106,28 @@ describe("ManageEmails", () => {
     );
   });
 
-  it("translates errors", async () => {
-    const { user } = renderWithUser();
-    const primary = await screen.findByLabelText("Email address", {
-      exact: false,
+  for (const [lang, translations] of Object.entries(langs)) {
+    it("translates errors", async () => {
+      const { user } = renderWithUser();
+      const primary = await screen.findByLabelText("Email address", {
+        exact: false,
+      });
+
+      // Enter bad info and blur
+
+      await user.type(primary, "invalid email");
+
+      await user.tab();
+
+      await waitFor(() => {
+        i18n.changeLanguage(lang);
+      });
+
+      expect(
+        await screen.findByText(translations.translation.patient.form.errors.email)
+      ).toBeInTheDocument();
     });
-
-    // Enter bad info and blur
-
-    await user.type(primary, "invalid email");
-
-    await user.tab();
-
-    await waitFor(() => {
-      i18n.changeLanguage("es");
-    });
-
-    expect(
-      await screen.findByText(es.translation.patient.form.errors.email)
-    ).toBeInTheDocument();
-  });
+  }
 
   it("adds and removes email addresses", async () => {
     const { user } = renderWithUser();

--- a/frontend/src/app/patients/Components/ManagePhoneNumbers.test.tsx
+++ b/frontend/src/app/patients/Components/ManagePhoneNumbers.test.tsx
@@ -4,6 +4,9 @@ import userEvent from "@testing-library/user-event";
 
 import i18n from "../../../i18n";
 import { es } from "../../../lang/es";
+import { eo } from "../../../lang/eo";
+
+const langs = { es, eo };
 
 import ManagePhoneNumbers from "./ManagePhoneNumbers";
 
@@ -84,22 +87,24 @@ describe("ManagePhoneNumbers", () => {
       ).toBe(1);
     });
   });
-  it("translates errors", async () => {
-    const { user } = renderWithUser();
-    const primary = await screen.findByLabelText("Primary phone", {
-      exact: false,
-    });
-    // Show two errors
-    await user.clear(primary);
-    await user.tab();
+  for (const [lang, translations] of Object.entries(langs)) {
+    it("translates errors", async () => {
+      const { user } = renderWithUser();
+      const primary = await screen.findByLabelText("Primary phone", {
+        exact: false,
+      });
+      // Show two errors
+      await user.clear(primary);
+      await user.tab();
 
-    await waitFor(() => {
-      i18n.changeLanguage("es");
+      await waitFor(() => {
+        i18n.changeLanguage(lang);
+      });
+      expect(
+        await screen.findByText(translations.translation.patient.form.errors.telephone)
+      ).toBeInTheDocument();
     });
-    expect(
-      await screen.findByText(es.translation.patient.form.errors.telephone)
-    ).toBeInTheDocument();
-  });
+  }
   it("adds and removes phone numbers", async () => {
     const { user } = renderWithUser();
     const primary = await screen.findByLabelText("Primary phone", {

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -421,6 +421,7 @@ export const countryOptions = Object.entries(countries)
 export const languages: Language[] = [
   "English",
   "Spanish",
+  "Esperanto",
   "Unknown",
   "Afrikaans",
   "Amaric",

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -3,8 +3,9 @@ import { initReactI18next } from "react-i18next";
 
 import { en } from "./lang/en";
 import { es } from "./lang/es";
+import { eo } from "./lang/eo";
 
-export const resources = { en, es };
+export const resources = { en, es, eo };
 
 i18n.use(initReactI18next).init({
   resources,

--- a/frontend/src/lang/en.ts
+++ b/frontend/src/lang/en.ts
@@ -103,6 +103,7 @@ export const en = {
     languages: {
       English: "English",
       Spanish: "Spanish",
+      Esperanto: "Esperanto"
     },
     common: {
       required: "Required fields are marked with an asterisk",

--- a/frontend/src/lang/eo.ts
+++ b/frontend/src/lang/eo.ts
@@ -1,0 +1,116 @@
+import { en, LanguageConfig } from "./en";
+
+const YES = "Jes";
+const NO = "Ne";
+const OTHER = "Alia";
+const REFUSED = "Mi preferas ne respondi";
+const UNKNOWN = "Nekonata";
+const NOT_SURE = "Mi ne certas";
+const POSITIVE = "Pozitiva";
+const NEGATIVE = "Negativa";
+const UNDETERMINED = "Nedifinita";
+
+export const eo: LanguageConfig = {
+  translation: {
+    // This is not correct, but since this is still a draft,
+    // it will be left like this so the TypeScript compiler doesn't complain.
+    ...en.translation,
+    header: "COVID-19 Testa Portalo",
+    banner: {
+      dotGov: ".gov fino signifas, ke la retejo estas oficiala.",
+      dotGovHelper:
+        "Federaciaj registaraj retejoj ofte finiĝas per .gov aŭ .mil. Antaŭ ol dividi sentemajn informojn, certigu, ke vi estas en federacia registarretejo.",
+      secure: "La retejo estas sekura.",
+      secureHelper:
+        "La <0>https://</0> certigas, ke vi konektas al la oficiala retejo kaj ke ajna informo, kiun vi provizas, estas ĉifrita kaj sekure transdonita.",
+      officialWebsite:
+        "Oficiala retejo de la Usona Registaro",
+      howYouKnow: "Jen kiel vi scias",
+    },
+    constants: {
+      testResults: {
+        POSITIVE,
+        NEGATIVE,
+        UNDETERMINED,
+        UNKNOWN,
+      },
+      testResultsSymbols: {
+        POSITIVE: "(+)",
+        NEGATIVE: "(-)",
+      },
+      disease: {
+        COVID19: "COVID-19",
+        FLUA: "Gripo A",
+        FLUB: "Gripo B",
+        FLUAB: "Gripo A kaj B",
+        RSV: "RSV",
+        HIV: "HIV",
+        SYPHILIS: "Sifiliso",
+        HEPATITIS_C: "Hepatito C",
+        GONORRHEA: "Gonoreo",
+        CHLAMYDIA: "Klamidio",
+      },
+      diseaseResultTitle: {
+        COVID19: "COVID-19 rezulto",
+        FLUA: "Gripo A rezulto",
+        FLUB: "Gripo B rezulto",
+        FLUAB: "Gripo A kaj B rezulto",
+        RSV: "RSV rezulto",
+        HIV: "HIV testa rezulto",
+        SYPHILIS: "Sifiliso rezulto",
+        HEPATITIS_C: "Hepatito C rezulto",
+        GONORRHEA: "Gonoreo rezulto",
+        CHLAMYDIA: "Klamidio rezulto",
+      },
+      role: {
+        STAFF: "Personaro",
+        RESIDENT: "Loĝanto",
+        STUDENT: "Studento",
+        VISITOR: "Vizitanto",
+      },
+      race: {
+        native: "Indiĝena/Alaska Nativo",
+        asian: "Azia",
+        black: "Nigra/Afroamerikano",
+        pacific: "Havaja Nativo/Aliaj Pacifikaj Insuloj",
+        white: "Blanka",
+        other: OTHER,
+        refused: REFUSED,
+      },
+      gender: {
+        female: "Ina",
+        male: "Vira",
+      },
+      ethnicity: {
+        hispanic: YES,
+        not_hispanic: NO,
+        refused: REFUSED,
+      },
+      phoneType: {
+        MOBILE: "Poŝtelefono",
+        LANDLINE: "Fikstelefono",
+      },
+      yesNoUnk: {
+        YES,
+        NO,
+        UNKNOWN,
+      },
+      yesNoNotSure: {
+        YES,
+        NO,
+        NOT_SURE,
+      },
+      date: {
+        month: "Monato",
+        day: "Tago",
+        year: "Jaro",
+      },
+    },
+    languages: {
+      English: "Angla",
+      Spanish: "Hispana",
+      Esperanto: "Esperanto"
+    },
+    // Draft will continue here
+  },
+};

--- a/frontend/src/lang/es.ts
+++ b/frontend/src/lang/es.ts
@@ -106,6 +106,7 @@ export const es: LanguageConfig = {
     languages: {
       English: "Inglés",
       Spanish: "Español",
+      Esperanto: "Esperanto"
     },
     common: {
       required: "Los campos obligatorios están marcados con un asterisco",

--- a/frontend/src/patientApp/LanguageToggler.tsx
+++ b/frontend/src/patientApp/LanguageToggler.tsx
@@ -3,6 +3,7 @@ import i18n from "../i18n";
 import { setLanguage } from "../app/utils/languages";
 import "./LanguageToggler.scss";
 
+// Should be modified in the future to be a selector, not a switch button
 export default function LanguageToggler() {
   return (
     <div lang={i18n.language === "en" ? (i18n.language === "es" ? "eo" : "es") : "en"}>

--- a/frontend/src/patientApp/LanguageToggler.tsx
+++ b/frontend/src/patientApp/LanguageToggler.tsx
@@ -5,16 +5,16 @@ import "./LanguageToggler.scss";
 
 export default function LanguageToggler() {
   return (
-    <div lang={i18n.language === "en" ? "es" : "en"}>
+    <div lang={i18n.language === "en" ? (i18n.language === "es" ? "eo" : "es") : "en"}>
       <Button
         icon={"globe"}
         className="sr-language-toggler usa-button--unstyled"
         onClick={() => {
-          const displayLanguage = i18n.language === "en" ? "es" : "en";
+          const displayLanguage = i18n.language === "en" ? (i18n.language === "es" ? "eo" : "es") : "en";
           setLanguage(displayLanguage);
         }}
       >
-        {i18n.language === "en" ? "Español" : "English"}
+        {i18n.language === "en" ? (i18n.language === "es" ? "Esperanto" : "Español") : "English"}
       </Button>
     </div>
   );


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Changes Proposed

- Laying the foundations for additional language support, since right now, only Spanish is supported. The idea is to adapt the tests and frontend to add more available langauges. This PR adds some parts for Esperanto (the world's most widely spoken constructed international auxiliary language) since it is only a draft for now.
- In the future, the project should support other widely spoken languages, like Chinese.

## Additional Information

- Esperanto was chosen as it uses the alphabet, as to not introduce asian characters for now.
- In the future, the project should support other widely spoken languages, like Chinese.

## Testing

- Even if it is a draft, the translations can be verified with any translator that supports Esperanto (like Google Translate)

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
