### PR TITLE
Bulk Upload Specimen Type getting improperly remapped

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/FhirConverter.java
@@ -594,19 +594,17 @@ public class FhirConverter {
   private Specimen setCollectionCodingAndName(Specimen specimen, ConvertToSpecimenProps props) {
     boolean collectionCodeProvided = StringUtils.isNotBlank(props.getCollectionCode());
     boolean collectionLocationNameProvided = StringUtils.isNotBlank(props.getCollectionName());
-
-    String collectionCodeToSet = DEFAULT_LOCATION_CODE;
+    String collectionCodeToSet;
     String collectionLocationNameToSet = null;
-
-    if (collectionCodeProvided && !collectionLocationNameProvided) {
+    if (collectionCodeProvided) {
       collectionCodeToSet = props.getCollectionCode();
-    } else if (collectionCodeProvided && collectionLocationNameProvided) {
-      collectionCodeToSet = props.getCollectionCode();
-      collectionLocationNameToSet = props.getCollectionName();
+      if (collectionLocationNameProvided) {
+        collectionLocationNameToSet = props.getCollectionName();
+      }
     } else {
+      collectionCodeToSet = DEFAULT_LOCATION_CODE;
       collectionLocationNameToSet = DEFAULT_LOCATION_NAME;
     }
-
     Specimen.SpecimenCollectionComponent collection = specimen.getCollection();
     CodeableConcept collectionCodeableConcept = collection.getBodySite();
     Coding collectionCoding = collectionCodeableConcept.addCoding();


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8631

## Changes Proposed

If only the code is provided but no collection name it sets the collection code to a default value. 
`collectionCodeToSet = "87100004"`

With this change if the collectionCode is provided with no name it will retain the correct code and not default the value


## Testing

Set a breakpoint at line 595 the first line of the method `setCollectionCodingAndName` then run 
convertToSpecimen_withBronchoalveolarLavageCode_usesProvidedCode
you will notice that collectionCode is not being changed and retains the original value as set in the test. 

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

