### PR TITLE
FHIR mapping "prefer not to answer" not working in Universal Pipeline

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/PersonUtils.java
@@ -709,7 +709,7 @@ public class PersonUtils {
           "not_hispanic", not_hispanic,
           "not hispanic or latino", not_hispanic,
           "2186-5", not_hispanic,
-          "refused", List.of("U", "unknown"));
+          "refused", List.of(MappingConstants.UNK_CODE, MappingConstants.UNKNOWN_STRING));
 
   public static final String HOSPITAL_LITERAL = "hospital";
   public static final String HOSPITAL_SNOMED = "22232009";

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/FhirConverterTest.java
@@ -354,7 +354,8 @@ class FhirConverterTest {
     return Stream.of(
         arguments("hispanic", ethnicitySystem, "H", "Hispanic or Latino"),
         arguments("not_hispanic", ethnicitySystem, "N", "Not Hispanic or Latino"),
-        arguments("refused", ethnicitySystem, "U", "unknown"),
+        arguments(
+            "refused", ethnicitySystem, MappingConstants.UNK_CODE, MappingConstants.UNKNOWN_STRING),
         arguments("shark", ethnicitySystem, "U", "unknown"));
   }
 


### PR DESCRIPTION
# BACKEND PULL REQUEST

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8629

## Changes Proposed

This is a small change but took some time to identify and could use input from the team if this logic makes sense:


` "prefer not to answer"` maps to` "refused"`. 
The method `convertToEthnicity` in FhirConverter looks up "refused" in  `PersonUtils.ETHNICITY_MAP`. It finds the entry and retrieves the code "U" and the display text "unknown".
The code "U" is not a valid FHIR
The unknown should be "UNK" so I made that change. This only effects the universal pipeline because that is the one where we are doing the FHIRConversion. The covid pipeline has this logic as well but the ethnicity map is created locally within TestEvent and is used for the creation of the CSV and not for use with the FHIR bundle.

The other methods i.e for Race and Gender FhirConversion look correct:

For Race: 

`raceMap.put("refused", MappingConstants.ASKED_BUT_UNKNOWN_CODE); (maps to "ASKU") `

For Gender Identity: 

Mapping: `REFUSED, "asked-declined"` (maps "refused" to "asked-declined")
 retrieves the code `"asked-declined"` sets the value to ` DATA_ABSENT_REASON_CODE_SYSTEM`
which is a valid FHIR value. 



## Testing




<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->

---


