### PR TITLE
Add AIMS secrets as env vars in backend

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -189,6 +189,12 @@ loinc-fhir:
   url: "https://fhir.loinc.org"
 umls:
   api-key: ${UMLS_API_KEY:super-secret-api-key}
+aims:
+  access-key-id: ${AIMS_ACCESS_KEY_ID}
+  secret-access-key: ${AIMS_SECRET_ACCESS_KEY}
+  encryption-key: ${AIMS_KMS_ENCRYPTION_KEY}
+  outbound-endpoint: ${AIMS_OUTBOUND_ENDPOINT}
+  message-queue-endpoint: ${AIMS_MESSAGE_QUEUE_ENDPOINT}
 features:
   oktaMigrationEnabled: false
   chlamydiaEnabled: true

--- a/ops/dev/_data.tf
+++ b/ops/dev/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -65,6 +65,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev/api.tf
+++ b/ops/dev/api.tf
@@ -65,11 +65,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"

--- a/ops/dev/main.tf
+++ b/ops/dev/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/dev2/_data.tf
+++ b/ops/dev2/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev2/api.tf
+++ b/ops/dev2/api.tf
@@ -66,11 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev2/api.tf
+++ b/ops/dev2/api.tf
@@ -66,6 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev2"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev2"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev2"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"

--- a/ops/dev2/main.tf
+++ b/ops/dev2/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev2"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev3/_data.tf
+++ b/ops/dev3/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev3/api.tf
+++ b/ops/dev3/api.tf
@@ -66,11 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev3/api.tf
+++ b/ops/dev3/api.tf
@@ -66,6 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev3"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev3"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev3"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev3/main.tf
+++ b/ops/dev3/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev3"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev4/_data.tf
+++ b/ops/dev4/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev4/api.tf
+++ b/ops/dev4/api.tf
@@ -66,11 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev4/api.tf
+++ b/ops/dev4/api.tf
@@ -66,6 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev4"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev4"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev4"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"

--- a/ops/dev4/main.tf
+++ b/ops/dev4/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev4"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev5/_data.tf
+++ b/ops/dev5/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev5/api.tf
+++ b/ops/dev5/api.tf
@@ -66,11 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev5/api.tf
+++ b/ops/dev5/api.tf
@@ -66,6 +66,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev5"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev5"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev5"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"

--- a/ops/dev5/main.tf
+++ b/ops/dev5/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev5"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev6/_data.tf
+++ b/ops/dev6/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -263,5 +263,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/dev6/api.tf
+++ b/ops/dev6/api.tf
@@ -67,11 +67,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev6/api.tf
+++ b/ops/dev6/api.tf
@@ -67,6 +67,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "dev6"
   env_level = "dev"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "dev6"
-  env_level = "dev"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "dev6"
+  env_level        = "dev"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app   = "simple-report"

--- a/ops/dev6/main.tf
+++ b/ops/dev6/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "dev6"
   env_level        = "dev"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app   = "simple-report"
     environment = local.env

--- a/ops/prod/_data.tf
+++ b/ops/prod/_data.tf
@@ -196,7 +196,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-prod"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
@@ -225,22 +225,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-prod"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-prod"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-prod"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-prod"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
@@ -256,5 +256,30 @@ data "azurerm_key_vault_secret" "simple_report_prod_backend_url" {
 
 data "azurerm_key_vault_secret" "simple_report_prod_devices_token" {
   name         = "simple-report-prod-devices-token"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -67,11 +67,11 @@ module "simple_report_api" {
     SLACK_HOOK_TOKEN                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_hook_token.id})"
     SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
     SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/prod/api.tf
+++ b/ops/prod/api.tf
@@ -67,6 +67,11 @@ module "simple_report_api" {
     SLACK_HOOK_TOKEN                              = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.slack_hook_token.id})"
     SR_PROD_BACKEND_URL                           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_backend_url.id})"
     SR_PROD_DEVICES_TOKEN                         = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.simple_report_prod_devices_token.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "prod"
   env_level        = "prod"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "prod"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "prod"
   env_level = "prod"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/prod/main.tf
+++ b/ops/prod/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "prod"
-  env_level = "prod"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "prod"
+  env_level        = "prod"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"

--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -240,7 +240,7 @@ data "azurerm_storage_account" "app" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 

--- a/ops/stg/_data.tf
+++ b/ops/stg/_data.tf
@@ -192,22 +192,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-prod"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-prod"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-prod"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-prod"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }
 
@@ -271,5 +271,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.global.id
 }

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -70,6 +70,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/stg/api.tf
+++ b/ops/stg/api.tf
@@ -70,11 +70,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default: can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows (and overrides) an identical declaration in application.yaml

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "stg"
-  env_level = "stg"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "stg"
+  env_level        = "stg"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "stg"
   env_level        = "stg"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "prod"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/stg/main.tf
