### PR TITLE
Focusing search by name causes an unexpected page reload

### DIFF
--- a/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
@@ -159,6 +159,7 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
   const handlePatientInputChange: ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
+    if (event.type !== "change") return;
     if (event.target.value === "") {
       setFilterParams("patientId")(null);
     }

--- a/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsFilters.tsx
@@ -159,13 +159,14 @@ const TestResultsFilters: React.FC<TestResultsFiltersProps> = ({
   const handlePatientInputChange: ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
-    if (event.type !== "change") return;
-    if (event.target.value === "") {
-      setFilterParams("patientId")(null);
-    }
-    setShowSuggestion(true);
-    if (event.target.value !== queryString) {
-      setDebounced(event.target.value);
+    if (event.type === "change") {
+      if (event.target.value === "") {
+        setFilterParams("patientId")(null);
+      }
+      setShowSuggestion(true);
+      if (event.target.value !== queryString) {
+        setDebounced(event.target.value);
+      }
     }
   };
 

--- a/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
@@ -741,7 +741,7 @@ describe("TestResultsList", () => {
           ]}
         >
           <Provider store={store}>
-            <MockedProvider mocks={mocks}>
+            <MockedProvider mocks={mocksWithMultiplex}>
               <TestResultsList />
             </MockedProvider>
           </Provider>
@@ -749,11 +749,13 @@ describe("TestResultsList", () => {
       );
 
       expect(
-        await screen.findByText("Test Results", { exact: false })
+        await screen.findByText("Test results", { exact: false })
       ).toBeInTheDocument();
 
-      const pageLink = await screen.findByRole("link", { name: /page 2/i });
-      const initialPath = pageLink.getAttribute("href");
+      const paginationText = await screen.findByText(
+        /Showing results for.*of.*/i
+      );
+      const initialPaginationText = paginationText.textContent || "";
 
       const searchInput = screen.getByRole("searchbox", {
         name: /search by name/i,
@@ -761,10 +763,11 @@ describe("TestResultsList", () => {
 
       await user.click(searchInput);
 
-      await waitFor(() => {}, { timeout: 100 });
-
-      const pageLinkAfter = screen.getByRole("link", { name: /page 2/i });
-      expect(pageLinkAfter).toHaveAttribute("href", initialPath);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Showing results for.*of.*/i)
+        ).toHaveTextContent(initialPaginationText);
+      });
     });
   });
 

--- a/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
@@ -726,6 +726,46 @@ describe("TestResultsList", () => {
         );
       });
     });
+
+    it("should not navigate when focusing the search input on pages other than page 1", async () => {
+      const search = new URLSearchParams({
+        facility: "1",
+      });
+
+      const user = userEvent.setup();
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/results/2", search: search.toString() },
+          ]}
+        >
+          <Provider store={store}>
+            <MockedProvider mocks={mocks}>
+              <TestResultsList />
+            </MockedProvider>
+          </Provider>
+        </MemoryRouter>
+      );
+
+      expect(
+        await screen.findByText("Test Results", { exact: false })
+      ).toBeInTheDocument();
+
+      const pageLink = await screen.findByRole("link", { name: /page 2/i });
+      const initialPath = pageLink.getAttribute("href");
+
+      const searchInput = screen.getByRole("searchbox", {
+        name: /search by name/i,
+      });
+
+      await user.click(searchInput);
+
+      await waitFor(() => {}, { timeout: 100 });
+
+      const pageLinkAfter = screen.getByRole("link", { name: /page 2/i });
+      expect(pageLinkAfter).toHaveAttribute("href", initialPath);
+    });
   });
 
   it("should hide facility filter if user can see only 1 facility", async () => {

--- a/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
+++ b/frontend/src/app/testResults/viewResults/TestResultsList.test.tsx
@@ -727,7 +727,7 @@ describe("TestResultsList", () => {
       });
     });
 
-    it("should not navigate when focusing the search input on pages other than page 1", async () => {
+    it("should not navigate to page 1 when focusing the search input on pages other then page 1", async () => {
       const search = new URLSearchParams({
         facility: "1",
       });

--- a/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -722,41 +722,6 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 </span>
               </a>
             </li>
-            <li>
-              <a
-                aria-label="Page 2"
-                class=""
-                href="/results/2?facility=1"
-              >
-                <span>
-                  2
-                </span>
-              </a>
-            </li>
-            <li>
-              <a
-                aria-label="Next Page"
-                class=""
-                href="/results/2?facility=1"
-              >
-                Next 
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-angle-right "
-                  data-icon="angle-right"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M278.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 256 73.4 118.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </a>
-            </li>
           </ol>
         </nav>
       </div>

--- a/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -722,6 +722,41 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 </span>
               </a>
             </li>
+            <li>
+              <a
+                aria-label="Page 2"
+                class=""
+                href="/results/2?facility=1"
+              >
+                <span>
+                  2
+                </span>
+              </a>
+            </li>
+            <li>
+              <a
+                aria-label="Next Page"
+                class=""
+                href="/results/2?facility=1"
+              >
+                Next 
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-angle-right "
+                  data-icon="angle-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M278.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 256 73.4 118.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </a>
+            </li>
           </ol>
         </nav>
       </div>


### PR DESCRIPTION
# FRONTEND PULL REQUEST



## Changes Proposed

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8448

search input is using the same handler for focus events as it does for change events,
The way search input is written we have  `onFocus = {onInputChange}`

in this case` onInputChange` triggers `handlePatientInputChange` which has a `setDebounced `with refreshes the page this is causing the filter and therby the page to update. My initial approach was to create a separate handler for focus events but that would require a new handler for the SearchInput component potentially effected other parts of the app. Instead within handlePatientInput change I am checking if the event type is a change event. If it is then invoke the function otherwise do nothing. I added a test to verify this let me know if you have any questions. 


## Testing

If you create more then 20 results locally you can test this out on the results page. Or in dev4
https://dev4.simplereport.gov/app/results/3?facility=1f94021c-b13e-45ad-b176-f02274bb2823


## Screenshots / Demos


https://github.com/user-attachments/assets/9ec14dab-a965-42ee-9241-fb6647e87770




<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
