### PR TITLE
Fixed issue #8575

### DIFF
--- a/frontend/src/app/Settings/Facility/FacilityForm.tsx
+++ b/frontend/src/app/Settings/Facility/FacilityForm.tsx
@@ -328,7 +328,7 @@ const FacilityForm: React.FC<Props> = (props) => {
             <div>
               <div className="display-flex flex-align-center">
                 {props.newOrg ? (
-                  <h2 className="margin-top-05">Welcome to SimpleReport!</h2>
+                  <h1 className="margin-top-05">Welcome to SimpleReport!</h1>
                 ) : (
                   <>
                     <svg
@@ -348,9 +348,9 @@ const FacilityForm: React.FC<Props> = (props) => {
                   </>
                 )}
               </div>
-              <h1 className="font-heading-lg margin-y-1">
+              <h2 className="font-heading-lg margin-y-1">
                 {facility.name || "Add facility"}
-              </h1>
+              </h2>
             </div>
             <div
               style={{


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Issue #8575, the order of the headings was wrong, `<h1>` and `<h2>` was not in order as documented in [heading-order](https://dequeuniversity.com/rules/axe/4.10/heading-order?application=AxeChrome).

## Changes Proposed

- Change `<h1>` to `<h2>` and inversely.

## Testing

- To test, you have to create a newe org. Once created, sign up as the new org adminvia the link you are recived in your email from Okta. After sining up, you will be redirected to "Add facility". Now that form contains the correct heading order.
