### PR TITLE
adding feature flag for bulk upload feature

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/BulkUploadDisabledException.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/errors/BulkUploadDisabledException.java
@@ -1,0 +1,13 @@
+package gov.cdc.usds.simplereport.api.model.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** An error thrown when bulk upload is disabled */
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class BulkUploadDisabledException extends RuntimeException {
+
+  public BulkUploadDisabledException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
@@ -6,6 +6,7 @@ import static gov.cdc.usds.simplereport.config.WebConfiguration.PATIENT_UPLOAD;
 import static gov.cdc.usds.simplereport.config.WebConfiguration.RESULT_UPLOAD;
 
 import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
+import gov.cdc.usds.simplereport.api.model.errors.BulkUploadDisabledException;
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
 import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
@@ -67,10 +68,9 @@ public class FileUploadController {
 
   @PostMapping(RESULT_UPLOAD)
   @SuppressWarnings({"checkstyle:illegalcatch"})
-  public List<TestResultUpload> handleResultsUpload(@RequestParam("file") MultipartFile file)
-      throws Exception {
+  public List<TestResultUpload> handleResultsUpload(@RequestParam("file") MultipartFile file) {
     if (featureFlagsConfig.isBulkUploadDisabled()) {
-      throw new Exception("Bulk upload feature is temporarily disabled.");
+      throw new BulkUploadDisabledException("Bulk upload feature is temporarily disabled.");
     }
 
     assertCsvFileType(file);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/uploads/FileUploadController.java
@@ -8,6 +8,7 @@ import static gov.cdc.usds.simplereport.config.WebConfiguration.RESULT_UPLOAD;
 import gov.cdc.usds.simplereport.api.model.errors.BadRequestException;
 import gov.cdc.usds.simplereport.api.model.errors.CsvProcessingException;
 import gov.cdc.usds.simplereport.api.model.errors.IllegalGraphqlArgumentException;
+import gov.cdc.usds.simplereport.config.FeatureFlagsConfig;
 import gov.cdc.usds.simplereport.db.model.TestResultUpload;
 import gov.cdc.usds.simplereport.service.PatientBulkUploadService;
 import gov.cdc.usds.simplereport.service.TestResultUploadService;
@@ -29,6 +30,7 @@ public class FileUploadController {
   public static final String TEXT_CSV_CONTENT_TYPE = "text/csv";
   private final PatientBulkUploadService patientBulkUploadService;
   private final TestResultUploadService testResultUploadService;
+  private final FeatureFlagsConfig featureFlagsConfig;
 
   @PostMapping(PATIENT_UPLOAD)
   public PatientBulkUploadResponse handlePatientsUpload(
@@ -65,7 +67,12 @@ public class FileUploadController {
 
   @PostMapping(RESULT_UPLOAD)
   @SuppressWarnings({"checkstyle:illegalcatch"})
-  public List<TestResultUpload> handleResultsUpload(@RequestParam("file") MultipartFile file) {
+  public List<TestResultUpload> handleResultsUpload(@RequestParam("file") MultipartFile file)
+      throws Exception {
+    if (featureFlagsConfig.isBulkUploadDisabled()) {
+      throw new Exception("Bulk upload feature is temporarily disabled.");
+    }
+
     assertCsvFileType(file);
 
     try (InputStream resultsUpload = file.getInputStream()) {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -32,6 +32,7 @@ public class FeatureFlagsConfig {
   private boolean hivEnabled;
   private boolean agnosticEnabled;
   private boolean agnosticBulkUploadEnabled;
+  private boolean bulkUploadDisabled; // inverting logic because bulk uploader is enabled by default
 
   @Scheduled(fixedRateString = "60000") // 1 min
   private void loadFeatureFlagsFromDB() {
@@ -49,6 +50,7 @@ public class FeatureFlagsConfig {
       case "hivEnabled" -> setHivEnabled(flagValue);
       case "agnosticEnabled" -> setAgnosticEnabled(flagValue);
       case "agnosticBulkUploadEnabled" -> setAgnosticBulkUploadEnabled(flagValue);
+      case "bulkUploadDisabled" -> setBulkUploadDisabled(flagValue);
       default -> log.info("no mapping for " + flagName);
     }
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- No issue made yet, WIP
- ReportStream has some planned downtime in the very near future.  I think it would be advantageous given our latest incident with bulk upload submissions to explicitly disable bulk uploads during the maintenance window.

## Changes Proposed

- Create a feature flag (inverse of the normal logic, default is to enabled)
- When the feature flag is set to true, we disable the bulk upload feature at the backend api level
- This causes a 500 error which will be handled by the existing frontend logic

## Additional Information
Screenshot: 
<img width="1725" alt="Screenshot 2025-03-23 at 11 47 09 AM" src="https://github.com/user-attachments/assets/44084c80-de46-480e-8d24-74f51e2ce696" />


## Testing

- Set the flag to false (default), attempt an upload (it should work)
- Set the flag to true, attempt an upload (you should see a generic error toast)

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
