### PR TITLE
remove plpgsql extension

### DIFF
--- a/ops/services/postgres_db/main.tf
+++ b/ops/services/postgres_db/main.tf
@@ -78,5 +78,5 @@ resource "azurerm_postgresql_flexible_server_configuration" "postgresql_shared_p
 resource "azurerm_postgresql_flexible_server_configuration" "postgresql_extensions" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.db.id
-  value     = "PG_STAT_STATEMENTS,PGCRYPTO,PLPGSQL"
+  value     = "PG_STAT_STATEMENTS,PGCRYPTO"
 }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

`plpgsql` is no longer an accepted value for the server parameter `azure.extensions`, causing deploys to fail because of an error from the Azure API

It looks like it's pre-installed so we don't need to explicitly add it as an extension.

> In PostgreSQL 9.0 and later, PL/pgSQL is installed by default. However it is still a loadable module, so especially security-conscious administrators could choose to remove it.

https://www.postgresql.org/docs/current/plpgsql-overview.html

## Changes Proposed

Remove it

## Additional Information

[debugging Slack thread](https://skylight-hq.slack.com/archives/C01FPLGB0VD/p1744819920920999)

## Testing

deploy to a lower and see that it builds