### PR TITLE
Test correction fails with a toast when the patient has a different test in a "pending" state

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/TestOrderService.java
@@ -551,6 +551,14 @@ public class TestOrderService {
         ensureCorrectionFlowBackwardCompatibility(event);
         order.setCorrectionStatus(status);
         order.setReasonForCorrection(reasonForCorrection);
+        Person currentPatient = order.getPatient();
+        Optional<TestOrder> pendingTestOrder =
+            _testOrderRepo.fetchQueueItem(currentPatient.getOrganization(), currentPatient);
+        if (pendingTestOrder.isPresent()) {
+          throw new IllegalGraphqlArgumentException(
+              "Cannot correct a test for a patient with an active test");
+        }
+
         order.markPending();
         if (order.getDateTestedBackdate() == null) {
           order.setDateTestedBackdate(event.getDateTested());

--- a/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultCorrectionModal.tsx
+++ b/frontend/src/app/testResults/viewResults/actionMenuModals/TestResultCorrectionModal.tsx
@@ -157,17 +157,12 @@ export const DetachedTestResultCorrectionModal = ({
         id: testResultId,
         reason: correctionDetails || reason,
       },
-    })
-      .then(() => {
-        // TODO: better text here, maybe indicating to user that the test should now
-        // be available in the queue
-        showSuccess("", "Result marked as correction");
-      })
-      .finally(() => {
-        setTimeout(() => {
-          navigate(`/queue?facility=${activeFacilityId}`);
-        }, 1000);
-      });
+    }).then(() => {
+      // TODO: better text here, maybe indicating to user that the test should now
+      // be available in the queue
+      showSuccess("", "Result marked as correction");
+      navigate(`/queue?facility=${activeFacilityId}`);
+    });
   };
 
   const validationMessageForDeletedFacility = () => {


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- https://github.com/CDCgov/prime-simplereport/issues/7973

## Changes Proposed

- If a user tries to correct a test while a different test is in the queue, the backend throws an exception that propagates to the frontend toast. The exception tells the user that they cannot correct a test while another test is pending on the queue.

## Testing

- Locally and in dev2

