### PR TITLE
Touchpoints.js causing webpack popup on local

### DIFF
--- a/frontend/src/app/commonComponents/Page/Page.tsx
+++ b/frontend/src/app/commonComponents/Page/Page.tsx
@@ -28,7 +28,7 @@ const Page: React.FC<Props> = ({ header, children, isPatientApp }) => {
       script.src =
         process.env.PUBLIC_URL && urlPrefix.includes(process.env.PUBLIC_URL)
           ? `${urlPrefix}static/touchpoints.js`
-          : "touchpoints.js";
+          : `${urlPrefix}touchpoints.js`;
       script.async = true;
 
       document.body.appendChild(script);


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

Fixes this popup in local dev

![Screenshot_20250418_171656](https://github.com/user-attachments/assets/9f45b0eb-3487-488d-99ce-3af510dc4943)

## Changes Proposed

- Apply url prefix when the PUBLIC_URL is not defined in the env

## Additional Information

N/A

## Testing

- Navigate to a page locally while running the dev server like `http://localhost:3000/results/` and make sure you don't see the popup

## Screenshots / Demos

- For large changes, please pair with a designer to ensure changes are as intended

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
