### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,26 @@
+---
+name: Support Request
+about: Fill this out for any work that stems from customer support, asks from other teams, being on call, incidents, etc. You may fill this out retroactively.
+title: ""
+labels: "Support Request"
+assignees: ""
+---
+
+## Date of request
+
+X/X/XXXX
+
+## Who requested it / the origin of the work
+
+Customer support, ReportStream, STLT, etc.
+
+## One sentence summary
+
+What happened and what work was done? Some examples could be:
+- new device request
+- investigations into errors / trouble shooting user issues
+- requests for emails for facility outreach (e.g. when a new STLT goes live on the UP)
+- responding to an incident
+
+## (Optional) Links to supporting material
+


### PR DESCRIPTION
## Related Issue

- Product team needs a way to track non-feature work done on the team to better represent to stakeholders the true amount of work accomplished. Some of that work have issues associated with them, but not all of them do.
 
## Changes Proposed

- Add a new, lightweight issue template for engineers to quickly document any otherwise untracked work stemming from customer support, asks from other teams, being on call, incidents, etc. 
- Eng may fill this issues out retroactively.

## Additional Information

- N/A

## Testing

- N/A