### PR TITLE
Update front-end to handle invalid phone numbers for pending organizations

### DIFF
--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizations.tsx
@@ -55,6 +55,18 @@ const initialState: PendingOrganizationState = {
 };
 
 const phoneUtil = PhoneNumberUtil.getInstance();
+
+const parsePhoneNumber = (phoneNumber: string) => {
+  try {
+    return phoneUtil.format(
+      phoneUtil.parseAndKeepRawInput(phoneNumber, "US"),
+      PhoneNumberFormat.NATIONAL
+    );
+  } catch {
+    return "";
+  }
+};
+
 const PendingOrganizations = ({
   organizations,
   submitIdentityVerified,
@@ -217,12 +229,7 @@ const PendingOrganizations = ({
         <td className="word-break-break-word">
           <a href={`mailto:${o.adminEmail}}`}>{o.adminEmail}</a>
           <br />
-          {o.adminPhone
-            ? phoneUtil.format(
-                phoneUtil.parseAndKeepRawInput(o.adminPhone, "US"),
-                PhoneNumberFormat.NATIONAL
-              )
-            : ""}
+          {parsePhoneNumber(o.adminPhone)}
         </td>
         <td
           data-testid="org-created-at-table-cell"

--- a/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/PendingOrganizationsContainer.test.tsx
@@ -12,7 +12,11 @@ import Page from "../../commonComponents/Page/Page";
 
 import PendingOrganizationsContainer from "./PendingOrganizationsContainer";
 
-const organizationsQuery = (name: string, id: string) => {
+const organizationsQuery = (
+  name: string,
+  id: string,
+  adminPhone = "530-867-5309"
+) => {
   return {
     request: {
       query: GetPendingOrganizationsDocument,
@@ -26,7 +30,7 @@ const organizationsQuery = (name: string, id: string) => {
             adminEmail: "admin@spacecamp.org",
             adminFirstName: "John",
             adminLastName: "Doe",
-            adminPhone: "530-867-5309",
+            adminPhone,
             createdAt: "2021-12-01T00:00:00.000Z",
           },
           {
@@ -245,6 +249,32 @@ describe("PendingOrganizationsContainer", () => {
       const rowsCreatedAt = screen.getAllByTestId("org-created-at-table-cell");
       expect(rowsCreatedAt[0]).toHaveTextContent("12/26/2021, 12:00:00 AM");
       expect(rowsCreatedAt[1]).toHaveTextContent("12/1/2021, 12:00:00 AM");
+    });
+
+    it("displays org table with invalid data hidden", async () => {
+      const invalidPhoneNumber = "invalid-phone-number";
+
+      render(
+        <Page>
+          <MockedProvider
+            mocks={[
+              organizationsQuery(
+                "Space Camp",
+                "DC-Space-Camp-f34183c4-b4c5-449f-98b0-2e02abb7aae0",
+                invalidPhoneNumber
+              ),
+              verificationMutation,
+              editOrganizationsMutation,
+            ]}
+          >
+            <PendingOrganizationsContainer />
+          </MockedProvider>
+        </Page>
+      );
+
+      await screen.findByText("Space Camp");
+      // we should not display the invalid phone number
+      expect(screen.queryByText(invalidPhoneNumber)).not.toBeInTheDocument();
     });
 
     describe("confirm/edit modal acts correctly", () => {


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Resolves #8451 

## Changes Proposed

- Attempt to parse the phone number, and default to an empty string on failure

## Additional Information

* There are a number of phoneNumber validation utility functions in `frontend/src/app/patients/personSchema.ts` that may be better suited to a more generic utility module
* I omitted using the existing `phoneNumberIsValid` in the above module here, because it would require us to parse the phone number string twice

## Testing

To test this locally:

1. Go to `localhost:3000/sign-up` and step through new organization form. Enter any data
2. Go to `localhost:3000/admin/pending-organizations`; the org you created should correctly display
3. Update the row for your org in the DB to set `workPhoneNumber` to an invalid phone number Example:
```sql
update simple_report.organization_queue
set request_data = jsonb_set(request_data, '{workPhoneNumber}', '"this_is_an_invalid_phone_num"')
where internal_id = <internal_id>;
```
4. Re-visit `localhost:3000/admin/pending-organizations`. The page should properly load, and the invalid phone number will not be rendered in the row.

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->