+++ b/ops/stg/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "stg"
   env_level = "stg"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/test/_data.tf
+++ b/ops/test/_data.tf
@@ -188,7 +188,7 @@ data "azurerm_key_vault_secret" "experian_preciseid_password" {
 }
 
 data "azurerm_key_vault_secret" "report_stream_exception_callback_token" {
-  name         = "report-stream-exception-callback-test"
+  name         = "report-stream-exception-callback-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -217,22 +217,22 @@ data "azurerm_key_vault_secret" "db_password_no_phi" {
 }
 
 data "azurerm_key_vault_secret" "datahub_api_key" {
-  name         = "datahub-api-key-test"
+  name         = "datahub-api-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_fhir_key" {
-  name         = "datahub-fhir-key-test"
+  name         = "datahub-fhir-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_url" {
-  name         = "datahub-url-test"
+  name         = "datahub-url-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
 data "azurerm_key_vault_secret" "datahub_signing_key" {
-  name         = "datahub-signing-key-test"
+  name         = "datahub-signing-key-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }
 
@@ -268,5 +268,30 @@ data "azurerm_key_vault_secret" "loinc_fhir_api_password" {
 
 data "azurerm_key_vault_secret" "umls_api_key" {
   name         = "umls-api-key-dev"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_access_key_id" {
+  name         = "aims-access-key-id-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_secret_access_key" {
+  name         = "aims-secret-access-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_kms_encryption_key" {
+  name         = "aims-kms-encryption-key-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_outbound_storage_endpoint" {
+  name         = "aims-outbound-storage-endpoint-${local.token_env_suffix}"
+  key_vault_id = data.azurerm_key_vault.sr_global.id
+}
+
+data "azurerm_key_vault_secret" "aims_message_queue_endpoint" {
+  name         = "aims-message-queue-endpoint-${local.token_env_suffix}"
   key_vault_id = data.azurerm_key_vault.sr_global.id
 }

--- a/ops/test/api.tf
+++ b/ops/test/api.tf
@@ -64,11 +64,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
-    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
-    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
-    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
-    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
-    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
+    AIMS_ACCESS_KEY_ID                            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                        = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT                   = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default, can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows/overrides an identical declaration in application.yaml

--- a/ops/test/api.tf
+++ b/ops/test/api.tf
@@ -64,6 +64,11 @@ module "simple_report_api" {
     LOINC_FHIR_API_USERNAME                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_username.id})"
     LOINC_FHIR_API_PASSWORD                       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.loinc_fhir_api_password.id})"
     UMLS_API_KEY                                  = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.umls_api_key.id})"
+    AIMS_ACCESS_KEY_ID                    = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_access_key_id.id})"
+    AIMS_SECRET_ACCESS_KEY                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_secret_access_key.id})"
+    AIMS_KMS_ENCRYPTION_KEY               = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_kms_encryption_key.id})"
+    AIMS_OUTBOUND_ENDPOINT                = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_outbound_storage_endpoint.id})"
+    AIMS_MESSAGE_QUEUE_ENDPOINT           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.aims_message_queue_endpoint.id})"
     # true by default, can be disabled quickly here
     # SPRING_LIQUIBASE_ENABLED                       = "true"
     # this shadows/overrides an identical declaration in application.yaml

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -1,8 +1,8 @@
 locals {
-  project   = "prime"
-  name      = "simple-report"
-  env       = "test"
-  env_level = "test"
+  project          = "prime"
+  name             = "simple-report"
+  env              = "test"
+  env_level        = "test"
   token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -3,6 +3,7 @@ locals {
   name      = "simple-report"
   env       = "test"
   env_level = "test"
+  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env

--- a/ops/test/main.tf
+++ b/ops/test/main.tf
@@ -3,7 +3,7 @@ locals {
   name             = "simple-report"
   env              = "test"
   env_level        = "test"
-  token_env_suffix = (local.env == "prod" || local.env == "stg") ? "prod" : "test"
+  token_env_suffix = "test"
   management_tags = {
     prime-app      = "simple-report"
     environment    = local.env


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

resolves #8919 

## Changes Proposed

- make our AIMS secrets available to the backend as properties/env variables
- fixed a mostly inconsequential bug in `stg` where we were using the wrong token to try to save report stream exceptions from the RS function app to our DB so the process was failing

## Testing

- make sure terraform checks look good
- spot check that I added all 5 variables to all the envs that connect to AIMS: dev[1-6], prod, stg, test (no demo, training, pentest)
- spot check for copy-paste errors
- deployed to a lower and verified successful build and deploy