### PR TITLE
Add HSTS rule

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -184,6 +184,7 @@ resource "azurerm_application_gateway" "www_redirect" {
     rule_type                   = "Basic"
     http_listener_name          = "${local.name}-http"
     redirect_configuration_name = "httpsRedirect"
+    rewrite_rule_set_name       = "HSTS_ReWrite"
   }
 
   redirect_configuration {
@@ -202,6 +203,7 @@ resource "azurerm_application_gateway" "www_redirect" {
     rule_type                   = "Basic"
     http_listener_name          = "${local.name}-https"
     redirect_configuration_name = "wwwRedirect"
+    rewrite_rule_set_name       = "HSTS_ReWrite"
   }
 
   redirect_configuration {
@@ -368,6 +370,7 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
     rule_type                   = "Basic"
     http_listener_name          = "${local.name}-http"
     redirect_configuration_name = "httpsRedirect"
+    rewrite_rule_set_name       = "HSTS_ReWrite"
   }
 
   redirect_configuration {
@@ -386,6 +389,7 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
     rule_type                   = "Basic"
     http_listener_name          = "${local.name}-https"
     redirect_configuration_name = "wwwRedirect"
+    rewrite_rule_set_name       = "HSTS_ReWrite"
   }
 
   redirect_configuration {

--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -401,11 +401,11 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
     name = "HSTS_ReWrite"
 
     rewrite_rule {
-      name = "HSTS_Rewrite"
+      name          = "HSTS_Rewrite"
       rule_sequence = "100"
 
       request_header_configuration {
-        header_name = "Strict-Transport-Security"
+        header_name  = "Strict-Transport-Security"
         header_value = "31536000"
       }
     }

--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -397,6 +397,20 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
     target_url           = "https://www.simplereport.gov"
   }
 
+  rewrite_rule_set {
+    name = "HSTS_ReWrite"
+
+    rewrite_rule {
+      name = "HSTS_Rewrite"
+      rule_sequence = "100"
+
+      request_header_configuration {
+        header_name = "Strict-Transport-Security"
+        header_value = "31536000"
+      }
+    }
+  }
+
   depends_on = [
     azurerm_key_vault_access_policy.cdc_gov_redirect
   ]

--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -406,7 +406,7 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
 
       request_header_configuration {
         header_name  = "Strict-Transport-Security"
-        header_value = "31536000"
+        header_value = "31536000; includeSubDomains"
       }
     }
   }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- On April 28, CSPO admins manually enabled the Strict-Transport-Security header in Azure. However, since this change was made outside of Terraform, it was overwritten during the next infrastructure deployment. This PR incorporates that manual change into the Terraform configuration to ensure the Strict-Transport-Security header is preserved in future deployments.

## Changes Proposed

- Added a `rewrite_rule_set` named `HSTS_ReWrite`

- Configured a rewrite rule with the same name that adds the following response header:
`Strict-Transport-Security: max-age=31536000; includeSubDomains`

## Testing

- Used Terraform Plan to confirm changes will add the rewrite [rule](https://github.com/CDCgov/prime-simplereport/actions/runs/14982524765/job/42089748680#step:8:370)
- For reference this is the Github [actions](https://github.com/CDCgov/prime-simplereport/actions/runs/14780835113/job/41499318347#step:3:11769) that initially removed the rewrite. You'll noticed this does not have `includeSubDomains`, this was added to match the configs the CSPO provided during our meeting as the desired state for this rule. See screenshot for reference 
- 
![successful_scan](https://github.com/user-attachments/assets/41149768-3fff-476b-8027-f8ded60f07a6)
