### PR TITLE
[BUG] Update bulk uploader datetime validations

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -466,7 +466,11 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message("Invalid date format: " + value + ". Expected format: M/d/yyyy [H:mm] [TZ]")
+              .message(
+                  "Invalid date format: "
+                      + value
+                      + ". Expected format: M/d/yyyy [H:mm] [TZ] for "
+                      + input.getHeader())
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())
               .build());
@@ -485,7 +489,13 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message("Invalid timezone code: " + timezoneCode + " for " + input.getHeader())
+              .message(
+                  "Invalid timezone code: "
+                      + timezoneCode
+                      + " in "
+                      + value
+                      + " for "
+                      + input.getHeader())
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(false)
               .build());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -44,7 +44,9 @@ import static gov.cdc.usds.simplereport.db.model.PersonUtils.SUBSTANCE_ABUSE_TRE
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_LITERAL;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_SNOMED;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getGenderIdentityAbbreviationMap;
-import static gov.cdc.usds.simplereport.utils.DateTimeUtils.*;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.convertToZonedDateTime;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.hasTimezoneSubstring;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.timezoneAbbreviationZoneIdMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 
@@ -460,7 +462,7 @@ public class CsvValidatorUtils {
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));
       }
-    } catch (Exception e) {
+    } catch (DateTimeParseException | StringIndexOutOfBoundsException e) {
       errors.add(
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -460,16 +460,12 @@ public class CsvValidatorUtils {
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));
       }
-    } catch (DateTimeParseException e) {
+    } catch (Exception e) {
       errors.add(
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message(
-                  "Invalid date format: "
-                      + value
-                      + ". Expected format: M/d/yyyy [H:mm] [TZ] for "
-                      + input.getHeader())
+              .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())
               .build());
@@ -488,13 +484,7 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message(
-                  "Invalid timezone code: "
-                      + timezoneCode
-                      + " in "
-                      + value
-                      + " for "
-                      + input.getHeader())
+              .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(false)
               .build());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -65,7 +65,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -456,7 +455,7 @@ public class CsvValidatorUtils {
     }
 
     try {
-      ZonedDateTime dateTime = convertToZonedDateTime(value);
+      convertToZonedDateTime(value);
 
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -467,6 +467,7 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
+              .source(ResultUploadErrorSource.SIMPLE_REPORT)
               .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Resolves #8253

## Changes Proposed

- Removes the use of REGEX to validate date time strings in CSV upload. We now attempt to parse the date string, and catch any errors.

## Additional Information

- ~~Error messaging for `validateDateTimeZoneCode` has been modified to be more clear to the user~~
- Use of `convertToZonedDateTime` to attempt parsing of the date string

## Testing

You can use this .csv to start, which should fail by default with an invalid timezone for the `specimen_collection_date` column.

[pr_ordering_INVALID_TIMEZONE.csv](https://github.com/user-attachments/files/19571496/pr_ordering_INVALID_TIMEZONE.csv)

You can modify this column to test the other scenarios.

Should fail:
```
01 / 01 / 2023 11 : 11
01/01 /2023 11:11 EST
01/01/2023 11:11 WAT
```

Should pass:
```
    01/01/2023 11:11 EST   
01/01 /2023 11:11
```

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
