### PR TITLE
Fixing frontend processing of bulk upload parseable failure

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -479,7 +479,7 @@ public class TestResultUploadService {
           InterruptedException {
     try {
       CovidSubmissionSummary submissionSummary = futureSubmissionSummary.get();
-      if (submissionSummary.processingException() != null) {
+      if (submissionSummary.processingException() instanceof DependencyFailureException) {
         throw (DependencyFailureException) submissionSummary.processingException();
       }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestResultUploadService.java
@@ -479,7 +479,7 @@ public class TestResultUploadService {
           InterruptedException {
     try {
       CovidSubmissionSummary submissionSummary = futureSubmissionSummary.get();
-      if (submissionSummary.processingException() instanceof DependencyFailureException) {
+      if (submissionSummary.processingException() != null) {
         throw (DependencyFailureException) submissionSummary.processingException();
       }
 

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -334,6 +334,129 @@ describe("Uploads", () => {
         },
       });
     });
+
+    it("response errors are shown to user when upload fails one pipeline", async () => {
+      jest.spyOn(FileUploadService, "uploadResults").mockImplementation(() => {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                internalId: "2c8eb0a5-4e82-4723-a851-c50e7c6b1564",
+                createdAt: "2025-03-21T18:42:22.157+00:00",
+                updatedAt: "2025-03-21T18:42:22.183+00:00",
+                reportId: null,
+                submissionId: "6d014dcf-f1ec-46e3-8ebe-5211ca865645",
+                status: "PENDING",
+                recordsCount: 0,
+                warnings: [
+                  {
+                    scope: "item",
+                    message:
+                      "No match found for equipment_model_id (equipment_model_id); please refer to the CDC LIVD table LOINC Mapping spreadsheet for acceptable values.",
+                    indices: [1],
+                    fieldHeader: null,
+                    fieldRequired: false,
+                    errorType: null,
+                    source: null,
+                  },
+                  {
+                    scope: "item",
+                    message:
+                      "No match found for test_kit_name_id (test_kit_name_id); please refer to the CDC LIVD table LOINC Mapping spreadsheet for acceptable values.",
+                    indices: [1],
+                    fieldHeader: null,
+                    fieldRequired: false,
+                    errorType: null,
+                    source: null,
+                  },
+                  {
+                    scope: "item",
+                    message:
+                      "No match found for test_performed_name (test_performed_name); please refer to the CDC LIVD table LOINC Mapping spreadsheet for acceptable values.",
+                    indices: [1],
+                    fieldHeader: null,
+                    fieldRequired: false,
+                    errorType: null,
+                    source: null,
+                  },
+                ],
+                errors: [
+                  {
+                    scope: "item",
+                    message:
+                      "No match found for equipment_model_name (equipment_model_name); please refer to the CDC LIVD table LOINC Mapping spreadsheet for acceptable values.",
+                    indices: [1],
+                    fieldHeader: null,
+                    fieldRequired: false,
+                    errorType: null,
+                    source: "REPORT_STREAM",
+                  },
+                ],
+                destination: "COVID",
+                uploadDiseaseDetails: null,
+              },
+              {
+                internalId: "3b651647-5d37-4cd9-abd7-7bd2e3b6d778",
+                createdAt: "2025-03-21T18:42:22.926+00:00",
+                updatedAt: "2025-03-21T18:42:22.926+00:00",
+                reportId: "1153c235-ad05-4407-a52c-77ee3f6fb32e",
+                submissionId: "6d014dcf-f1ec-46e3-8ebe-5211ca865645",
+                status: "PENDING",
+                recordsCount: 1,
+                warnings: [],
+                errors: [],
+                destination: "UNIVERSAL",
+                uploadDiseaseDetails: null,
+              },
+            ]),
+            { status: 200 }
+          )
+        );
+      });
+
+      const { user } = renderWithUser();
+
+      const fileInput = screen.getByTestId("upload-csv-input");
+      await user.upload(fileInput, validFile());
+      expect(
+        screen.getByText("Drag file here or choose from folder to change file")
+      ).toBeInTheDocument();
+
+      const submitButton = screen.getByTestId("button");
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Error: File not accepted")
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByText("Error")).toBeInTheDocument();
+      expect(screen.getByText("Row(s)")).toBeInTheDocument();
+      expect(screen.getByText("No match found for")).toBeInTheDocument();
+      expect(screen.getAllByText("equipment_model_name")).toHaveLength(2);
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        name: "Spreadsheet upload validation failure",
+        properties: {
+          errors: [
+            {
+              message:
+                "No match found for equipment_model_name (equipment_model_name); please refer to the CDC LIVD table LOINC Mapping spreadsheet for acceptable values.",
+              scope: "item",
+              errorType: null,
+              fieldHeader: null,
+              fieldRequired: false,
+              indices: [1],
+              indicesRange: ["1"],
+              source: "REPORT_STREAM",
+            },
+          ],
+          org: "Test Org",
+          user: "testuser@test.org",
+          uploadType: "Disease Specific",
+        },
+      });
+    });
   });
 
   describe("error row grouping", () => {

--- a/frontend/src/app/testResults/uploads/UploadForm.test.tsx
+++ b/frontend/src/app/testResults/uploads/UploadForm.test.tsx
@@ -425,11 +425,9 @@ describe("Uploads", () => {
       const submitButton = screen.getByTestId("button");
       await user.click(submitButton);
 
-      await waitFor(() => {
-        expect(
-          screen.getByText("Error: File not accepted")
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText("Error: File not accepted")
+      ).toBeInTheDocument();
       expect(screen.getByText("Error")).toBeInTheDocument();
       expect(screen.getByText("Row(s)")).toBeInTheDocument();
       expect(screen.getByText("No match found for")).toBeInTheDocument();
@@ -487,12 +485,9 @@ describe("Uploads", () => {
       const submitButton = screen.getByTestId("button");
       await user.click(submitButton);
 
-      await waitFor(() => {
-        expect(
-          screen.getByText("Error: File not accepted")
-        ).toBeInTheDocument();
-      });
-
+      expect(
+        await screen.findByText("Error: File not accepted")
+      ).toBeInTheDocument();
       expect(
         screen.getByText((content) => {
           return content.includes(


### PR DESCRIPTION
# FRONTEND PULL REQUEST

- https://github.com/CDCgov/prime-simplereport/issues/8496?reload=1

- This changes the frontend processing to be in line with what the backend returns for a parseable bulk upload failure while still allowing for processing of failures from Simple Report's own validation prior to sending to either Report Stream pipeline (Covid or Universal).

## Testing

- To create a single pipeline failure in only the Covid pipeline, set up the following device locally and then try to upload the CSV below the screenshots (thanks @mpbrown!). This tests the first if statement modified here. For the `else` statement, I'm not sure there's a way to manually test it, but it exists more as a catch-all in the event that we receive a 200 from the backend that doesn't satisfy the if/if-else above it.
![image (3)](https://github.com/user-attachments/assets/f67bbc2a-944d-4ad4-b6d5-aed022d379d0)
![image (4)](https://github.com/user-attachments/assets/143f5699-4977-4982-8f24-958f49a9a064)

[test_results_manual_device_requests_biofire_original.csv](https://github.com/user-attachments/files/19396048/test_results_manual_device_requests_biofire_original.csv)