### PR TITLE
Add alerting for aims uploader job not functioning or erroring

### DIFF
--- a/ops/services/alerts/app_service_metrics/function_triggers.tf
+++ b/ops/services/alerts/app_service_metrics/function_triggers.tf
@@ -102,3 +102,39 @@ requests
   }
 }
 
+resource "azurerm_monitor_scheduled_query_rules_alert" "send_to_aims_function_not_triggering" {
+  name                = "${var.env}-send-to-aims-function-not-triggering"
+  description         = "AIMS Uploader is not triggering on schedule"
+  location            = data.azurerm_resource_group.app.location
+  resource_group_name = var.rg_name
+  severity            = 4
+  frequency           = 60
+  time_window         = 1440
+  enabled             = contains(var.disabled_alerts, "send_to_aims_function_not_triggering") ? false : true
+
+  data_source_id = var.app_insights_id
+
+  auto_mitigation_enabled = true
+
+  query = <<-QUERY
+requests
+| where timestamp >= ago(1d)
+    and operation_Name =~ 'SendToAIMS'
+  QUERY
+
+  trigger {
+    operator  = "Equal"
+    threshold = 0
+  }
+
+  action {
+    action_group           = var.action_group_ids
+    custom_webhook_payload = var.wiki_docs_text
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

Add alerting for @arinkulshi-skylight 's AIMS function 

## Changes Proposed

Adds alert for if the job hasn't run in a day, adds alert for if there are any errors tagged with the job in the logs. 

## Additional Information

- frequency of the error check was set to 2 hours, didn't seem relevant to run more often given the job only runs once a day
- 

