### PR TITLE
Add new template for issues that spring up while on call

### DIFF
--- a/.github/ISSUE_TEMPLATE/on_call.md
+++ b/.github/ISSUE_TEMPLATE/on_call.md
@@ -1,0 +1,25 @@
+---
+name: On Call
+about: Fill this out for any work that stems from being on call, such as customer support, asks from other teams, incidents, general requests for help, etc. You may fill this out retroactively.
+title: ""
+labels: "On Call"
+assignees: ""
+---
+
+## Date of request
+X/X/XXXX
+
+## Who requested it / the origin of the work
+
+Customer support, ReportStream, STLT, etc.
+
+## One sentence summary
+
+What happened and what work was done? Some examples could be:
+- new device request
+- investigations into errors / trouble shooting user issues
+- requests for emails for facility outreach (e.g. when a new STLT goes live on the UP)
+- responding to an incident
+
+## (Optional) Links to supporting material
+


### PR DESCRIPTION
## Related Issue

- Product team needs a way to track non-feature work done on the team to better plan capacity as well as represent to stakeholders the true amount of work accomplished. Some of that work have issues associated with them, but not all of them do.
 
## Changes Proposed

- Add a new, lightweight issue template for engineers to quickly document any otherwise untracked work stemming from customer support, asks from other teams, being on call, incidents, etc. 
- Eng may fill this issues out retroactively.

## Additional Information

- N/A

## Testing

- N/A