### PR TITLE
Add properties to data retention banner custom event

### DIFF
--- a/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionLimitsBanner.tsx
@@ -1,8 +1,8 @@
 import { getAppInsights } from "../TelemetryService";
 
 import Alert from "./Alert";
-
 import "./DataRetentionLimitsBanner.scss";
+import { DATA_RETENTION_LIMITS_INFO_LINK } from "./DataRetentionModal";
 
 interface Props {
   dataRetained: string;
@@ -13,7 +13,13 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
 
   const handleSupportClick = () => {
     if (appInsights) {
-      appInsights.trackEvent({ name: "Data Retention Limits" });
+      appInsights.trackEvent({
+        name: "Data Retention Limits",
+        properties: {
+          source: `${dataRetained} data retention limits banner`,
+          link: DATA_RETENTION_LIMITS_INFO_LINK,
+        },
+      });
     }
   };
 
@@ -36,9 +42,7 @@ export const DataRetentionLimitsBanner = ({ dataRetained }: Props) => {
         className={"data-retention-limits-link"}
         target="_blank"
         rel="noopener noreferrer"
-        href={
-          "https://simplereport.gov/using-simplereport/data-retention-limits/"
-        }
+        href={DATA_RETENTION_LIMITS_INFO_LINK}
         onClick={handleSupportClick}
       >
         {"Learn how to prepare for data retention limits."}

--- a/frontend/src/app/commonComponents/DataRetentionModal.tsx
+++ b/frontend/src/app/commonComponents/DataRetentionModal.tsx
@@ -14,7 +14,7 @@ declare global {
 }
 
 const DATA_RETENTION_MODAL_DISMISSED_KEY = "dataRetentionModalDismissed";
-const SUPPORT_LINK =
+export const DATA_RETENTION_LIMITS_INFO_LINK =
   "https://www.simplereport.gov/using-simplereport/data-retention-limits/";
 
 interface DataRetentionModalProps {
@@ -43,10 +43,14 @@ const DataRetentionModal = ({ isOpen, onClose }: DataRetentionModalProps) => {
       properties: {
         action: "learn_more_clicked",
         modalType: "data_retention",
-        supportLink: SUPPORT_LINK,
+        supportLink: DATA_RETENTION_LIMITS_INFO_LINK,
       },
     });
-    window.open(SUPPORT_LINK, "_blank", "noopener,noreferrer");
+    window.open(
+      DATA_RETENTION_LIMITS_INFO_LINK,
+      "_blank",
+      "noopener,noreferrer"
+    );
   };
 
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
+++ b/frontend/src/app/testResults/__snapshots__/ResultsNavWrapper.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`ResultsNav displays the results sub nav when user has the permission 1`
             This change may impact how your facility uses SimpleReport. 
             <a
               class="data-retention-limits-link"
-              href="https://simplereport.gov/using-simplereport/data-retention-limits/"
+              href="https://www.simplereport.gov/using-simplereport/data-retention-limits/"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -116,7 +116,7 @@ exports[`ResultsNav doesnt display the results sub nav when user doesnt have the
             This change may impact how your facility uses SimpleReport. 
             <a
               class="data-retention-limits-link"
-              href="https://simplereport.gov/using-simplereport/data-retention-limits/"
+              href="https://www.simplereport.gov/using-simplereport/data-retention-limits/"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

request from Lauryn to improve analytics of user response to data retention communication

## Changes Proposed

add properties to the custom event tracked when users click through to the support site from the data retention limits banner to differentiate between clicks from the patients page and the results page

## Testing

deployed to a lower and see if app insights shows the correct properties for the event(s)

## Screenshots / Demos
<img width="1426" height="947" alt="Screenshot 2025-08-08 at 12 01 31 PM" src="https://github.com/user-attachments/assets/508ba171-e2fc-4359-9853-2d050cc76850" />