### PR TITLE
Fix for bulk uploader datetime validations

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/DateTimeUtils.java
@@ -126,12 +126,13 @@ public class DateTimeUtils {
   private static ZoneId parseDateStringZoneId(String dateString) {
     ZoneId zoneId;
 
-    var timezoneCode = dateString.substring(dateString.lastIndexOf(" ")).trim();
     try {
+      var timezoneCode = dateString.substring(dateString.lastIndexOf(" ")).trim();
       zoneId = parseZoneId(timezoneCode);
-    } catch (DateTimeException e) {
+    } catch (DateTimeException | StringIndexOutOfBoundsException e) {
       zoneId = FALLBACK_TIMEZONE_ID;
     }
+
     return zoneId;
   }
 

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -466,7 +466,11 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message("Invalid date format: " + value + ". Expected format: M/d/yyyy [H:mm] [TZ]")
+              .message(
+                  "Invalid date format: "
+                      + value
+                      + ". Expected format: M/d/yyyy [H:mm] [TZ] for "
+                      + input.getHeader())
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())
               .build());
@@ -485,7 +489,13 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message("Invalid timezone code: " + timezoneCode + " for " + input.getHeader())
+              .message(
+                  "Invalid timezone code: "
+                      + timezoneCode
+                      + " in "
+                      + value
+                      + " for "
+                      + input.getHeader())
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(false)
               .build());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -44,8 +44,9 @@ import static gov.cdc.usds.simplereport.db.model.PersonUtils.SUBSTANCE_ABUSE_TRE
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_LITERAL;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_SNOMED;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getGenderIdentityAbbreviationMap;
-import static gov.cdc.usds.simplereport.utils.DateTimeUtils.convertToZonedDateTime;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.DATE_TIME_FORMATTER;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.hasTimezoneSubstring;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.parseLocalDateTime;
 import static gov.cdc.usds.simplereport.utils.DateTimeUtils.timezoneAbbreviationZoneIdMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
@@ -457,7 +458,7 @@ public class CsvValidatorUtils {
     }
 
     try {
-      convertToZonedDateTime(value);
+      parseLocalDateTime(value, DATE_TIME_FORMATTER);
 
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -92,16 +92,6 @@ public class CsvValidatorUtils {
   private static final String DATE_REGEX =
       "^(0{0,1}[1-9]|1[0-2])\\/(0{0,1}[1-9]|1\\d|2\\d|3[01])\\/\\d{4}$";
 
-  /**
-   * Validates MM/DD/YYYY HH:mm, MM/DD/YYYY H:mm, M/D/YYYY HH:mm OR M/D/YYYY H:mm
-   *
-   * <p>Optional timezone code suffix which is checked as a valid timezone separately
-   *
-   * @see gov.cdc.usds.simplereport.utils.DateTimeUtils
-   */
-  private static final String DATE_TIME_REGEX =
-      "^(0{0,1}[1-9]|1[0-2])\\/(0{0,1}[1-9]|1\\d|2\\d|3[01])\\/\\d{4}( ([0-1]?[0-9]|2[0-3]):[0-5][0-9]( \\S+)?)?$";
-
   private static final String LOINC_CODE_REGEX = "([0-9]{5})-[0-9]";
   private static final String EMAIL_REGEX = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$";
   private static final String SNOMED_REGEX = "(^[0-9]{9}$)|(^[0-9]{15}$)";

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -44,7 +44,9 @@ import static gov.cdc.usds.simplereport.db.model.PersonUtils.SUBSTANCE_ABUSE_TRE
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_LITERAL;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.WORK_ENVIRONMENT_SNOMED;
 import static gov.cdc.usds.simplereport.db.model.PersonUtils.getGenderIdentityAbbreviationMap;
-import static gov.cdc.usds.simplereport.utils.DateTimeUtils.*;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.convertToZonedDateTime;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.hasTimezoneSubstring;
+import static gov.cdc.usds.simplereport.utils.DateTimeUtils.timezoneAbbreviationZoneIdMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 
@@ -460,7 +462,7 @@ public class CsvValidatorUtils {
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));
       }
-    } catch (Exception e) {
+    } catch (DateTimeParseException | StringIndexOutOfBoundsException e) {
       errors.add(
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -460,16 +460,12 @@ public class CsvValidatorUtils {
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));
       }
