### PR TITLE
Continued HSTS header work

### DIFF
--- a/ops/prod/app_gateway_url_redirects.tf
+++ b/ops/prod/app_gateway_url_redirects.tf
@@ -213,7 +213,7 @@ resource "azurerm_application_gateway" "www_redirect" {
       name          = "HSTS_Rewrite"
       rule_sequence = "100"
 
-      request_header_configuration {
+      response_header_configuration {
         header_name  = "Strict-Transport-Security"
         header_value = "31536000; includeSubDomains"
       }
@@ -422,7 +422,7 @@ resource "azurerm_application_gateway" "cdc_gov_redirect" {
       name          = "HSTS_Rewrite"
       rule_sequence = "100"
 
-      request_header_configuration {
+      response_header_configuration {
         header_name  = "Strict-Transport-Security"
         header_value = "31536000; includeSubDomains"
       }


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue


1. For app gateway named simple-report-cdc-gov-redirect I deployed the HSTS rewrite rule to the `request` header, add the rule to the `response` header instead
2.  For the app gateway named `simple-report-app-gateway,` the `simple-report-redirec`t rule does not have the HSTS rule applied to it
3. For app gateway named `simple-report-www-redirect`  I deployed the HSTS rewrite rule to the `request` header, add the rule to the `response` header instead

## Changes Proposed

- Detailed explanation of what this PR should do

## Additional Information

- decisions that were made
- notice of future work that needs to be done

## Testing

- How should reviewers verify this PR?

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->

