### PR TITLE
Remove function-tests job from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,17 +145,6 @@ jobs:
         with:
           name: data-publisher-function-coverage
           path: ops/services/app_functions/test_data_publisher/functions/coverage
-  function-tests:
-    # satisfy branch protection checks - to be removed once required checks are updated to use new names
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - shell: bash
-        run: echo "RS function tests have been moved to rs-function-tests job"
   sonar:
     needs: [backend-tests, frontend-tests, rs-function-tests, data-publisher-function-tests]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

resolves #9022 

## Changes Proposed

remove the `function-tests` job, since it's not doing anything at this point

## Additional Information

- already updated branch protection checks on `main` to require `rs-function-tests` and `data-publisher-function-tests` and not require `function-tests`

## Testing

- verify on any PR (inc this one) that `rs-function-tests` and `data-publisher-function-tests` are required and verify on a different PR (not this one) that `function-tests` is not
- `function-tests` should not run at all on this PR
<img width="1243" height="1082" alt="Screenshot 2025-08-04 at 11 25 21 AM" src="https://github.com/user-attachments/assets/9bc724e8-8b79-474d-b712-e45ea5063a15" />