### PR TITLE
Data retention limits banner

### DIFF
--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
@@ -1,9 +1,12 @@
 @use "../../scss/settings";
 
-.data-retention-limits-alert-body {
-  max-width: settings.$site-max-width !important;
+.data-retention-limits-alert {
   color: #5c4809 !important;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15);
+}
+
+.data-retention-limits-alert-body {
+  color: #5c4809 !important;
 }
 
 .data-retention-limits-header {

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
@@ -1,0 +1,22 @@
+@use "../../scss/settings";
+
+.data-retention-limits-alert-body {
+  max-width: settings.$site-max-width !important;
+  color: #5c4809 !important;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15);
+}
+
+.data-retention-limits-header {
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 140%; /* 28px */
+}
+
+.data-retention-limits-link {
+  color: #5c4809;
+}
+
+.usa-alert--warning .usa-alert__body::before {
+  background: #5c4809 !important;
+}

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.scss
@@ -7,6 +7,7 @@
 
 .data-retention-limits-alert-body {
   color: #5c4809 !important;
+  margin: 0 !important;
 }
 
 .data-retention-limits-header {

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -19,33 +19,31 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
   };
 
   return (
-    <>
-      {
-        <div className="prime-home grid-row width-full margin-bottom-1em">
-          <Alert
-            type="warning"
-            role="alert"
-            className={"width-full margin-bottom-40px"}
-            bodyClassName={"data-retention-limits-alert-body"}
-          >
-            <strong className={"data-retention-limits-header"}>
-              {"Beginning November 1st, 2025, "} {dataRetained}{" "}
-              {" will only be stored for 30 days"}
-              <br />
-            </strong>
-            {"This change may impact how your facility uses SimpleReport. "}
-            <a
-              className={"data-retention-limits-link"}
-              href={
-                "https://dev5.simplereport.gov/using-simplereport/data-retention-limits/"
-              }
-              onClick={handleSupportClick}
-            >
-              {"Learn how to prepare for data retention limits."}
-            </a>
-          </Alert>
-        </div>
+    <Alert
+      type="warning"
+      role="alert"
+      className={
+        "width-full margin-bottom-2em margin-top-1em data-retention-limits-alert"
       }
-    </>
+      bodyClassName={"data-retention-limits-alert-body"}
+    >
+      <strong className={"data-retention-limits-header"}>
+        {"Beginning November 1st, 2025, "} {dataRetained}{" "}
+        {" will only be stored for 30 days"}
+        <br />
+      </strong>
+      {"This change may impact how your facility uses SimpleReport. "}
+      <a
+        className={"data-retention-limits-link"}
+        target="_blank"
+        rel="noopener noreferrer"
+        href={
+          "https://dev5.simplereport.gov/using-simplereport/data-retention-limits/"
+        }
+        onClick={handleSupportClick}
+      >
+        {"Learn how to prepare for data retention limits."}
+      </a>
+    </Alert>
   );
 };

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,5 +1,3 @@
-import { NavLink } from "react-router-dom";
-
 import Alert from "./Alert";
 
 import "./DataRetentionLimitsBanner.scss";
@@ -25,14 +23,14 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
               <br />
             </strong>
             {"This change may impact how your facility uses SimpleReport. "}
-            <NavLink to="/using-simplereport/data-retention-limits">
-              <a
-                className={"data-retention-limits-link"}
-                href={"/using-simplereport/data-retention-limits"}
-              >
-                {"Learn how to prepare for data retention limits."}
-              </a>
-            </NavLink>
+            <a
+              className={"data-retention-limits-link"}
+              href={
+                "https://dev5.simplereport.gov/using-simplereport/data-retention-limits/"
+              }
+            >
+              {"Learn how to prepare for data retention limits."}
+            </a>
           </Alert>
         </div>
       }

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,7 +1,8 @@
+import { NavLink } from "react-router-dom";
+
 import Alert from "./Alert";
 
 import "./DataRetentionLimitsBanner.scss";
-import { NavLink } from "react-router-dom";
 
 interface Props {
   dataRetained: string;
@@ -25,7 +26,10 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
             </strong>
             {"This change may impact how your facility uses SimpleReport. "}
             <NavLink to="/using-simplereport/data-retention-limits">
-              <a className={"data-retention-limits-link"}>
+              <a
+                className={"data-retention-limits-link"}
+                href={"data-retention-limits-info"}
+              >
                 {"Learn how to prepare for data retention limits."}
               </a>
             </NavLink>

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,12 +1,22 @@
 import Alert from "./Alert";
 
 import "./DataRetentionLimitsBanner.scss";
+import { getAppInsights } from "../TelemetryService";
 
 interface Props {
   dataRetained: string;
 }
 
 export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
+  const appInsights = getAppInsights();
+
+  const handleSupportClick = () => {
+    if (appInsights) {
+      appInsights.trackEvent({ name: "Data Retention Limits" });
+      console.log("handle support click worked!!!!!");
+    }
+  };
+
   return (
     <>
       {
@@ -28,6 +38,7 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
               href={
                 "https://dev5.simplereport.gov/using-simplereport/data-retention-limits/"
               }
+              onClick={handleSupportClick}
             >
               {"Learn how to prepare for data retention limits."}
             </a>

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -28,7 +28,7 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
             <NavLink to="/using-simplereport/data-retention-limits">
               <a
                 className={"data-retention-limits-link"}
-                href={"data-retention-limits-info"}
+                href={"/using-simplereport/data-retention-limits"}
               >
                 {"Learn how to prepare for data retention limits."}
               </a>

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,7 +1,8 @@
+import { getAppInsights } from "../TelemetryService";
+
 import Alert from "./Alert";
 
 import "./DataRetentionLimitsBanner.scss";
-import { getAppInsights } from "../TelemetryService";
 
 interface Props {
   dataRetained: string;

--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,0 +1,37 @@
+import Alert from "./Alert";
+
+import "./DataRetentionLimitsBanner.scss";
+import { NavLink } from "react-router-dom";
+
+interface Props {
+  dataRetained: string;
+}
+
+export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
+  return (
+    <>
+      {
+        <div className="prime-home grid-row width-full margin-bottom-1em">
+          <Alert
+            type="warning"
+            role="alert"
+            className={"width-full margin-bottom-40px"}
+            bodyClassName={"data-retention-limits-alert-body"}
+          >
+            <strong className={"data-retention-limits-header"}>
+              {"Beginning November 1st, 2025, "} {dataRetained}{" "}
+              {" will only be stored for 30 days"}
+              <br />
+            </strong>
+            {"This change may impact how your facility uses SimpleReport. "}
+            <NavLink to="/using-simplereport/data-retention-limits">
+              <a className={"data-retention-limits-link"}>
+                {"Learn how to prepare for data retention limits."}
+              </a>
+            </NavLink>
+          </Alert>
+        </div>
+      }
+    </>
+  );
+};

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -34,11 +34,11 @@ import { StartTestProps } from "../testQueue/addToQueue/AddToQueueSearch";
 import { MenuButton } from "../commonComponents/MenuButton";
 import { IconLabel } from "../commonComponents/IconLabel";
 import { ArchivedStatus } from "../../generated/graphql";
+import { DataRetentionLimitsBanner } from "../commonComponents/DataRetentionLimitsBanner";
 
 import ArchivePersonModal from "./ArchivePersonModal";
 
 import "./ManagePatients.scss";
-import { DataRetentionLimitsBanner } from "../commonComponents/DataRetentionLimitsBanner";
 
 export const patientsCountQuery = gql`
   query GetPatientsCountByFacility(

--- a/frontend/src/app/patients/ManagePatients.tsx
+++ b/frontend/src/app/patients/ManagePatients.tsx
@@ -38,6 +38,7 @@ import { ArchivedStatus } from "../../generated/graphql";
 import ArchivePersonModal from "./ArchivePersonModal";
 
 import "./ManagePatients.scss";
+import { DataRetentionLimitsBanner } from "../commonComponents/DataRetentionLimitsBanner";
 
 export const patientsCountQuery = gql`
   query GetPatientsCountByFacility(
@@ -320,6 +321,7 @@ export const DetachedManagePatients = ({
     <div className="prime-home flex-1" data-cy="manage-patients-page">
       <div className="grid-container">
         <div className="grid-row">
+          <DataRetentionLimitsBanner dataRetained={"patient profiles"} />
           <div className="prime-container card-container">
             <div className="usa-card__header" data-cy="manage-patients-header">
               <div className="display-flex flex-align-center">

--- a/frontend/src/app/testResults/ResultsNavWrapper.tsx
+++ b/frontend/src/app/testResults/ResultsNavWrapper.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from "react";
 
+import { DataRetentionLimitsBanner } from "../commonComponents/DataRetentionLimitsBanner";
+
 import ResultsNav from "./ResultsNav";
 
 type Props = {
@@ -10,6 +12,7 @@ const ResultsNavWrapper = ({ children }: Props) => {
   return (
     <div className="prime-home flex-1">
       <div className="grid-container results-wide-container">
+        <DataRetentionLimitsBanner dataRetained={"test results"} />
         <ResultsNav />
         {children}
       </div>


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- https://github.com/CDCgov/prime-simplereport/issues/8990
## Changes Proposed

- Adds a banner to the Patients and Results tabs informing users of upcoming data retention limits.
- Tracks clicking on the "learn more..." link to the static site via appInsights

## Additional Information

- This should wait to be merged until the two accompanying stories are complete AND the email is sent to users informing them of upcoming data retention changes.

## Testing

- In dev5