### PR TITLE
Fix CODEOWNERS for github actions updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ Dockerfile          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-
 Dockerfile.*        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # github-actions
-workflows/*         @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+workflows/**        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # gradle
 build.gradle        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,23 +2,23 @@
 # the repo. Unless a later match takes precedence,
 # the team on this line will be requested for
 # review when someone opens a pull request.
-*                   @CDCgov/simplereport-engineeringreviews
+*                     @CDCgov/simplereport-engineeringreviews
 
 # docker
-Dockerfile          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
-Dockerfile.*        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+Dockerfile            @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+Dockerfile.*          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # github-actions
-workflows/**        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+/.github/workflows/** @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # gradle
-build.gradle        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
-gradle.lockfile     @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+build.gradle          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+gradle.lockfile       @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # npm
-package.json        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
-yarn.lock           @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+package.json          @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+yarn.lock             @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
 
 # terraform
-.terraform.lock.hcl @CDCgov/simplereport-devsecops
-_config.tf          @CDCgov/simplereport-devsecops
+.terraform.lock.hcl   @CDCgov/simplereport-devsecops
+_config.tf            @CDCgov/simplereport-devsecops


### PR DESCRIPTION
# PULL REQUEST

## Related Issue

Noticed [updating workflows is not getting picked up as a dependency review](https://github.com/CDCgov/prime-simplereport/pull/8959) and is instead triggering the engineering reviews "assign-everyone" behavior
GitHub claims the CODEOWNERS file uses same syntax as the .gitignore file but looks like path needs to be relative to project root instead of relative to the file

## Testing

Started to open up a PR for an update to a workflow file and saw that the right groups were prepopulated under reviewers