-    } catch (DateTimeParseException e) {
+    } catch (Exception e) {
       errors.add(
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message(
-                  "Invalid date format: "
-                      + value
-                      + ". Expected format: M/d/yyyy [H:mm] [TZ] for "
-                      + input.getHeader())
+              .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(input.isRequired())
               .build());
@@ -488,13 +484,7 @@ public class CsvValidatorUtils {
           FeedbackMessage.builder()
               .scope(ITEM_SCOPE)
               .fieldHeader(input.getHeader())
-              .message(
-                  "Invalid timezone code: "
-                      + timezoneCode
-                      + " in "
-                      + value
-                      + " for "
-                      + input.getHeader())
+              .message(getInvalidValueErrorMessage(input.getValue(), input.getHeader()))
               .errorType(ResultUploadErrorType.INVALID_DATA)
               .fieldRequired(false)
               .build());

--- a/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtils.java
@@ -65,7 +65,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -456,7 +455,7 @@ public class CsvValidatorUtils {
     }
 
     try {
-      ZonedDateTime dateTime = convertToZonedDateTime(value);
+      convertToZonedDateTime(value);
 
       if (hasTimezoneSubstring(value)) {
         errors.addAll(validateDateTimeZoneCode(input));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/DateTimeUtilsTest.java
@@ -58,6 +58,15 @@ public class DateTimeUtilsTest {
   }
 
   @Test
+  void testConvertToZonedDateTime_withFallbackWithoutTimeOrZoneId() {
+    String dateString = "6/28/2023";
+
+    var actualZonedDateTime = convertToZonedDateTime(dateString);
+    var expectedZonedDateTime = ZonedDateTime.of(2023, 6, 28, 12, 0, 0, 0, ZoneId.of("US/Eastern"));
+    assertThat(actualZonedDateTime).hasToString(expectedZonedDateTime.toString());
+  }
+
+  @Test
   void testConvertToZonedDateTime_withFallbackWithJustString() {
     String dateString = "6/28/2023 14:00";
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -196,7 +196,6 @@ class CsvValidatorUtilsTest {
     invalidDates.add(new ValueOrError("00/01/2023", "date"));
     invalidDates.add(new ValueOrError("1/32/2023", "date"));
     invalidDates.add(new ValueOrError("1/1/23", "date"));
-    invalidDates.add(new ValueOrError("1/1/23", "date"));
     invalidDates.add(new ValueOrError("11/00/2023", "date"));
     invalidDates.add(new ValueOrError("0/31/2023", "date"));
     invalidDates.add(new ValueOrError("10/0/2023", "date"));

--- a/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/validators/CsvValidatorUtilsTest.java
@@ -196,6 +196,7 @@ class CsvValidatorUtilsTest {
     invalidDates.add(new ValueOrError("00/01/2023", "date"));
     invalidDates.add(new ValueOrError("1/32/2023", "date"));
     invalidDates.add(new ValueOrError("1/1/23", "date"));
+    invalidDates.add(new ValueOrError("1/1/23", "date"));
     invalidDates.add(new ValueOrError("11/00/2023", "date"));
     invalidDates.add(new ValueOrError("0/31/2023", "date"));
     invalidDates.add(new ValueOrError("10/0/2023", "date"));
@@ -216,6 +217,7 @@ class CsvValidatorUtilsTest {
     validDateTimes.add(new ValueOrError("01/1/2023 00:00", "datetime"));
     validDateTimes.add(new ValueOrError("1/31/2023 05:50", "datetime"));
     validDateTimes.add(new ValueOrError("12/01/2023 1:01", "datetime"));
+    validDateTimes.add(new ValueOrError("12/01/2023", "datetime"));
     for (var datetime : validDateTimes) {
       assertThat(validateDateTime(datetime)).isEmpty();
     }
@@ -233,6 +235,7 @@ class CsvValidatorUtilsTest {
     invalidDateTimes.add(new ValueOrError("00/00/2023 07:30", "datetime"));
     invalidDateTimes.add(new ValueOrError("0/0/2023 10:23", "datetime"));
     invalidDateTimes.add(new ValueOrError("0/0/202 11:11", "datetime"));
+    invalidDateTimes.add(new ValueOrError("12/1/23", "datetime"));
     for (var datetime : invalidDateTimes) {
       assertThat(validateDateTime(datetime)).hasSize(1);
     }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

See #8721 and #8687 

Resolves https://github.com/CDCgov/prime-simplereport/issues/8253

The last PR did not account for date strings without times or timezones. The result was a customer reported issue where CSV uploads with date strings such as `4/14/2025`, which had previously passed the check, were now failing. See screenshot:

![image](https://github.com/user-attachments/assets/9ac21958-a32a-4592-a1f4-ba20ec2774e6)


## Changes Proposed

The fix uses `parseLocalDateTime` to parse the date times. The previous PR used `convertToZonedDateTime` as a means to indirectly call `parseLocalDateTime` while disregarding the parsed ZoneId.

This PR also modifies `parseDateStringZoneId` in `DateTimeUtils` to fail more gracefully by performing the substring manipulation within the try/catch block, and catching any `StringIndexOutOfBoundsException`s that would occur with a string like `4/14/2025`.

Tests have been updated to account for the changes.

## Additional Information

- parseLocalDateTime

## Testing

You can use this .csv to start, which should fail by default with an invalid timezone for the `specimen_collection_date` column.

[pr_ordering_INVALID_TIMEZONE.csv](https://github.com/user-attachments/files/19571496/pr_ordering_INVALID_TIMEZONE.csv)

You can modify this column to test the other scenarios.

Should fail:
```
01 / 01 / 2023 11 : 11
01/01 /2023 11:11 EST
01/01/2023 11:11 WAT
01/01/23
```

Should pass:
```
    01/01/2023 11:11 EST   
01/01/2023 11:11  
01/01/2023
```

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->