### PR TITLE
Create HL7v2 Storage Queue

### DIFF
--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -66,6 +66,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -68,6 +68,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -68,6 +68,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -68,6 +68,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -68,6 +68,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -68,6 +68,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -47,11 +47,6 @@ resource "azurerm_storage_share" "db_client_export" {
   quota                = 10
 }
 
-resource "azurerm_storage_queue" "hl7v2_data_queue" {
-  name                 = "hl7v2-data-publishing"
-  storage_account_name = azurerm_storage_account.app.name
-}
-
 module "app_gateway" {
   source                  = "../services/app_gateway"
   name                    = local.name

--- a/ops/pentest/main.tf
+++ b/ops/pentest/main.tf
@@ -47,6 +47,11 @@ resource "azurerm_storage_share" "db_client_export" {
   quota                = 10
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 module "app_gateway" {
   source                  = "../services/app_gateway"
   name                    = local.name

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -66,6 +66,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -66,6 +66,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -66,6 +66,11 @@ resource "azurerm_storage_queue" "fhir_publishing_error_queue" {
   storage_account_name = azurerm_storage_account.app.name
 }
 
+resource "azurerm_storage_queue" "hl7v2_data_queue" {
+  name                 = "hl7v2-data-publishing"
+  storage_account_name = azurerm_storage_account.app.name
+}
+
 resource "azurerm_storage_share" "db_client_export" {
   name                 = "db-client-export-${local.env}"
   storage_account_name = azurerm_storage_account.app.name


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

https://github.com/CDCgov/prime-simplereport/issues/8952

Create a new storage queue using terraform for all environments

## Changes Proposed

- Creates `hl7v2-data-publishing` storage queue in all environments

## Additional Information

- N/A

## Testing

- This was deployed to dev5 and can be verified by looking at the existing Storage Queues for dev5.

<img width="1901" height="1310" alt="image" src="https://github.com/user-attachments/assets/eb7790c6-7372-43a4-8c53-47abbcc54ab0" />

<!---
## Checklist for Primary Reviewer
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any changes that might generate questions in the support inbox have been flagged to the support team
- [ ] GraphQL schema changes are backward compatible with older version of the front-end
- [ ] Changes comply with the SimpleReport Style Guide
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed
- [ ] Any changes to the startup configuration have been documented in the README
-->
