### PR TITLE
Add review and submit table to form

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/universalreporting/SpecimenInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/universalreporting/SpecimenInput.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SpecimenInput {
   private final String snomedTypeCode;
+  private final String snomedDisplay;
   private final Date collectionDate;
   private final Date receivedDate;
   private final String collectionBodySiteName;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/model/universalreporting/TestDetailsInput.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/model/universalreporting/TestDetailsInput.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public class TestDetailsInput {
   private final String condition;
   private final String testOrderLoinc;
+  private final String testOrderDisplayName;
   private final String testPerformedLoinc;
   private final String testPerformedLoincLongCommonName;
   private final ResultScaleType resultType;

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -492,6 +492,7 @@ input FacilityReportInput {
 
 input SpecimenInput {
   snomedTypeCode: String!
+  snomedDisplayName: String
   collectionDate: DateTime
   receivedDate: DateTime
   collectionBodySiteName: String
@@ -501,6 +502,7 @@ input SpecimenInput {
 input TestDetailsInput {
   condition: String!
   testOrderLoinc: String!
+  testOrderDisplayName: String
   testPerformedLoinc: String!
   testPerformedLoincLongCommonName: String
   resultType: ResultScaleType!

--- a/frontend/src/app/universalReporting/FacilityFormSection.tsx
+++ b/frontend/src/app/universalReporting/FacilityFormSection.tsx
@@ -35,6 +35,7 @@ const FacilityFormSection = ({
             label={"Facility name"}
             onChange={(e) => setFacility({ ...facility, name: e.target.value })}
             value={facility.name}
+            required
           ></TextInput>
         </div>
       </div>
@@ -45,6 +46,7 @@ const FacilityFormSection = ({
             label={"Facility CLIA number"}
             value={facility.clia}
             onChange={(e) => setFacility({ ...facility, clia: e.target.value })}
+            required
           ></TextInput>
         </div>
       </div>

--- a/frontend/src/app/universalReporting/LabReportForm.tsx
+++ b/frontend/src/app/universalReporting/LabReportForm.tsx
@@ -270,10 +270,7 @@ const LabReportForm = () => {
       specimenFieldsMissing ||
       testDetailFieldsMissing
     ) {
-      showError(
-        "Required fields are marked with an asterisk (*)",
-        "Missing required fields"
-      );
+      showError("Please fill out required fields", "Missing required fields");
       return false;
     }
     return true;

--- a/frontend/src/app/universalReporting/LabReportFormUtils.tsx
+++ b/frontend/src/app/universalReporting/LabReportFormUtils.tsx
@@ -15,7 +15,7 @@ export const defaultPatientReportInputState: PatientReportInput = {
   city: "",
   country: "USA",
   county: "",
-  dateOfBirth: "",
+  dateOfBirth: "01/01/1990",
   email: "",
   ethnicity: "",
   firstName: "",

--- a/frontend/src/app/universalReporting/LabReportFormUtils.tsx
+++ b/frontend/src/app/universalReporting/LabReportFormUtils.tsx
@@ -8,6 +8,8 @@ import {
   SpecimenBodySite,
   SpecimenInput,
 } from "../../generated/graphql";
+import { RadioGroupOptions } from "../commonComponents/RadioGroup";
+import { TEST_RESULTS_SNOMED } from "../testResults/constants";
 
 export const defaultPatientReportInputState: PatientReportInput = {
   city: "",
@@ -34,11 +36,11 @@ export const defaultProviderReportInputState: ProviderReportInput = {
   city: "",
   county: "",
   email: "",
-  firstName: "",
-  lastName: "",
+  firstName: "Count",
+  lastName: "Dracula",
   middleName: "",
-  npi: "",
-  phone: "",
+  npi: "0000000000",
+  phone: "(555) 555-5555",
   state: "",
   street: "",
   streetTwo: "",
@@ -47,16 +49,16 @@ export const defaultProviderReportInputState: ProviderReportInput = {
 };
 
 export const defaultFacilityReportInputState: FacilityReportInput = {
-  city: "",
-  clia: "",
-  county: "",
+  city: "Jefferson City",
+  clia: "00D000000000",
+  county: "Cole",
   email: "",
-  name: "",
-  phone: "",
-  state: "",
-  street: "",
+  name: "Dracula",
+  phone: "(555) 555-5555",
+  state: "MO",
+  street: "201 W Capitol Ave",
   streetTwo: "",
-  zipCode: "",
+  zipCode: "65101-6809",
 };
 
 export const defaultSpecimenReportInputState: SpecimenInput = {
@@ -79,6 +81,21 @@ export const mapScaleDisplayToResultScaleType = (scaleDisplay: string) => {
       return ResultScaleType.Ordinal;
   }
 };
+
+export const ordinalResultOptions: RadioGroupOptions<string> = [
+  {
+    value: TEST_RESULTS_SNOMED.POSITIVE,
+    label: `Positive (+)`,
+  },
+  {
+    value: TEST_RESULTS_SNOMED.NEGATIVE,
+    label: `Negative (-)`,
+  },
+  {
+    value: TEST_RESULTS_SNOMED.UNDETERMINED,
+    label: `Undetermined`,
+  },
+];
 
 export const buildSpecimenOptionList = (specimens: Specimen[]) => {
   const options = specimens.map((specimen) => {

--- a/frontend/src/app/universalReporting/ProviderFormSection.tsx
+++ b/frontend/src/app/universalReporting/ProviderFormSection.tsx
@@ -37,6 +37,7 @@ const ProviderFormSection = ({
               setProvider({ ...provider, firstName: e.target.value })
             }
             value={provider.firstName}
+            required
           ></TextInput>
         </div>
         <div className="grid-col-4">
@@ -61,6 +62,7 @@ const ProviderFormSection = ({
               setProvider({ ...provider, lastName: e.target.value })
             }
             value={provider.lastName}
+            required
           ></TextInput>
         </div>
         <div className="grid-col-4">
@@ -82,6 +84,7 @@ const ProviderFormSection = ({
             label={"Provider NPI number"}
             value={provider.npi}
             onChange={(e) => setProvider({ ...provider, npi: e.target.value })}
+            required
           ></TextInput>
         </div>
       </div>

--- a/frontend/src/app/universalReporting/ReviewFormSection.scss
+++ b/frontend/src/app/universalReporting/ReviewFormSection.scss
@@ -1,0 +1,14 @@
+.review-form {
+  table,
+  th,
+  td {
+    border-top: none !important;
+    border-bottom: 1px solid #dfe1e2 !important;
+    line-height: 1;
+  }
+
+  td:first-child {
+    width: 18rem;
+    padding-left: 0;
+  }
+}

--- a/frontend/src/app/universalReporting/ReviewFormSection.tsx
+++ b/frontend/src/app/universalReporting/ReviewFormSection.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Table } from "@trussworks/react-uswds";
-import _ from "lodash";
 import moment from "moment/moment";
+import { startCase } from "lodash";
 
 import {
   FacilityReportInput,
   PatientReportInput,
   ProviderReportInput,
+  ResultScaleType,
   SpecimenInput,
   TestDetailsInput,
 } from "../../generated/graphql";
@@ -27,7 +28,28 @@ type ReviewFormSectionProps = {
 interface RowData {
   name: string;
   value: string | null | undefined;
+  required?: boolean;
 }
+
+const formatPatientEthnicity = (ethnicity: string) =>
+  startCase(ethnicity?.replaceAll("_", " ").toLowerCase());
+
+const formatPatientRace = (race: string) =>
+  RACE_VALUES.find((r) => r.value === race)?.label;
+
+const formatPatientTribalAffiliation = (tribalAffiliation: string) =>
+  TRIBAL_AFFILIATION_VALUES.find((tribe) => tribe.value === tribalAffiliation)
+    ?.label;
+
+const formatTestResultValue = (testDetail: TestDetailsInput) => {
+  if (testDetail.resultType === ResultScaleType.Ordinal) {
+    const ordinalLabel = ordinalResultOptions.find(
+      (option) => option.value === testDetail.resultValue
+    )?.label;
+    return ordinalLabel ?? "Unknown ordinal result";
+  }
+  return testDetail.resultValue;
+};
 
 const ReviewFormSection = ({
   facility,
@@ -40,10 +62,12 @@ const ReviewFormSection = ({
     {
       name: "Facility name",
       value: facility.name,
+      required: true,
     },
     {
       name: "CLIA number",
       value: facility.clia,
+      required: true,
     },
     {
       name: "Street address",
@@ -83,6 +107,7 @@ const ReviewFormSection = ({
     {
       name: "First name",
       value: provider.firstName,
+      required: true,
     },
     {
       name: "Middle name",
@@ -91,6 +116,7 @@ const ReviewFormSection = ({
     {
       name: "Last name",
       value: provider.lastName,
+      required: true,
     },
     {
       name: "Suffix",
@@ -99,6 +125,7 @@ const ReviewFormSection = ({
     {
       name: "NPI",
       value: provider.npi,
+      required: true,
     },
     {
       name: "Street address",
@@ -138,6 +165,7 @@ const ReviewFormSection = ({
     {
       name: "First name",
       value: patient.firstName,
+      required: true,
     },
     {
       name: "Middle name",
@@ -146,6 +174,7 @@ const ReviewFormSection = ({
     {
       name: "Last name",
       value: patient.lastName,
+      required: true,
     },
     {
       name: "Suffix",
@@ -154,24 +183,23 @@ const ReviewFormSection = ({
     {
       name: "Date of birth",
       value: patient.dateOfBirth,
+      required: true,
     },
     {
       name: "Sex",
-      value: _.startCase(patient.sex ?? ""),
+      value: startCase(patient.sex ?? ""),
     },
     {
       name: "Race",
-      value: RACE_VALUES.find((r) => r.value === patient.race)?.label,
+      value: formatPatientRace(patient.race ?? ""),
     },
     {
       name: "Ethnicity",
-      value: _.startCase(patient.ethnicity?.replaceAll("_", " ").toLowerCase()),
+      value: formatPatientEthnicity(patient.ethnicity ?? ""),
     },
     {
       name: "Tribal affiliation",
-      value: TRIBAL_AFFILIATION_VALUES.find(
-        (tribe) => tribe.value === patient.tribalAffiliation
-      )?.label,
+      value: formatPatientTribalAffiliation(patient.tribalAffiliation ?? ""),
     },
     {
       name: "Street address",
@@ -211,10 +239,12 @@ const ReviewFormSection = ({
     {
       name: "Test order",
       value: testDetailsList[0]?.testOrderDisplayName,
+      required: true,
     },
     {
       name: "Specimen type",
       value: specimen.snomedDisplayName,
+      required: true,
     },
     {
       name: "Collection date",
@@ -244,22 +274,22 @@ const ReviewFormSection = ({
         data: [
           {
             name: "Test result value",
-            value:
-              ordinalResultOptions.find(
-                (option) => option.value === testDetail.resultValue
-              )?.label ?? "Unknown ordinal result",
+            value: formatTestResultValue(testDetail),
+            required: true,
           },
           {
             name: "Result date",
             value: !!testDetail.resultDate
               ? formatDate(moment(testDetail.resultDate).toDate())
               : "",
+            required: true,
           },
           {
             name: "Result time",
             value: !!testDetail.resultDate
               ? moment(testDetail.resultDate).format("HH:mm")
               : "",
+            required: true,
           },
           {
             name: "Notes",
@@ -314,7 +344,12 @@ const ReviewFormSection = ({
               <tbody>
                 {data.map((row) => (
                   <tr key={`${keyPrefix}-data-row-${row.name}`}>
-                    <td className={"text-bold"}>{row.name}</td>
+                    <td className={"text-bold"}>
+                      {row.name}{" "}
+                      {row.required && (
+                        <span className={"usa-hint--required"}>*</span>
+                      )}
+                    </td>
                     <td>{row.value ?? ""}</td>
                   </tr>
                 ))}

--- a/frontend/src/app/universalReporting/ReviewFormSection.tsx
+++ b/frontend/src/app/universalReporting/ReviewFormSection.tsx
@@ -1,22 +1,329 @@
 import React from "react";
+import { Table } from "@trussworks/react-uswds";
+import _ from "lodash";
+import moment from "moment/moment";
 
-import { FacilityReportInput } from "../../generated/graphql";
+import {
+  FacilityReportInput,
+  PatientReportInput,
+  ProviderReportInput,
+  SpecimenInput,
+  TestDetailsInput,
+} from "../../generated/graphql";
+import { formatDate } from "../utils/date";
+import { RACE_VALUES, TRIBAL_AFFILIATION_VALUES } from "../constants";
+
+import { ordinalResultOptions } from "./LabReportFormUtils";
+import "./ReviewFormSection.scss";
 
 type ReviewFormSectionProps = {
   facility: FacilityReportInput;
+  provider: ProviderReportInput;
+  patient: PatientReportInput;
+  specimen: SpecimenInput;
+  testDetailsList: TestDetailsInput[];
 };
 
-const ReviewFormSection = ({ facility }: ReviewFormSectionProps) => {
+interface RowData {
+  name: string;
+  value: string | null | undefined;
+}
+
+const ReviewFormSection = ({
+  facility,
+  provider,
+  patient,
+  specimen,
+  testDetailsList,
+}: ReviewFormSectionProps) => {
+  const facilityTableInfo: RowData[] = [
+    {
+      name: "Facility name",
+      value: facility.name,
+    },
+    {
+      name: "CLIA number",
+      value: facility.clia,
+    },
+    {
+      name: "Street address",
+      value: facility.street,
+    },
+    {
+      name: "Apt, suite, etc",
+      value: facility.streetTwo,
+    },
+    {
+      name: "City",
+      value: facility.city,
+    },
+    {
+      name: "County",
+      value: facility.county,
+    },
+    {
+      name: "State",
+      value: facility.state,
+    },
+    {
+      name: "ZIP code",
+      value: facility.zipCode,
+    },
+    {
+      name: "Phone",
+      value: facility.phone,
+    },
+    {
+      name: "Email",
+      value: facility.email,
+    },
+  ];
+
+  const providerTableInfo: RowData[] = [
+    {
+      name: "First name",
+      value: provider.firstName,
+    },
+    {
+      name: "Middle name",
+      value: provider.middleName,
+    },
+    {
+      name: "Last name",
+      value: provider.lastName,
+    },
+    {
+      name: "Suffix",
+      value: provider.suffix,
+    },
+    {
+      name: "NPI",
+      value: provider.npi,
+    },
+    {
+      name: "Street address",
+      value: provider.street,
+    },
+    {
+      name: "Apt, suite, etc",
+      value: provider.streetTwo,
+    },
+    {
+      name: "City",
+      value: provider.city,
+    },
+    {
+      name: "County",
+      value: provider.county,
+    },
+    {
+      name: "State",
+      value: provider.state,
+    },
+    {
+      name: "ZIP code",
+      value: provider.zipCode,
+    },
+    {
+      name: "Phone",
+      value: provider.phone,
+    },
+    {
+      name: "Email",
+      value: provider.email,
+    },
+  ];
+
+  const patientTableInfo: RowData[] = [
+    {
+      name: "First name",
+      value: patient.firstName,
+    },
+    {
+      name: "Middle name",
+      value: patient.middleName,
+    },
+    {
+      name: "Last name",
+      value: patient.lastName,
+    },
+    {
+      name: "Suffix",
+      value: patient.suffix,
+    },
+    {
+      name: "Date of birth",
+      value: patient.dateOfBirth,
+    },
+    {
+      name: "Sex",
+      value: _.startCase(patient.sex ?? ""),
+    },
+    {
+      name: "Race",
+      value: RACE_VALUES.find((r) => r.value === patient.race)?.label,
+    },
+    {
+      name: "Ethnicity",
+      value: _.startCase(patient.ethnicity?.replaceAll("_", " ").toLowerCase()),
+    },
+    {
+      name: "Tribal affiliation",
+      value: TRIBAL_AFFILIATION_VALUES.find(
+        (tribe) => tribe.value === patient.tribalAffiliation
+      )?.label,
+    },
+    {
+      name: "Street address",
+      value: patient.street,
+    },
+    {
+      name: "Apt, suite, etc",
+      value: patient.streetTwo,
+    },
+    {
+      name: "City",
+      value: patient.city,
+    },
+    {
+      name: "County",
+      value: patient.county,
+    },
+    {
+      name: "State",
+      value: patient.state,
+    },
+    {
+      name: "ZIP code",
+      value: patient.zipCode,
+    },
+    {
+      name: "Phone",
+      value: patient.phone,
+    },
+    {
+      name: "Email",
+      value: patient.email,
+    },
+  ];
+
+  const testOrderTableData: RowData[] = [
+    {
+      name: "Test order",
+      value: testDetailsList[0]?.testOrderDisplayName,
+    },
+    {
+      name: "Specimen type",
+      value: specimen.snomedDisplayName,
+    },
+    {
+      name: "Collection date",
+      value: !!specimen.collectionDate
+        ? formatDate(moment(specimen.collectionDate).toDate())
+        : "",
+    },
+    {
+      name: "Collection time",
+      value: !!specimen.collectionDate
+        ? moment(specimen.collectionDate).format("HH:mm")
+        : "",
+    },
+    {
+      name: "Specimen collection body site",
+      value: specimen.collectionBodySiteName,
+    },
+  ];
+
+  const individualTestResultTableData = testDetailsList.map(
+    (testDetail, index) => {
+      return {
+        title: `Result ${index + 1} - ${
+          testDetail.testPerformedLoincLongCommonName
+        }`,
+        keyPrefix: `test-result-${testDetail.testPerformedLoinc}`,
+        data: [
+          {
+            name: "Test result value",
+            value:
+              ordinalResultOptions.find(
+                (option) => option.value === testDetail.resultValue
+              )?.label ?? "Unknown ordinal result",
+          },
+          {
+            name: "Result date",
+            value: !!testDetail.resultDate
+              ? formatDate(moment(testDetail.resultDate).toDate())
+              : "",
+          },
+          {
+            name: "Result time",
+            value: !!testDetail.resultDate
+              ? moment(testDetail.resultDate).format("HH:mm")
+              : "",
+          },
+          {
+            name: "Notes",
+            value: testDetail.resultInterpretation,
+          },
+        ] as RowData[],
+      };
+    }
+  );
+
+  const reviewSectionData = [
+    {
+      title: "Facility information",
+      keyPrefix: "facility",
+      data: facilityTableInfo,
+    },
+    {
+      title: "Provider information",
+      keyPrefix: "provider",
+      data: providerTableInfo,
+    },
+    {
+      title: "Patient information",
+      keyPrefix: "patient",
+      data: patientTableInfo,
+    },
+    {
+      title: "Test results",
+      keyPrefix: "test-order",
+      data: testOrderTableData,
+    },
+    ...individualTestResultTableData,
+  ];
+
   return (
-    <>
-      <div className="grid-row">
-        <div className="grid-col-auto">
-          <h2 className={"font-sans-lg"}>
-            Placeholder for reviewing form data from {facility.name}
-          </h2>
+    <div className="review-form">
+      {reviewSectionData.map(({ title, keyPrefix, data }) => (
+        <div className="grid-row" key={`review-section-${keyPrefix}`}>
+          <div className="grid-col">
+            <h2 className={"font-sans-lg"}>{title}</h2>
+            <Table bordered={false} fullWidth={true}>
+              <thead>
+                <tr>
+                  <th scope="col" className={"usa-sr-only"}>
+                    Field
+                  </th>
+                  <th scope="col" className={"usa-sr-only"}>
+                    Value
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((row) => (
+                  <tr key={`${keyPrefix}-data-row-${row.name}`}>
+                    <td className={"text-bold"}>{row.name}</td>
+                    <td>{row.value ?? ""}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
         </div>
-      </div>
-    </>
+      ))}
+    </div>
   );
 };
 

--- a/frontend/src/app/universalReporting/ReviewFormSection.tsx
+++ b/frontend/src/app/universalReporting/ReviewFormSection.tsx
@@ -28,7 +28,6 @@ type ReviewFormSectionProps = {
 interface RowData {
   name: string;
   value: string | null | undefined;
-  required?: boolean;
 }
 
 const formatPatientEthnicity = (ethnicity: string) =>
@@ -62,12 +61,10 @@ const ReviewFormSection = ({
     {
       name: "Facility name",
       value: facility.name,
-      required: true,
     },
     {
       name: "CLIA number",
       value: facility.clia,
-      required: true,
     },
     {
       name: "Street address",
@@ -107,7 +104,6 @@ const ReviewFormSection = ({
     {
       name: "First name",
       value: provider.firstName,
-      required: true,
     },
     {
       name: "Middle name",
@@ -116,7 +112,6 @@ const ReviewFormSection = ({
     {
       name: "Last name",
       value: provider.lastName,
-      required: true,
     },
     {
       name: "Suffix",
@@ -125,7 +120,6 @@ const ReviewFormSection = ({
     {
       name: "NPI",
       value: provider.npi,
-      required: true,
     },
     {
       name: "Street address",
@@ -165,7 +159,6 @@ const ReviewFormSection = ({
     {
       name: "First name",
       value: patient.firstName,
-      required: true,
     },
     {
       name: "Middle name",
@@ -174,7 +167,6 @@ const ReviewFormSection = ({
     {
       name: "Last name",
       value: patient.lastName,
-      required: true,
     },
     {
       name: "Suffix",
@@ -183,7 +175,6 @@ const ReviewFormSection = ({
     {
       name: "Date of birth",
       value: patient.dateOfBirth,
-      required: true,
     },
     {
       name: "Sex",
@@ -239,12 +230,10 @@ const ReviewFormSection = ({
     {
       name: "Test order",
       value: testDetailsList[0]?.testOrderDisplayName,
-      required: true,
     },
     {
       name: "Specimen type",
       value: specimen.snomedDisplayName,
-      required: true,
     },
     {
       name: "Collection date",
@@ -344,12 +333,7 @@ const ReviewFormSection = ({
               <tbody>
                 {data.map((row) => (
                   <tr key={`${keyPrefix}-data-row-${row.name}`}>
-                    <td className={"text-bold"}>
-                      {row.name}{" "}
-                      {row.required && (
-                        <span className={"usa-hint--required"}>*</span>
-                      )}
-                    </td>
+                    <td className={"text-bold"}>{row.name}</td>
                     <td>{row.value ?? ""}</td>
                   </tr>
                 ))}

--- a/frontend/src/app/universalReporting/SpecimenFormSection.tsx
+++ b/frontend/src/app/universalReporting/SpecimenFormSection.tsx
@@ -33,12 +33,15 @@ const SpecimenFormSection = ({
   );
 
   const handleSpecimenSelect = async (selectedSnomedCode: string) => {
-    const specimenBodySiteList =
-      specimenList.find((s) => s.snomedCode === selectedSnomedCode)
-        ?.bodySiteList ?? [];
+    const specimenListEntry = specimenList.find(
+      (s) => s.snomedCode === selectedSnomedCode
+    );
+    const specimenBodySiteList = specimenListEntry?.bodySiteList ?? [];
+
     setSpecimen({
       ...specimen,
       snomedTypeCode: selectedSnomedCode,
+      snomedDisplayName: specimenListEntry?.snomedDisplay ?? "",
       collectionBodySiteCode: specimenBodySiteList[0]?.snomedSiteCode ?? "",
       collectionBodySiteName: specimenBodySiteList[0]?.snomedSiteDisplay ?? "",
     });

--- a/frontend/src/app/universalReporting/SpecimenFormSection.tsx
+++ b/frontend/src/app/universalReporting/SpecimenFormSection.tsx
@@ -164,7 +164,6 @@ const SpecimenFormSection = ({
                 selectedValue={specimen.collectionBodySiteCode ?? ""}
                 onChange={(e) => handleBodySiteChange(e.target.value)}
                 className="card-dropdown"
-                required={true}
                 options={bodySiteOptions}
               />
             </div>

--- a/frontend/src/app/universalReporting/TestDetailSection.tsx
+++ b/frontend/src/app/universalReporting/TestDetailSection.tsx
@@ -3,33 +3,20 @@ import moment from "moment";
 import { Label, Textarea } from "@trussworks/react-uswds";
 
 import TextInput from "../commonComponents/TextInput";
-import RadioGroup, { RadioGroupOptions } from "../commonComponents/RadioGroup";
-import { TEST_RESULTS_SNOMED } from "../testResults/constants";
+import RadioGroup from "../commonComponents/RadioGroup";
 import { formatDate } from "../utils/date";
 import "./TestDetailSection.scss";
 import { ResultScaleType, TestDetailsInput } from "../../generated/graphql";
 
-import { ResultScaleTypeOptions } from "./LabReportFormUtils";
+import {
+  ordinalResultOptions,
+  ResultScaleTypeOptions,
+} from "./LabReportFormUtils";
 
 type TestDetailSectionProps = {
   testDetails: TestDetailsInput;
   updateTestDetails: (details: TestDetailsInput) => void;
 };
-
-const ordinalResultButtons: RadioGroupOptions<string> = [
-  {
-    value: TEST_RESULTS_SNOMED.POSITIVE,
-    label: `Positive (+)`,
-  },
-  {
-    value: TEST_RESULTS_SNOMED.NEGATIVE,
-    label: `Negative (-)`,
-  },
-  {
-    value: TEST_RESULTS_SNOMED.UNDETERMINED,
-    label: `Undetermined`,
-  },
-];
 
 const TestDetailSection = ({
   testDetails,
@@ -117,7 +104,7 @@ const TestDetailSection = ({
           <div className="grid-col-4">
             <RadioGroup<string>
               legend={`Test result`}
-              buttons={ordinalResultButtons}
+              buttons={ordinalResultOptions}
               name={`test-detail-${testDetails.testPerformedLoinc}-test-result-value`}
               selectedRadio={testDetails.resultValue}
               required={true}

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1092,6 +1092,7 @@ export type SpecimenInput = {
   collectionBodySiteName?: InputMaybe<Scalars["String"]["input"]>;
   collectionDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   receivedDate?: InputMaybe<Scalars["DateTime"]["input"]>;
+  snomedDisplayName?: InputMaybe<Scalars["String"]["input"]>;
   snomedTypeCode: Scalars["String"]["input"];
 };
 
@@ -1146,6 +1147,7 @@ export type TestDetailsInput = {
   resultInterpretation?: InputMaybe<Scalars["String"]["input"]>;
   resultType: ResultScaleType;
   resultValue: Scalars["String"]["input"];
+  testOrderDisplayName?: InputMaybe<Scalars["String"]["input"]>;
   testOrderLoinc: Scalars["String"]["input"];
   testPerformedLoinc: Scalars["String"]["input"];
   testPerformedLoincLongCommonName?: InputMaybe<Scalars["String"]["input"]>;


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #8813 

## Changes Proposed

- Adds a table for the user to review the form values before submitting
- Adds `snomedDisplay` and `testOrderDisplayName` to the input types so that the review section can use the human-readable name rather than just displaying the code. If we include this display data in the HL7 message, it's also one less thing the backend would need to look up.
- Redirects the user to the pilot landing page after submitting

## Additional Information

- Example data is added for facility and provider to simulate pre-populating this data for the purposes of the CSTE demo. Since the new pilot flow doesn't involve selecting a facility to start, the frontend has no way of determining what facility should be used to populate the facility and provider data. Design work is still in progress for selecting a facility and provider within the form itself.
- The success toast will appear at the bottom left since the app-wide toast container is currently configured that way. This can't be changed without it impacting all other toasts across the app.
- Added some minor formatting of data for patient race, ethnicity, and tribal affiliation so that it shows the readable label values (like showing the full tribal affiliation name rather than the numeric data code)
- I'll work on adding unit tests for this, but it will probably be in a follow-up PR since the team wants to prioritize getting this in for CSTE demos.

## Testing

- Deployed on dev
- Navigate to https://dev.simplereport.gov/app/pilot/report
- Click Enter lab results
- Fill out the form and see the data in the review section

## Screenshots / Demos

![Screenshot 2025-06-03 191306](https://github.com/user-attachments/assets/3f215136-4fdc-40af-9616-f894d354ac13)
![Screenshot 2025-06-03 191318](https://github.com/user-attachments/assets/1ed42a2f-7442-4ba4-821f-53cff556d1d7)
![Screenshot 2025-06-03 191424](https://github.com/user-attachments/assets/5328d3ea-f278-4a04-ac83-de8ebe2ec7bc)
