### PR TITLE
Removing Calendly links

### DIFF
--- a/frontend/src/app/signUp/IdentityVerification/NextSteps.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/NextSteps.tsx
@@ -8,24 +8,19 @@ const NextSteps = () => {
   return (
     <CardBackground>
       <Card logo>
-        <h1 className="font-ui-lg margin-top-3 margin-bottom-4">
-          Identity verification call
+        <h1 className="font-ui-lg margin-top-3 margin-bottom-3">
+          Experian was unable to verify your identity
         </h1>
         <p className="margin-bottom-2">
-          Experian was unable to verify your identity. You’ll need to schedule a
-          quick identity verification call with our customer support team
-          instead.
+          Your security and experience are important to us. Let's schedule a
+          quick call to get you back on track.
         </p>
-        <p className="margin-bottom-0">
-          Your SimpleReport account will be accessible after your identity is
-          verified.
+        <p className="margin-bottom-2">
+          Email{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          to schedule a call to verify your identity and address any other
+          questions.
         </p>
-        <a
-          className="usa-button width-full margin-top-3 display-block"
-          href="https://calendly.com/simplereport-id-verification-sessions/simplereport-id-verification-sessions?back=1&month=2022-05"
-        >
-          Schedule identity verification
-        </a>
       </Card>
     </CardBackground>
   );

--- a/frontend/src/app/signUp/IdentityVerification/QuestionsFormContainer.test.tsx
+++ b/frontend/src/app/signUp/IdentityVerification/QuestionsFormContainer.test.tsx
@@ -120,7 +120,7 @@ describe("QuestionsFormContainer", () => {
       jest.advanceTimersByTime(1000);
     });
     expect(
-      await screen.findByText("Experian was unable to verify your identity.", {
+      await screen.findByText("Experian was unable to verify your identity", {
         exact: false,
       })
     ).toBeInTheDocument();

--- a/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
+++ b/frontend/src/app/signUp/Organization/OrganizationForm.test.tsx
@@ -199,7 +199,7 @@ describe("OrganizationForm", () => {
 
     expect(
       await screen.findByText(
-        "Your organization is already registered with SimpleReport. To begin using it, schedule a time",
+        "Your organization is already registered with SimpleReport. To begin using it, email",
         { exact: false }
       )
     );

--- a/frontend/src/app/signUp/Organization/utils.tsx
+++ b/frontend/src/app/signUp/Organization/utils.tsx
@@ -140,10 +140,10 @@ export const organizationBackendErrors = (error: string): ReactElement => {
       return (
         <Alert type="error" title="Duplicate organization">
           Your organization is already registered with SimpleReport. To begin
-          using it, schedule a time to complete our{" "}
-          <a href="https://calendly.com/simplereport-id-verification-sessions/simplereport-id-verification-sessions?back=1&month=2022-05">
-            online identity verification.
-          </a>{" "}
+          using it, email{" "}
+          <a href="mailto:support@simplereport.gov">support@simplereport.gov</a>{" "}
+          to schedule a call to verify your identity and address any other
+          questions.
         </Alert>
       );
     // Duplicate org. Non-admin user is attempting to reregister the organization.


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #8781

## Changes Proposed

- Changed copy in two places to get rid of calendly links. Here's the new copy for those two places:
1.
<img width="1903" height="1041" alt="Screenshot 2025-08-19 at 11 43 15 AM" src="https://github.com/user-attachments/assets/bb982f21-42a5-41e7-a796-ad0d9d7f63d8" />
2. 

https://github.com/user-attachments/assets/8cc18cf3-675c-4d76-8ee6-e7933ed4f74e


## Testing

- Testing is tricky and took a lot of commenting and changing of conditional statements to get these two scenarios to occur. Relying on the screenshots should be sufficient.