### PR TITLE
Arin/8988 data retention change modal

### DIFF
--- a/frontend/src/app/ReportingApp.tsx
+++ b/frontend/src/app/ReportingApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { gql, useQuery } from "@apollo/client";
 import { useDispatch, connect } from "react-redux";
 import {
@@ -39,6 +39,10 @@ import UploadPatients from "./patients/UploadPatients";
 import DiseaseSpecificUploadContainer from "./testResults/uploads/DiseaseSpecificUploadContainer";
 import { specificSchemaBuilder } from "./testResults/uploads/specificSchemaBuilder";
 import LabReportForm from "./universalReporting/LabReportForm";
+import DataRetentionModal, {
+  shouldShowDataRetentionModal,
+} from "./commonComponents/DataRetentionModal";
+import "./commonComponents/DataRetentionModal.scss";
 
 export const WHOAMI_QUERY = gql`
   query WhoAmI {
@@ -87,6 +91,7 @@ const ReportingApp = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   const accessToken = localStorage.getItem("access_token");
+  const [showDataRetentionModal, setShowDataRetentionModal] = useState(false);
 
   // Check if the user is logged in, if not redirect to Okta
   checkOktaLoginStatus(accessToken, location);
@@ -133,6 +138,9 @@ const ReportingApp = () => {
         },
       })
     );
+    if (shouldShowDataRetentionModal()) {
+      setShowDataRetentionModal(true);
+    }
   }, [data, dispatch, appInsights]);
 
   if (loading) {
@@ -194,6 +202,10 @@ const ReportingApp = () => {
       {process.env.REACT_APP_IS_TRAINING_SITE === "true" && (
         <TrainingNotification />
       )}
+      <DataRetentionModal
+        isOpen={showDataRetentionModal}
+        onClose={() => setShowDataRetentionModal(false)}
+      />
       <WithFacility>
         <Page
           header={<Header />}

--- a/frontend/src/app/commonComponents/DataRetentionModal.scss
+++ b/frontend/src/app/commonComponents/DataRetentionModal.scss
@@ -1,0 +1,28 @@
+.sr-data-retention-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.sr-data-retention-modal-content {
+  background: white;
+  border-radius: 0.25rem;
+  padding: 1.5rem;
+  max-width: 40rem;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.15);
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/frontend/src/app/commonComponents/DataRetentionModal.test.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionModal.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Modal from "react-modal";
+
+import DataRetentionModal, {
+  shouldShowDataRetentionModal,
+} from "./DataRetentionModal";
+
+const mockTrackEvent = jest.fn();
+jest.mock("../TelemetryService", () => ({
+  getAppInsights: () => ({
+    trackEvent: mockTrackEvent,
+  }),
+}));
+
+beforeAll(() => {
+  const modalRoot = document.createElement("div");
+  modalRoot.setAttribute("id", "modal-root");
+  document.body.appendChild(modalRoot);
+  Modal.setAppElement(modalRoot);
+});
+
+const mockWindowOpen = jest.fn();
+Object.defineProperty(window, "open", {
+  writable: true,
+  value: mockWindowOpen,
+});
+
+describe("DataRetentionModal", () => {
+  const mockOnClose = jest.fn();
+  const DATA_RETENTION_MODAL_DISMISSED_KEY = "dataRetentionModalDismissed";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe("Modal rendering", () => {
+    it("renders modal when isOpen is true", async () => {
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      expect(
+        await screen.findByText(
+          "New data retention limits are coming to SimpleReport"
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Beginning November 1st, SimpleReport will only store/)
+      ).toBeInTheDocument();
+      expect(screen.getByText("Learn more")).toBeInTheDocument();
+      expect(screen.getByText("Continue to SimpleReport")).toBeInTheDocument();
+    });
+
+    it("does not render modal when isOpen is false", () => {
+      render(<DataRetentionModal isOpen={false} onClose={mockOnClose} />);
+
+      expect(
+        screen.queryByText(
+          "New data retention limits are coming to SimpleReport"
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders checkbox with correct label", async () => {
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      expect(
+        await screen.findByText("Got it. I don't need to see this again.")
+      ).toBeInTheDocument();
+      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    });
+
+    it("renders external link icon in Learn more button", async () => {
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const learnMoreButton = (await screen.findByText("Learn more")).closest(
+        "button"
+      );
+      expect(learnMoreButton).toBeInTheDocument();
+      expect(learnMoreButton?.querySelector("svg")).toBeInTheDocument();
+    });
+  });
+
+  describe("Learn more button functionality", () => {
+    it("opens external link when Learn more is clicked", async () => {
+      const user = userEvent.setup();
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const learnMoreButton = await screen.findByText("Learn more");
+      await user.click(learnMoreButton);
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        "https://www.simplereport.gov/using-simplereport/data-retention-limits/",
+        "_blank",
+        "noopener,noreferrer"
+      );
+    });
+
+    it("tracks analytics event when Learn more is clicked", async () => {
+      const user = userEvent.setup();
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const learnMoreButton = await screen.findByText("Learn more");
+      await user.click(learnMoreButton);
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        name: "dataRetentionModal_learnMore_clicked",
+        properties: {
+          action: "learn_more_clicked",
+          modalType: "data_retention",
+          supportLink:
+            "https://www.simplereport.gov/using-simplereport/data-retention-limits/",
+        },
+      });
+    });
+  });
+
+  describe("Continue button functionality", () => {
+    it("calls onClose when Continue button is clicked", async () => {
+      const user = userEvent.setup();
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const continueButton = await screen.findByText(
+        "Continue to SimpleReport"
+      );
+      await user.click(continueButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not save to localStorage when checkbox is unchecked", async () => {
+      const user = userEvent.setup();
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const continueButton = await screen.findByText(
+        "Continue to SimpleReport"
+      );
+      await user.click(continueButton);
+
+      expect(
+        localStorage.getItem(DATA_RETENTION_MODAL_DISMISSED_KEY)
+      ).toBeNull();
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("saves to localStorage when checkbox is checked and Continue is clicked", async () => {
+      const user = userEvent.setup();
+      render(<DataRetentionModal isOpen={true} onClose={mockOnClose} />);
+
+      const checkbox = await screen.findByRole("checkbox");
+      const continueButton = await screen.findByText(
+        "Continue to SimpleReport"
+      );
+
+      await user.click(checkbox);
+      await user.click(continueButton);
+
+      expect(localStorage.getItem(DATA_RETENTION_MODAL_DISMISSED_KEY)).toBe(
+        "true"
+      );
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("shouldShowDataRetentionModal", () => {
+  const DATA_RETENTION_MODAL_DISMISSED_KEY = "dataRetentionModalDismissed";
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns true when localStorage key is not set", () => {
+    expect(shouldShowDataRetentionModal()).toBe(true);
+  });
+
+  it("returns false when localStorage key is set to 'true'", () => {
+    localStorage.setItem(DATA_RETENTION_MODAL_DISMISSED_KEY, "true");
+    expect(shouldShowDataRetentionModal()).toBe(false);
+  });
+
+  it("returns true when localStorage key is set to other values", () => {
+    localStorage.setItem(DATA_RETENTION_MODAL_DISMISSED_KEY, "false");
+    expect(shouldShowDataRetentionModal()).toBe(true);
+
+    localStorage.setItem(DATA_RETENTION_MODAL_DISMISSED_KEY, "");
+    expect(shouldShowDataRetentionModal()).toBe(true);
+  });
+});

--- a/frontend/src/app/commonComponents/DataRetentionModal.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionModal.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import Modal from "react-modal";
+
+import Button from "./Button/Button";
+
+const DATA_RETENTION_MODAL_DISMISSED_KEY = "dataRetentionModalDismissed";
+const SUPPORT_LINK =
+  "https://www.simplereport.gov/using-simplereport/data-retention-limits/";
+
+interface DataRetentionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DataRetentionModal = ({ isOpen, onClose }: DataRetentionModalProps) => {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const handleContinue = () => {
+    if (dontShowAgain) {
+      localStorage.setItem(DATA_RETENTION_MODAL_DISMISSED_KEY, "true");
+    }
+    onClose();
+  };
+
+  const handleLearnMoreClick = () => {
+    window.open(SUPPORT_LINK, "_blank", "noopener,noreferrer");
+  };
+
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDontShowAgain(event.target.checked);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      shouldCloseOnOverlayClick={false}
+      shouldCloseOnEsc={false}
+      className="sr-data-retention-modal-content"
+      overlayClassName="sr-data-retention-modal-overlay"
+      contentLabel="Data retention notification"
+      aria-labelledby="data-retention-title"
+      aria-describedby="data-retention-description"
+    >
+      <div className="border-0 card-container">
+        <h2
+          id="data-retention-title"
+          className="font-heading-lg margin-top-05 margin-bottom-2"
+        >
+          New data retention limits are coming to SimpleReport
+        </h2>
+
+        <div id="data-retention-description" className="margin-bottom-3">
+          <p className="usa-prose">
+            Beginning November 1st, SimpleReport will only store patient
+            profiles and test results for 30 days. This change may impact how
+            your facility or organization uses SimpleReport.
+          </p>
+          <p className="usa-prose">
+            Learn more about data retention limits and our recommendations for
+            managing your workflow.
+          </p>
+        </div>
+
+        <div className="margin-bottom-3">
+          <label className="usa-checkbox">
+            <input
+              className="usa-checkbox__input"
+              id="dont-show-again"
+              type="checkbox"
+              name="dont-show-again"
+              checked={dontShowAgain}
+              onChange={handleCheckboxChange}
+            />
+            <span className="usa-checkbox__label">
+              Got it. I don't need to see this again.
+            </span>
+          </label>
+        </div>
+
+        <div className="border-top border-base-lighter margin-x-neg-205 margin-top-2 padding-top-205 text-right">
+          <div className="display-flex flex-justify-end">
+            <Button
+              className="margin-right-2"
+              onClick={handleLearnMoreClick}
+              variant="outline"
+              label="Learn more"
+            />
+            <Button onClick={handleContinue} label="Continue to SimpleReport" />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DataRetentionModal;
+
+export const shouldShowDataRetentionModal = (): boolean => {
+  const dismissed = localStorage.getItem(DATA_RETENTION_MODAL_DISMISSED_KEY);
+  return !dismissed;
+};

--- a/frontend/src/app/commonComponents/DataRetentionModal.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionModal.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
 import Modal from "react-modal";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { getAppInsights } from "../TelemetryService";
 
 import Button from "./Button/Button";
 
@@ -14,6 +18,7 @@ interface DataRetentionModalProps {
 
 const DataRetentionModal = ({ isOpen, onClose }: DataRetentionModalProps) => {
   const [dontShowAgain, setDontShowAgain] = useState(false);
+  const appInsights = getAppInsights();
 
   const handleContinue = () => {
     if (dontShowAgain) {
@@ -23,6 +28,14 @@ const DataRetentionModal = ({ isOpen, onClose }: DataRetentionModalProps) => {
   };
 
   const handleLearnMoreClick = () => {
+    appInsights?.trackEvent({
+      name: "dataRetentionModal_learnMore_clicked",
+      properties: {
+        action: "learn_more_clicked",
+        modalType: "data_retention",
+        supportLink: SUPPORT_LINK,
+      },
+    });
     window.open(SUPPORT_LINK, "_blank", "noopener,noreferrer");
   };
 
@@ -79,13 +92,18 @@ const DataRetentionModal = ({ isOpen, onClose }: DataRetentionModalProps) => {
 
         <div className="border-top border-base-lighter margin-x-neg-205 margin-top-2 padding-top-205 text-right">
           <div className="display-flex flex-justify-end">
+            <Button className="margin-right-2" onClick={handleLearnMoreClick}>
+              Learn more{" "}
+              <FontAwesomeIcon
+                icon={faExternalLinkAlt}
+                className="margin-left-1"
+              />
+            </Button>
             <Button
-              className="margin-right-2"
-              onClick={handleLearnMoreClick}
+              onClick={handleContinue}
               variant="outline"
-              label="Learn more"
+              label="Continue to SimpleReport"
             />
-            <Button onClick={handleContinue} label="Continue to SimpleReport" />
           </div>
         </div>
       </div>

--- a/frontend/src/app/commonComponents/DataRetentionModal.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionModal.tsx
@@ -115,5 +115,5 @@ export default DataRetentionModal;
 
 export const shouldShowDataRetentionModal = (): boolean => {
   const dismissed = localStorage.getItem(DATA_RETENTION_MODAL_DISMISSED_KEY);
-  return !dismissed;
+  return dismissed !== "true";
 };


### PR DESCRIPTION
# FRONTEND PULL REQUEST

https://app.zenhub.com/workspaces/simplereport-2025-and-onwards-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/8988

## Related Issue

This Issue is part of the data retention policy

## Testing 

You can run this locally and see the modal
You can run the tests locally

## Changes Proposed

Creates a modal to outline the new data retention policy
Modal will not show if the user checks "Got it. I don't need to see it again" 

## Screenshot

<img width="748" height="429" alt="Screenshot 2025-07-24 at 8 29 55 AM" src="https://github.com/user-attachments/assets/ce799c3a-a8da-4436-b1f2-4a7deb455c56" />


<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
