### PR TITLE
Only ingest active SNOMED codes

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
@@ -20,11 +20,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.UsageContext;
-import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.*;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -100,6 +96,10 @@ public class ConditionService {
 
       for (var entry : bundle.getEntry()) {
         ValueSet valueSet = (ValueSet) entry.getResource();
+        //        We only want to grab the ACTIVE value sets
+        if (valueSet.getStatus() != Enumerations.PublicationStatus.ACTIVE) {
+          continue;
+        }
         CodeableConcept conditionConcept = parseCondition(valueSet);
         Condition condition = saveCondition(conditionConcept);
         conditionsLoaded++;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
@@ -20,7 +20,12 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.UsageContext;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -97,7 +102,7 @@ public class ConditionService {
       for (var entry : bundle.getEntry()) {
         ValueSet valueSet = (ValueSet) entry.getResource();
         //        We only want to grab the ACTIVE value sets
-        if (valueSet.getStatus() != Enumerations.PublicationStatus.ACTIVE) {
+        if (valueSet.getStatus() != PublicationStatus.ACTIVE) {
           continue;
         }
         CodeableConcept conditionConcept = parseCondition(valueSet);

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenService.java
@@ -209,6 +209,9 @@ public class SpecimenService {
           JSONObject result = (JSONObject) results.get(i);
           boolean saveSnomed = false;
           String relationLabel = result.get("additionalRelationLabel").toString();
+          if (result.has("obsolete") && result.get("obsolete").equals(true)) {
+            continue;
+          }
           // Ensure the snomed specimen is an actual specimen
           // TODO: Could possibly use an ancestor hierarchy query for the Specimen Concept
           //    to ensure the snomed specimen concept is a descedant

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/SpecimenService.java
@@ -138,6 +138,9 @@ public class SpecimenService {
     List<Specimen> codes = new ArrayList<>();
     for (int i = 0; i < results.length(); i++) {
       JSONObject result = (JSONObject) results.get(i);
+      if (result.has("obsolete") && result.get("obsolete").equals(true)) {
+        continue;
+      }
       codes.add(
           new Specimen(
               loincSystemCode,

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
@@ -27,7 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.UsageContext;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -239,7 +244,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("covid-19");
     valueSet.setName("COVID-19");
-    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+    valueSet.setStatus(PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(
@@ -273,25 +278,25 @@ class ConditionServiceTest {
     //    This just clones the other one, saves some reading of the structure. The only practical
     // difference one is retired
     var inactiveValueSet = valueSet.copy();
-    inactiveValueSet.setStatus(Enumerations.PublicationStatus.RETIRED);
+    inactiveValueSet.setStatus(PublicationStatus.RETIRED);
     Bundle.BundleEntryComponent inactiveEntry =
         new Bundle.BundleEntryComponent().setResource(inactiveValueSet);
     bundle.addEntry(inactiveEntry);
 
     var draftValueSet = valueSet.copy();
-    draftValueSet.setStatus(Enumerations.PublicationStatus.DRAFT);
+    draftValueSet.setStatus(PublicationStatus.DRAFT);
     Bundle.BundleEntryComponent draftEntry =
         new Bundle.BundleEntryComponent().setResource(draftValueSet);
     bundle.addEntry(draftEntry);
 
     var unknownValueSet = valueSet.copy();
-    unknownValueSet.setStatus(Enumerations.PublicationStatus.UNKNOWN);
+    unknownValueSet.setStatus(PublicationStatus.UNKNOWN);
     Bundle.BundleEntryComponent unknownEntry =
         new Bundle.BundleEntryComponent().setResource(unknownValueSet);
     bundle.addEntry(unknownEntry);
 
     var nullValueSet = valueSet.copy();
-    nullValueSet.setStatus(Enumerations.PublicationStatus.NULL);
+    nullValueSet.setStatus(PublicationStatus.NULL);
     Bundle.BundleEntryComponent nullEntry =
         new Bundle.BundleEntryComponent().setResource(nullValueSet);
     bundle.addEntry(nullEntry);
@@ -312,7 +317,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("covid-19");
     valueSet.setName("COVID-19");
-    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+    valueSet.setStatus(PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(
@@ -365,7 +370,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("test-condition-1");
     valueSet.setName("Test Condition 1");
-    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+    valueSet.setStatus(PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(
@@ -413,7 +418,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("test-condition-2");
     valueSet.setName("Test Condition 2");
-    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+    valueSet.setStatus(PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
@@ -27,11 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.UsageContext;
-import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -160,6 +156,28 @@ class ConditionServiceTest {
     assertThrows(ExecutionException.class, future::get);
   }
 
+  @Test
+  @Transactional
+  void syncConditions_checksCodeStatus() throws Exception {
+    // Arrange
+    String response = createActiveAndInactiveConditionResponse();
+    Response mockResponse = createMockResponse(response);
+    when(this.tesClient.getConditions(anyInt(), anyInt())).thenReturn(mockResponse);
+    setupRepositoryMocks();
+
+    // Act
+    CompletableFuture<Void> future =
+        CompletableFuture.runAsync(
+            () -> {
+              this.conditionService.syncConditions();
+            });
+    future.get();
+
+    // Assert
+    verify(this.conditionRepository, times(1)).save(any());
+    verify(this.loincStagingRepository, times(1)).saveAll(any());
+  }
+
   private Response createMockResponse(String responseBody) {
     Response.Body body =
         new Response.Body() {
@@ -209,6 +227,79 @@ class ConditionServiceTest {
         .build();
   }
 
+  private String createActiveAndInactiveConditionResponse() {
+    Bundle bundle = new Bundle().setType(Bundle.BundleType.SEARCHSET).setTotal(1);
+
+    bundle
+        .addLink()
+        .setRelation("self")
+        .setUrl(
+            "https://tes.tools.aimsplatform.org/api/fhir/ValueSet?context-type=focus&_count=20&_getpagesoffset=0");
+
+    ValueSet valueSet = new ValueSet();
+    valueSet.setId("covid-19");
+    valueSet.setName("COVID-19");
+    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+    valueSet.setCompose(
+        new ValueSet.ValueSetComposeComponent()
+            .setInclude(
+                List.of(
+                    new ValueSet.ConceptSetComponent()
+                        .setSystem("http://loinc.org")
+                        .setConcept(
+                            List.of(
+                                new ValueSet.ConceptReferenceComponent()
+                                    .setCode("94534-5")
+                                    .setDisplay(
+                                        "SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay"))))));
+    valueSet.addUseContext(
+        new UsageContext()
+            .setCode(
+                new Coding()
+                    .setSystem("http://terminology.hl7.org/CodeSystem/usage-context-type")
+                    .setCode("focus")
+                    .setDisplay("Clinical Focus"))
+            .setValue(
+                new CodeableConcept()
+                    .addCoding(
+                        new Coding()
+                            .setSystem("http://snomed.info/sct")
+                            .setCode("428175000")
+                            .setDisplay("COVID-19"))
+                    .setText("COVID-19")));
+
+    Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent().setResource(valueSet);
+    bundle.addEntry(entry);
+    //    This just clones the other one, saves some reading of the structure. The only practical
+    // difference one is retired
+    var inactiveValueSet = valueSet.copy();
+    inactiveValueSet.setStatus(Enumerations.PublicationStatus.RETIRED);
+    Bundle.BundleEntryComponent inactiveEntry =
+        new Bundle.BundleEntryComponent().setResource(inactiveValueSet);
+    bundle.addEntry(inactiveEntry);
+
+    var draftValueSet = valueSet.copy();
+    draftValueSet.setStatus(Enumerations.PublicationStatus.DRAFT);
+    Bundle.BundleEntryComponent draftEntry =
+        new Bundle.BundleEntryComponent().setResource(draftValueSet);
+    bundle.addEntry(draftEntry);
+
+    var unknownValueSet = valueSet.copy();
+    unknownValueSet.setStatus(Enumerations.PublicationStatus.UNKNOWN);
+    Bundle.BundleEntryComponent unknownEntry =
+        new Bundle.BundleEntryComponent().setResource(unknownValueSet);
+    bundle.addEntry(unknownEntry);
+
+    var nullValueSet = valueSet.copy();
+    nullValueSet.setStatus(Enumerations.PublicationStatus.NULL);
+    Bundle.BundleEntryComponent nullEntry =
+        new Bundle.BundleEntryComponent().setResource(nullValueSet);
+    bundle.addEntry(nullEntry);
+
+    IParser parser = fhirContext.newJsonParser();
+    return parser.encodeResourceToString(bundle);
+  }
+
   private String createSinglePageResponse() {
     Bundle bundle = new Bundle().setType(Bundle.BundleType.SEARCHSET).setTotal(1);
 
@@ -221,6 +312,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("covid-19");
     valueSet.setName("COVID-19");
+    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(
@@ -273,6 +365,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("test-condition-1");
     valueSet.setName("Test Condition 1");
+    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(
@@ -320,6 +413,7 @@ class ConditionServiceTest {
     ValueSet valueSet = new ValueSet();
     valueSet.setId("test-condition-2");
     valueSet.setName("Test Condition 2");
+    valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
     valueSet.setCompose(
         new ValueSet.ValueSetComposeComponent()
             .setInclude(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenServiceTest.java
@@ -360,7 +360,6 @@ class SpecimenServiceTest {
     }
   }
 
-  // TODO:  This does not check if we parse it correctly
   @Test
   @SuppressWarnings("unchecked")
   void sendInitialSnomedRelationsRequests_shouldProcessAllSnomedCodes() throws Exception {
@@ -463,7 +462,7 @@ class SpecimenServiceTest {
     assertFalse(savedSpecimens.isEmpty());
 
     assertTrue(
-        savedSpecimens.size() >= 2,
+        savedSpecimens.size() == 2,
         "Expected at least 2 specimens, but got " + savedSpecimens.size());
 
     boolean foundArterialBloodSpecimen = false;
@@ -707,7 +706,7 @@ class SpecimenServiceTest {
     resultArray.put(specimenRelation);
 
     JSONObject obsoleteRelation = new JSONObject();
-    obsoleteRelation.put("additionalRelationLabel", "obsolete");
+    obsoleteRelation.put("additionalRelationLabel", "inverse_isa");
     obsoleteRelation.put("obsolete", true);
     obsoleteRelation.put(
         "relatedId",

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/SpecimenServiceTest.java
@@ -360,6 +360,7 @@ class SpecimenServiceTest {
     }
   }
 
+  // TODO:  This does not check if we parse it correctly
   @Test
   @SuppressWarnings("unchecked")
   void sendInitialSnomedRelationsRequests_shouldProcessAllSnomedCodes() throws Exception {
@@ -681,6 +682,12 @@ class SpecimenServiceTest {
     result2.put("name", "Serum specimen");
     resultArray.put(result2);
 
+    JSONObject result3 = new JSONObject();
+    result3.put("obsolete", true);
+    result3.put("ui", "8675309");
+    result3.put("name", "obsolete should not see");
+    resultArray.put(result3);
+
     json.put("result", resultArray);
     return json.toString();
   }
@@ -698,6 +705,15 @@ class SpecimenServiceTest {
         "https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/444555666");
     specimenRelation.put("relatedIdName", "Venous blood specimen");
     resultArray.put(specimenRelation);
+
+    JSONObject obsoleteRelation = new JSONObject();
+    obsoleteRelation.put("additionalRelationLabel", "obsolete");
+    obsoleteRelation.put("obsolete", true);
+    obsoleteRelation.put(
+        "relatedId",
+        "https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/444555667");
+    obsoleteRelation.put("relatedIdName", "Obsolete blood specimen");
+    resultArray.put(obsoleteRelation);
 
     // A body site relationship
     JSONObject bodySiteRelation = new JSONObject();
@@ -723,6 +739,15 @@ class SpecimenServiceTest {
         "https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/555666777");
     specimenRelation.put("relatedIdName", "Arterial blood specimen");
     resultArray.put(specimenRelation);
+
+    JSONObject obsoleteSpecimenRelation = new JSONObject();
+    obsoleteSpecimenRelation.put("obsolete", true);
+    obsoleteSpecimenRelation.put("additionalRelationLabel", "inverse_isa");
+    obsoleteSpecimenRelation.put(
+        "relatedId",
+        "https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/555666778");
+    obsoleteSpecimenRelation.put("relatedIdName", "Obsolete blood specimen");
+    resultArray.put(obsoleteSpecimenRelation);
 
     JSONObject bodySiteRelation = new JSONObject();
     bodySiteRelation.put("additionalRelationLabel", "has_specimen_source_topography");


### PR DESCRIPTION


# BACKEND PULL REQUEST

Ignore SNOMED codes that are not marked as active.

Update existing test fixtures to be marked as active

Add test to ensure only active codes are processed

## Related Issue

#8804 

## Changes Proposed

Updates parsing logic to only include active snomed codes (and associated LOINC codes)

## Additional Information



## Testing

Automated tests have been added

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->


