### PR TITLE
Updating dependabotClosePRIssue to trigger on pull_request_target

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -1,6 +1,6 @@
 name: Dependabot Close Issue
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
# BACKEND PULL REQUEST

[@mehansen noticed](https://skylight-hq.slack.com/archives/C064P7MHM47/p1742238472437089?thread_ts=1739311585.677449&cid=C064P7MHM47) that the dependabot close issue step was randomly failing, and after looking into it more, it seems that using [`pull_request` sometimes fails.](https://github.com/orgs/community/discussions/26657#discussioncomment-3252753) From that comment thread, it appears that changing to `pull_request_target` could fix the issue. We'll make this change and monitor if dependabot reliably closes issues going forward.