### PR TITLE
updated bulk upload to include testorderedCode 

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -545,7 +545,7 @@ public class BulkUploadResultsToFhir {
     var diagnosticReport =
         fhirConverter.convertToDiagnosticReport(
             mapTestResultStatusToFhirValue(row.getTestResultStatus().getValue()),
-            testPerformedCode,
+            testOrderedCode,
             testOrderedLoincLongName,
             testEventId,
             testResultDate,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhirTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhirTest.java
@@ -683,4 +683,36 @@ public class BulkUploadResultsToFhirTest {
     assertThat(syphilisHistoryObservations).hasSize(1);
     assertThat(codeableConceptValues).isEqualTo(List.of("unknown"));
   }
+
+  @Test
+  void diagnosticReport_usesTestOrderedCode() throws IOException {
+    byte[] input = loadCsv("testResultUpload/test-results-upload-all-fields.csv").readAllBytes();
+    FHIRBundleRecord bundleRecord =
+        sut.convertToFhirBundles(new ByteArrayInputStream(input), UUID.randomUUID());
+    var serializedBundles = bundleRecord.serializedBundle();
+    var mappingIterator = getIteratorForCsv(new ByteArrayInputStream(input));
+
+    int index = 0;
+    while (mappingIterator.hasNext()) {
+      var csvRow = mappingIterator.next();
+      var inputOrderedCode = csvRow.get("test_ordered_code");
+      var inputPerformedCode = csvRow.get("test_performed_code");
+
+      var bundle = serializedBundles.get(index++);
+      var deserializedBundle = (Bundle) parser.parseResource(bundle);
+
+      var diagnosticReportEntry =
+          deserializedBundle.getEntry().stream()
+              .filter(entry -> entry.getFullUrl().contains("DiagnosticReport/"))
+              .findFirst()
+              .orElseThrow(
+                  () -> new AssertionError("Expected to find DiagnosticReport, but not found"));
+      var diagnosticReport = (DiagnosticReport) diagnosticReportEntry.getResource();
+
+      var mappedCode = diagnosticReport.getCode().getCoding().stream().findFirst().get().getCode();
+
+      assertThat(mappedCode).isEqualTo(inputOrderedCode);
+      assertThat(inputOrderedCode).isNotEqualTo(inputPerformedCode);
+    }
+  }
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8536

## Changes Proposed

`testOrderedCode `is the expected value in the diagnostic report. I updated the bulk upload to put the ordered code there instead of the performed code.



## Testing

Find a device in the DB of the env that you're testing that has different test performed code from test ordered code and has both LOINC long names populated. I just used one of the COVID devices in this case and edited the test ordered code test performed code to be different numbers as well as adding the LOINC names. I edited one of the csv with the matching equipment model name and test performed code. Perform a bulk results upload with a file using that device's model name and test performed code.

Set the breakpoint at 543  `row.getComment().getValue());` in `BulkUploadResultsToFhir`
After that verify the `testPerformedCode`` testOrderedCode` by typing them into the expression window in the debugger
Then stepover to line 554 run this to expression  `diagnosticReport.getCode().getCoding().get(0).getCode() `to get the code that populated on the bundle you will notice the code is matching the` testOrderedCode`


<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
