### PR TITLE
Modifying copy from "conduct" to  "report"

### DIFF
--- a/cypress/e2e/04-covid_only_tests.cy.js
+++ b/cypress/e2e/04-covid_only_tests.cy.js
@@ -17,7 +17,7 @@ import {
 const specRunName = "spec04";
 const currentSpecRunVersionName = `${testNumber()}-cypress-${specRunName}`;
 
-describe("Conducting a COVID test from:", () => {
+describe("Reporting a COVID test from:", () => {
   const patient = generatePatient();
   const patientName = patient.fullName;
   const lastName = patient.lastName;
@@ -59,10 +59,10 @@ describe("Conducting a COVID test from:", () => {
     cleanUpPreviousRunSetupData(currentSpecRunVersionName);
   });
 
-  it("conducts a test from the result page", () => {
+  it("reports a test from the result page", () => {
     cy.visit("/");
     cy.get(".usa-nav-container");
-    cy.get("#desktop-conduct-test-nav-link").click();
+    cy.get("#desktop-report-test-nav-link").click();
     cy.get("#search-field-small").type(lastName);
     cy.get(".results-dropdown").contains(lastName);
 

--- a/frontend/src/app/Settings/Users/CreateUserSchema.ts
+++ b/frontend/src/app/Settings/Users/CreateUserSchema.ts
@@ -3,12 +3,12 @@ import { Role } from "../../permissions";
 export const ROLE_OPTIONS: { value: Role; label: string }[] = [
   {
     value: "ENTRY_ONLY",
-    label: "Testing only (conduct tests)",
+    label: "Testing only (report tests)",
   },
   {
     value: "USER",
     label:
-      "Standard user (conduct tests, manage test results and patient profiles)",
+      "Standard user (report tests, manage test results and patient profiles)",
   },
   {
     value: "ADMIN",

--- a/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
+++ b/frontend/src/app/Settings/Users/UserRoleSettingsForm.tsx
@@ -17,18 +17,18 @@ export const ROLES: RoleButton[] = [
     value: "ADMIN",
     label: "Admin",
     labelDescription:
-      "Full access: Conduct tests, bulk upload results, manage test results and patient profiles,  manage account settings, users, and testing facilities. ",
+      "Full access: Report tests, bulk upload results, manage test results and patient profiles,  manage account settings, users, and testing facilities. ",
   },
   {
     value: "USER",
     label: "Standard user",
     labelDescription:
-      "Conduct tests, bulk upload results, manage test results, and patient profiles",
+      "Report tests, bulk upload results, manage test results, and patient profiles",
   },
   {
     value: "ENTRY_ONLY",
     label: "Testing only",
-    labelDescription: "Conduct tests",
+    labelDescription: "Report tests",
   },
 ];
 

--- a/frontend/src/app/analytics/Analytics.tsx
+++ b/frontend/src/app/analytics/Analytics.tsx
@@ -273,7 +273,7 @@ export const Analytics = (props: Props) => {
                   <div className="grid-row grid-gap">
                     <div className="desktop:grid-col-3 tablet:grid-col-6 mobile:grid-col-1">
                       <div className="card display-flex flex-column flex-row">
-                        <h3>Tests conducted</h3>
+                        <h3>Tests reported</h3>
                         <span className="font-sans-3xl text-bold margin-y-auto">
                           {totalTests}
                         </span>

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -127,10 +127,10 @@ const Header: React.FC<{}> = () => {
     },
     {
       url: "/queue",
-      displayText: "Conduct tests",
+      displayText: "Report tests",
       displayPermissions: canViewTestQueue,
       className: getNavItemClassName,
-      key: "conduct-test-nav-link",
+      key: "report-test-nav-link",
     },
     {
       url: "/results",

--- a/frontend/src/app/patients/EditPatient.test.tsx
+++ b/frontend/src/app/patients/EditPatient.test.tsx
@@ -217,7 +217,7 @@ describe("EditPatient", () => {
       );
     });
 
-    it("redirects to test queue on save when coming from Conduct tests page", async () => {
+    it("redirects to test queue on save when coming from Report tests page", async () => {
       const { user } = renderWithRoutes(mockFacilityID, mockPatientID, true);
       await screen.findByText(/Loading/i);
       await waitFor(() =>
@@ -649,11 +649,11 @@ describe("EditPatient", () => {
       expect(
         await screen.findByText("Franecki, Eugenia", { exact: false })
       ).toBeInTheDocument();
-      expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
+      expect(await screen.findByText("Report tests")).toBeInTheDocument();
     });
   });
 
-  describe("edit patient from conduct tests page", () => {
+  describe("edit patient from report tests page", () => {
     let elementToRender: React.ReactElement;
     beforeEach(async () => {
       elementToRender = createGQLWrappedMemoryRouterWithDataApis(
@@ -667,9 +667,9 @@ describe("EditPatient", () => {
         false
       );
     });
-    it("shows Conduct tests link and hides Save and start test button", async () => {
+    it("shows Report tests link and hides Save and start test button", async () => {
       render(elementToRender);
-      expect(await screen.findByText("Conduct tests")).toBeInTheDocument();
+      expect(await screen.findByText("Report tests")).toBeInTheDocument();
       expect(screen.queryByText(PATIENT_TERM_CAP)).not.toBeInTheDocument();
       expect(screen.queryByText("Save and start test")).not.toBeInTheDocument();
       expect(screen.queryByText("Start test")).not.toBeInTheDocument();

--- a/frontend/src/app/patients/EditPatient.tsx
+++ b/frontend/src/app/patients/EditPatient.tsx
@@ -305,7 +305,7 @@ const EditPatient = (props: Props) => {
               to={`/queue?facility=${props.facilityId}`}
               className="margin-left-05"
             >
-              Conduct tests
+              Report tests
             </NavLink>
           ) : (
             <LinkWithQuery to={`/patients`} className="margin-left-05">

--- a/frontend/src/app/supportAdmin/ManageUsers/AdminManageUser.test.tsx
+++ b/frontend/src/app/supportAdmin/ManageUsers/AdminManageUser.test.tsx
@@ -632,7 +632,7 @@ describe("Admin manage users", () => {
 
       await screen.findByText(/user role/i);
       const roleRadioBtn = await screen.findByRole("radio", {
-        name: /standard user conduct tests, bulk upload results, manage test results, and patient profiles/i,
+        name: /standard user report tests, bulk upload results, manage test results, and patient profiles/i,
       });
       await waitFor(() => expect(roleRadioBtn).toHaveAttribute("checked", ""));
     });
@@ -656,7 +656,7 @@ describe("Admin manage users", () => {
       await user.click(orgAccessTab);
 
       const roleRadioBtn = await screen.findByRole("radio", {
-        name: /standard user conduct tests, bulk upload results, manage test results, and patient profiles/i,
+        name: /standard user report tests, bulk upload results, manage test results, and patient profiles/i,
       });
       await waitFor(() => expect(roleRadioBtn).toHaveAttribute("checked", ""));
 

--- a/frontend/src/app/supportAdmin/PendingOrganizations/modals/VerifyPendingOrganizationConfirmationModal.tsx
+++ b/frontend/src/app/supportAdmin/PendingOrganizations/modals/VerifyPendingOrganizationConfirmationModal.tsx
@@ -35,8 +35,8 @@ const VerifyPendingOrganizationConfirmationModal: React.FC<
         Are you sure you want to verify <strong>{organization?.name}</strong>?
       </p>
       <p>
-        Doing so will allow the organization to create an account and conduct
-        and submit tests.
+        Doing so will allow the organization to create an account and report
+        tests.
       </p>
       <div className="border-top border-base-lighter margin-x-neg-205"></div>
       <Modal.Footer

--- a/frontend/src/app/testQueue/TestQueue.tsx
+++ b/frontend/src/app/testQueue/TestQueue.tsx
@@ -263,7 +263,7 @@ const TestQueue: React.FC<Props> = ({ activeFacilityId }) => {
   return (
     <div className="prime-home flex-1">
       <div className="grid-container">
-        <h1 className="font-sans-lg">Conduct tests</h1>
+        <h1 className="font-sans-lg">Report tests</h1>
         <div className="position-relative">
           <AddToQueueSearch
             refetchQueue={refetch}

--- a/frontend/src/app/testQueue/TestQueueContainer.tsx
+++ b/frontend/src/app/testQueue/TestQueueContainer.tsx
@@ -4,7 +4,7 @@ import { useDocumentTitle } from "../utils/hooks";
 import TestQueue from "./TestQueue";
 
 const TestQueueContainer = () => {
-  useDocumentTitle("Conduct test");
+  useDocumentTitle("Report test");
   const [facility] = useSelectedFacility();
   const activeFacilityId = facility?.id;
 

--- a/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
+++ b/frontend/src/app/testQueue/__snapshots__/TestQueue.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TestQueue should render the test queue 1`] = `
       <h1
         class="font-sans-lg"
       >
-        Conduct tests
+        Report tests
       </h1>
       <div
         class="position-relative"

--- a/frontend/src/app/testResults/viewResults/ResultsTable.tsx
+++ b/frontend/src/app/testResults/viewResults/ResultsTable.tsx
@@ -32,7 +32,7 @@ export function formatTestResultAriaLabel(result: Result) {
     result.correctionStatus === "ORIGINAL"
       ? moment(result.dateTested).format(TEST_RESULT_ARIA_TIME_FORMAT)
       : moment(result.dateUpdated).format(TEST_RESULT_ARIA_TIME_FORMAT);
-  return `Click for more detailed results information for ${patientFullName} conducted on ${displayPatientDate}`;
+  return `Click for more detailed results information for ${patientFullName} reported on ${displayPatientDate}`;
 }
 
 export const generateTableHeaders = (hasFacility: boolean) => (

--- a/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
+++ b/frontend/src/app/testResults/viewResults/__snapshots__/TestResultsList.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Gerard, Sam G conducted on March 19th 2021, 7:27:21 pm"
+                  aria-label="Click for more detailed results information for Gerard, Sam G reported on March 19th 2021, 7:27:21 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >
@@ -544,7 +544,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Colleer, Barde X conducted on March 18th 2021, 7:27:21 pm"
+                  aria-label="Click for more detailed results information for Colleer, Barde X reported on March 18th 2021, 7:27:21 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >
@@ -626,7 +626,7 @@ exports[`TestResultsList should render a list of tests 1`] = `
                 class="patient-name-cell"
               >
                 <button
-                  aria-label="Click for more detailed results information for Cragell, Barb Whitaker conducted on March 17th 2021, 7:27:23 pm"
+                  aria-label="Click for more detailed results information for Cragell, Barb Whitaker reported on March 17th 2021, 7:27:23 pm"
                   class="usa-button usa-button--unstyled sr-link__primary"
                   type="button"
                 >


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## https://github.com/CDCgov/prime-simplereport/issues/8689

- Changes copy from "conduct" to "report" wherever applicable so as to indicate that the app will be more of a reporting tool than a conducting tool moving forward. This also prevents some confusion for current users.

## Testing

- Test on dev5
 