### PR TITLE
SonarCloud duplication issue fixed

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -130,7 +130,7 @@ public class TestResultUploadService {
 
   private static final String ALPHABET_REGEX = "^[a-zA-Z\\s]+$";
 
-  private static final String TIME_MEASSUREMENT_MILLISECONDS_NAME="milliseconds";
+  private static final String TIME_MEASSUREMENT_MILLISECONDS_NAME=" milliseconds";
   
   public String createDataHubSenderToken(String privateKey) throws InvalidRSAPrivateKeyException {
     Date inFiveMinutes = new Date(System.currentTimeMillis() + FIVE_MINUTES_MS);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -130,6 +130,8 @@ public class TestResultUploadService {
 
   private static final String ALPHABET_REGEX = "^[a-zA-Z\\s]+$";
 
+  private static final String TIME_MEASSUREMENT_MILLISECONDS_NAME="milliseconds";
+  
   public String createDataHubSenderToken(String privateKey) throws InvalidRSAPrivateKeyException {
     Date inFiveMinutes = new Date(System.currentTimeMillis() + FIVE_MINUTES_MS);
 
@@ -396,7 +398,7 @@ public class TestResultUploadService {
                   fhirConverter.convertToFhirBundles(content, org.getInternalId());
               UploadResponse response = uploadBundleAsFhir(fhirBundleWithMeta.serializedBundle());
               log.info(
-                  "FHIR submitted in " + (System.currentTimeMillis() - start) + " milliseconds");
+                  "FHIR submitted in " + (System.currentTimeMillis() - start) + TIME_MEASSUREMENT_MILLISECONDS_NAME);
 
               return new UniversalSubmissionSummary(
                   submissionId, org, response, fhirBundleWithMeta.metadata());
@@ -457,7 +459,7 @@ public class TestResultUploadService {
                 }
               }
               log.info(
-                  "CSV submitted in " + (System.currentTimeMillis() - start) + " milliseconds");
+                  "CSV submitted in " + (System.currentTimeMillis() - start) + TIME_MEASSUREMENT_MILLISECONDS_NAME);
 
               HashMap<String, Integer> diseaseReported = new HashMap<>();
 
@@ -628,7 +630,7 @@ public class TestResultUploadService {
                   fhirConverter.convertToConditionAgnosticFhirBundles(content);
               UploadResponse response = uploadBundleAsFhir(serializedFhirBundles);
               log.info(
-                  "FHIR submitted in " + (System.currentTimeMillis() - start) + " milliseconds");
+                  "FHIR submitted in " + (System.currentTimeMillis() - start) + TIME_MEASSUREMENT_MILLISECONDS_NAME);
               return response;
             }));
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Why is this being done? Link to issue, or a few sentences describing why this PR exists
   SonarCloud had given this file a high severity maintenance issue.
   https://sonarcloud.io/project/issues?impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=CDCgov_prime-data-input-client&open=AYsqal07dc2QNWg7T80m
## Changes Proposed
   The string "milliseconds was used 3 times, so instead, I have declared a string constant so it can be changed easily if needed and avoiding duplications.

## Additional Information
    File path: backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
![image](https://github.com/user-attachments/assets/e338ba5c-aada-44fc-a323-bebabdc48f28)
