### PR TITLE
Handle null values for yes/no/unk fields in bulk upload FHIR converter

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToFhir.java
@@ -476,7 +476,7 @@ public class BulkUploadResultsToFhir {
     }
 
     String employedInHealthcareValue = row.getEmployedInHealthcare().getValue();
-    if (valueIsYesNoOrUnknown(employedInHealthcareValue.toLowerCase())) {
+    if (valueIsYesNoOrUnknown(employedInHealthcareValue)) {
       Boolean employedInHealthcare =
           yesNoUnknownToBooleanMap.get(employedInHealthcareValue.toLowerCase());
       aoeObservations.add(
@@ -497,7 +497,7 @@ public class BulkUploadResultsToFhir {
     }
 
     String hospitalizedValue = row.getHospitalized().getValue();
-    if (valueIsYesNoOrUnknown(hospitalizedValue.toLowerCase())) {
+    if (valueIsYesNoOrUnknown(hospitalizedValue)) {
       Boolean hospitalized = yesNoUnknownToBooleanMap.get(hospitalizedValue.toLowerCase());
       aoeObservations.add(
           fhirConverter.convertToAOEYesNoUnkObservation(
@@ -509,7 +509,7 @@ public class BulkUploadResultsToFhir {
     }
 
     String icuValue = row.getIcu().getValue();
-    if (valueIsYesNoOrUnknown(icuValue.toLowerCase())) {
+    if (valueIsYesNoOrUnknown(icuValue)) {
       Boolean hospitalized = yesNoUnknownToBooleanMap.get(icuValue.toLowerCase());
       aoeObservations.add(
           fhirConverter.convertToAOEYesNoUnkObservation(
@@ -521,7 +521,7 @@ public class BulkUploadResultsToFhir {
     }
 
     String residentCongregateSettingValue = row.getResidentCongregateSetting().getValue();
-    if (valueIsYesNoOrUnknown(residentCongregateSettingValue.toLowerCase())) {
+    if (valueIsYesNoOrUnknown(residentCongregateSettingValue)) {
       Boolean residesInCongregateSetting =
           yesNoUnknownToBooleanMap.get(residentCongregateSettingValue.toLowerCase());
       String residenceTypeValue = row.getResidenceType().getValue();


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

Support is seeing complaints of errors with the bulk upload tool. Users get the "server error" message. See [thread](https://skylight-hq.slack.com/archives/C05M1B22AHY/p1748531712872959).

Stack trace for the error for the org shows:
```
java.lang.NullPointerException: Cannot invoke "String.toLowerCase()" because "employedInHealthcareValue" is null
	at gov.cdc.usds.simplereport.utils.BulkUploadResultsToFhir.convertRowToFhirBundle(BulkUploadResultsToFhir.java:479)
```

## Changes Proposed

`valueIsYesNoOrUnknown` already converts to lowercase within the method, so no need to do it when passing the value in
This also skips trying to convert null value to lower case

## Additional Information

Follow up PR with test coverage coming soon

## Testing
Upload a file in an env on `main` (e.g. `test`) without any or all of these optional columns: `employed_in_healthcare`, `hospitalized`, `icu`, `resident_congregate_setting`. File should fail with server error.
Upload file again in an env running this branch and verify file upload is successful.