### PR TITLE
Change copy for patient search on "Report tests" page

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/config/FeatureFlagsConfig.java
@@ -45,8 +45,7 @@ public class FeatureFlagsConfig {
   private boolean hivEnabled;
   private boolean bulkUploadDisabled; // inverting logic because bulk uploader is enabled by default
   private boolean universalReportingEnabled;
-  private boolean
-      dataRetentionDisabled; // Inverting because the  current logic defaults to enabled by default
+  private boolean dataRetentionLimitsEnabled;
 
   private Map<UUID, Map<String, Boolean>> allFacilitiesMap = new HashMap<>();
 
@@ -80,7 +79,7 @@ public class FeatureFlagsConfig {
       case "hivEnabled" -> setHivEnabled(flagValue);
       case "bulkUploadDisabled" -> setBulkUploadDisabled(flagValue);
       case "universalReportingEnabled" -> setUniversalReportingEnabled(flagValue);
-      case "dataRetentionDisabled" -> setDataRetentionDisabled(flagValue);
+      case "dataRetentionLimitsEnabled" -> setDataRetentionLimitsEnabled(flagValue);
       default -> log.info("no mapping for " + flagName);
     }
   }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -205,7 +205,7 @@ features:
   hepatitisCEnabled: true
   syphilisEnabled: true
   hivEnabled: true
-  dataRetentionDisabled: true
+  dataRetentionLimitsEnabled: false
   universalReportingEnabled: true
 slack:
   hook:

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.test.tsx
@@ -83,7 +83,7 @@ const mockFlags = (flags: Record<string, boolean>) => {
 describe("SearchResults", () => {
   describe("No Results", () => {
     it("should say 'No Results' for no matches when data retention flag is disabled", () => {
-      mockFlags({ dataRetentionDisabled: true });
+      mockFlags({ dataRetentionLimitsEnabled: false });
 
       render(
         <RouterWithFacility>
@@ -108,7 +108,7 @@ describe("SearchResults", () => {
     });
 
     it("should say data retention-specific text for no matches when data retention flag is not disabled", () => {
-      mockFlags({ dataRetentionDisabled: false });
+      mockFlags({ dataRetentionLimitsEnabled: true });
 
       render(
         <RouterWithFacility>

--- a/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
+++ b/frontend/src/app/testQueue/addToQueue/SearchResults.tsx
@@ -48,7 +48,7 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
   const [redirect, setRedirect] = useState<string | undefined>(undefined);
 
   const activeFacilityId = getFacilityIdFromUrl(useLocation());
-  const dataRetentionDisabled = useFeature("dataRetentionDisabled");
+  const dataRetentionLimitsEnabled = useFeature("dataRetentionLimitsEnabled");
 
   if (redirect) {
     return <Navigate to={redirect} />;
@@ -100,9 +100,9 @@ const SearchResults = (props: QueueProps | TestResultsProps) => {
         }
       >
         <div className="margin-bottom-105">
-          {dataRetentionDisabled
-            ? "No results found."
-            : "No results found in the last 30 days."}
+          {dataRetentionLimitsEnabled
+            ? "No results found in the last 30 days."
+            : "No results found."}
         </div>
         <div>
           Check for spelling errors


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

#9075 

## Changes Proposed

- On the 'report tests' page, if a user starts typing a name that isn't stored in SimpleReport (for any reason) they see new copy for the helper text.
- Adds feature flag from #9115 
- When `dataRetentionDisabled` is disabled, show 30-day cutoff text, else show default text in patient search

## Additional Information

N/A

## Testing

- Add `dataRetentionLimitsEnabled: true` to your `application-local.yaml` file under `features`.

```yaml
features:
  ...
  dataRetentionLimitsEnabled: true
```

- Type some text into the search box under the `Report Tests` tab. See new copy:
<img width="969" height="537" alt="image" src="https://github.com/user-attachments/assets/5806343d-0047-4605-86d8-406aeba016d4" />


## Screenshots / Demos

- See above

<!---
## Checklist for Author and Reviewer
### Accessibility
- [ ] Any large changes have been run through Deque manual testing
- [ ] All changes have run through the Deque automated testing

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README
-->
