### PR TITLE
Add CODEOWNERS and remove Dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the team on this line will be requested for
+# review when someone opens a pull request.
+*                   @CDCgov/simplereport-engineeringreviews
+
+# docker
+Dockerfile          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+Dockerfile.*        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# github-actions
+workflows/*         @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# gradle
+build.gradle        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+gradle.lockfile     @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# npm
+package.json        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+yarn.lock           @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# terraform
+.terraform.lock.hcl @CDCgov/simplereport-devsecops
+_config.tf          @CDCgov/simplereport-devsecops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/backend"
@@ -17,9 +14,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/backend/db-setup"
@@ -27,9 +21,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/cypress"
@@ -37,9 +28,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
@@ -47,9 +35,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/nginx"
@@ -57,9 +42,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "docker"
     directory: "/ops/services/container_instances/db_client/image"
@@ -67,9 +49,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -77,9 +56,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "gradle"
     directory: "/backend"
@@ -87,9 +63,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -97,9 +70,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -107,9 +77,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
     groups:
       eslint:
         patterns:
@@ -138,9 +105,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "npm"
     directory: "/ops/services/app_functions/report_stream_batched_publisher/functions"
@@ -148,9 +112,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "terraform"
     directory: "/ops/global"
@@ -158,8 +119,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
 
   - package-ecosystem: "terraform"
     directory: "/ops/services/okta-global"
@@ -167,8 +126,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
 
   - package-ecosystem: "terraform"
     directory: "/ops/test"
@@ -176,8 +133,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
 
   - package-ecosystem: "terraform"
     directory: "/ops/test/persistent"
@@ -185,5 +140,3 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Why?

The reviewers configuration is [being deprecated](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/). Switching to using CODEOWNERS and also adding auto-assign for non-dependency reviews as well.

## Changes proposed

New team created for dependency reviews: https://github.com/orgs/CDCgov/teams/simplereport-dependencyreviews. Once this PR is merged, I will update the existing team `engineeringreviews` to auto-assign 7 people (this is the max).

Expected behavior is for dependencies we auto-assign 3 people from the eng team but for all other PRs we auto-assign everyone. As long as we don't get over 7 engineers this solution will work. 🙃  If we do and we still want this functionality at that time, we could figure out some kind of workaround by creating 2 teams.

Known issue is any updates to files that aren't necessarily dependency updates might still get assigned as if they were if the PR doesn't touch any other file (e.g. changing/creating a GitHub action). Don't know a workaround for this. Evidence it's at least not obvious because somebody else is wondering too: https://github.com/orgs/community/discussions/159006

## Testing

Test PRs with auto-assign working [here](https://github.com/CDCgov/prime-simplereport/pull/8855) and [here](https://github.com/CDCgov/prime-simplereport/pull/8856)