### PR TITLE
More distinct condition display names

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/reporting/ConditionController.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/reporting/ConditionController.java
@@ -2,6 +2,7 @@ package gov.cdc.usds.simplereport.api.reporting;
 
 import gov.cdc.usds.simplereport.db.model.Condition;
 import gov.cdc.usds.simplereport.service.ConditionService;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +19,7 @@ public class ConditionController {
   private final ConditionService conditionService;
 
   @GetMapping("/sync")
-  public String syncConditions() {
+  public String syncConditions() throws IOException, InterruptedException {
     conditionService.syncConditions();
     return "Condition sync has been started successfully.";
   }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Condition.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Condition.java
@@ -28,6 +28,8 @@ public class Condition extends EternalAuditedEntity {
   @Column(nullable = false)
   private String display;
 
+  @Getter @Column private String snomedName;
+
   @Column private boolean hasLabs;
 
   public boolean getHasLabs() {
@@ -44,10 +46,11 @@ public class Condition extends EternalAuditedEntity {
   @Getter
   private Set<Lab> labs = new HashSet<>();
 
-  public Condition(String code, String display) {
+  public Condition(String code, String display, String snomedName) {
     super();
     this.code = code;
     this.display = display;
+    this.snomedName = snomedName;
   }
 
   protected Condition() {

--- a/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Condition.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/db/model/Condition.java
@@ -24,10 +24,12 @@ public class Condition extends EternalAuditedEntity {
   @Column(nullable = false)
   private String code;
 
+  /** This value comes from APHL's Terminology Exchange Service */
   @Getter
   @Column(nullable = false)
   private String display;
 
+  /** This value comes from the UMLS Terminology Service endpoint for a SNOMED */
   @Getter @Column private String snomedName;
 
   @Column private boolean hasLabs;

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
@@ -192,10 +192,14 @@ public class ConditionService {
 
     if (foundCondition == null) {
       log.info("Saving new condition {}", display);
-      return conditionRepository.save(new Condition(code, display, snomedName));
+      return conditionRepository.save(new Condition(code, display, null));
+    } else {
+      foundCondition.setDisplay(display);
+      foundCondition.setSnomedName(snomedName);
+      return conditionRepository.save(foundCondition);
     }
-    log.info("Found existing condition {}", display);
-    return foundCondition;
+    //    log.info("Found existing condition {}", display);
+    //    return foundCondition;
   }
 
   @AuthorizationConfiguration.RequireGlobalAdminUser

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
@@ -12,6 +12,10 @@ import gov.cdc.usds.simplereport.db.model.LoincStaging;
 import gov.cdc.usds.simplereport.db.repository.ConditionRepository;
 import gov.cdc.usds.simplereport.db.repository.LoincStagingRepository;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +30,8 @@ import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r4.model.UsageContext;
 import org.hl7.fhir.r4.model.ValueSet;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -34,6 +40,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @SuppressWarnings({"checkstyle:TodoComment"})
 public class ConditionService {
+
+  @Value("${umls.api-key}")
+  private String umlsApiKey;
 
   private final TerminologyExchangeClient tesClient;
   private final ConditionRepository conditionRepository;
@@ -74,7 +83,7 @@ public class ConditionService {
 
   @AuthorizationConfiguration.RequireGlobalAdminUser
   @Async
-  public void syncConditions() {
+  public void syncConditions() throws IOException, InterruptedException {
     // TODO add handling for HTTP 429 in case we get into a rate limiting situation.
     int conditionsLoaded = 0;
 
@@ -173,15 +182,17 @@ public class ConditionService {
   }
 
   // TODO rename to something like findOrSaveCondition
-  private Condition saveCondition(CodeableConcept conditionConcept) {
+  private Condition saveCondition(CodeableConcept conditionConcept)
+      throws IOException, InterruptedException {
     String code = conditionConcept.getCoding().get(0).getCode();
+    String snomedName = getSnomedConditionInfo(code).getJSONObject("result").get("name").toString();
     String display = conditionConcept.getText();
 
     Condition foundCondition = conditionRepository.findConditionByCode(code);
 
     if (foundCondition == null) {
       log.info("Saving new condition {}", display);
-      return conditionRepository.save(new Condition(code, display));
+      return conditionRepository.save(new Condition(code, display, snomedName));
     }
     log.info("Found existing condition {}", display);
     return foundCondition;
@@ -191,5 +202,22 @@ public class ConditionService {
   public void clearConditions() {
     conditionRepository.deleteAll();
     log.info("All conditions deleted.");
+  }
+
+  private JSONObject getSnomedConditionInfo(String conditionSnomedCode)
+      throws IOException, InterruptedException {
+    String uriString =
+        String.format(
+            "https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/%s?apiKey=%s&pageSize=500",
+            conditionSnomedCode, umlsApiKey);
+
+    URI uri = URI.create(uriString);
+
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+    return new JSONObject(response.body());
   }
 }

--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ConditionService.java
@@ -182,7 +182,6 @@ public class ConditionService {
     return new CodeableConcept();
   }
 
-  // TODO rename to something like findOrSaveCondition
   private Condition createOrUpdateCondition(CodeableConcept conditionConcept)
       throws IOException, InterruptedException {
     String code = conditionConcept.getCoding().get(0).getCode();

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -6542,3 +6542,24 @@ databaseChangeLog:
             columns:
               - column:
                   name: organization_id
+  - changeSet:
+      id: add-snomed-name-column-to-condition-table
+      author: david@skylight.digital
+      comment: Add a column for the display name associated with the SNOMED code
+      changes:
+        - tagDatabase:
+            tag: add-snomed-name-column-to-condition-table
+        - addColumn:
+            tableName: condition
+            columns:
+              - column:
+                  name: snomed_name
+                  type: text
+                  remarks: Condition name associated with the SNOMED code
+                  constraints:
+                    unique: false
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: condition
+            columnName: snomed_name

--- a/backend/src/main/resources/graphql/main.graphqls
+++ b/backend/src/main/resources/graphql/main.graphqls
@@ -532,6 +532,7 @@ enum ResultScaleType {
 type Condition {
   code: String!
   display: String!
+  snomedName: String
 }
 
 type Lab {

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
@@ -15,6 +15,7 @@ import feign.Response;
 import gov.cdc.usds.simplereport.db.repository.ConditionRepository;
 import gov.cdc.usds.simplereport.db.repository.LoincStagingRepository;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -85,7 +86,11 @@ class ConditionServiceTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              this.conditionService.syncConditions();
+              try {
+                this.conditionService.syncConditions();
+              } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             });
     future.get();
 
@@ -112,7 +117,11 @@ class ConditionServiceTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              this.conditionService.syncConditions();
+              try {
+                this.conditionService.syncConditions();
+              } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             });
     future.get();
 
@@ -135,7 +144,11 @@ class ConditionServiceTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              this.conditionService.syncConditions();
+              try {
+                this.conditionService.syncConditions();
+              } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             });
     future.get();
 
@@ -156,7 +169,11 @@ class ConditionServiceTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              this.conditionService.syncConditions();
+              try {
+                this.conditionService.syncConditions();
+              } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             });
     assertThrows(ExecutionException.class, future::get);
   }
@@ -174,7 +191,11 @@ class ConditionServiceTest {
     CompletableFuture<Void> future =
         CompletableFuture.runAsync(
             () -> {
-              this.conditionService.syncConditions();
+              try {
+                this.conditionService.syncConditions();
+              } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             });
     future.get();
 

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/ConditionServiceTest.java
@@ -61,12 +61,10 @@ class ConditionServiceTest {
   private ConditionService conditionService;
   private FhirContext fhirContext;
   private HttpClient mockHttpClient;
-  public HttpResponse<String> mockResponse;
 
   @BeforeEach
   void setup() {
     mockHttpClient = mock(HttpClient.class);
-    mockResponse = mock(HttpResponse.class);
     conditionService = new ConditionService(tesClient, conditionRepository, loincStagingRepository);
     fhirContext = FhirContext.forR4();
     fhirContext.getParserOptions().setStripVersionsFromReferences(false);

--- a/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationInitializingServiceTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/service/OrganizationInitializingServiceTest.java
@@ -137,7 +137,7 @@ class OrganizationInitializingServiceTest extends BaseServiceTest<DiseaseService
 
   @Test
   void initUELRExampleData_success_addsConditionsLabsSpecimensSpecimenBodySites() {
-    Condition testCondition = new Condition("conditionCode", "conditionDisplay");
+    Condition testCondition = new Condition("conditionCode", "conditionDisplay", "snomedNameHere");
     testCondition.setLabs(
         Set.of(
             new Lab(

--- a/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/test_util/TestDataFactory.java
@@ -771,12 +771,12 @@ public class TestDataFactory {
     return List.of(new PhoneNumberInput("MOBILE", "(503) 867-5309"));
   }
 
-  public Condition createCondition(String code, String display) {
-    return conditionRepository.save(new Condition(code, display));
+  public Condition createCondition(String code, String display, String snomedName) {
+    return conditionRepository.save(new Condition(code, display, snomedName));
   }
 
   public Condition createCondition(String code) {
-    return createCondition(code, "Lorem ipsumosis");
+    return createCondition(code, "Lorem ipsumosis", "the snomed name");
   }
 
   public List<Condition> createConditions(List<String> codes) {

--- a/frontend/src/app/universalReporting/LabReportFormUtils.tsx
+++ b/frontend/src/app/universalReporting/LabReportFormUtils.tsx
@@ -127,10 +127,11 @@ export const ResultScaleTypeOptions: {
 ];
 
 export const buildConditionsOptionList = (conditions: Condition[]) => {
+  console.log("here's the conditions list: " + JSON.stringify(conditions));
   const options = conditions.map((condition) => {
     const fullConditiondisplay = condition.snomedName
-      ? `${condition.display}  -  ${condition.snomedName}  -  ${condition.code}`
-      : `${condition.display}  -  ${condition.code}`;
+      ? `${condition.display} - ${condition.snomedName}  -  ${condition.code}`
+      : `${condition.display} - ${condition.code}`;
     return {
       value: condition.code,
       label: fullConditiondisplay,

--- a/frontend/src/app/universalReporting/LabReportFormUtils.tsx
+++ b/frontend/src/app/universalReporting/LabReportFormUtils.tsx
@@ -127,10 +127,9 @@ export const ResultScaleTypeOptions: {
 ];
 
 export const buildConditionsOptionList = (conditions: Condition[]) => {
-  console.log("here's the conditions list: " + JSON.stringify(conditions));
   const options = conditions.map((condition) => {
     const fullConditiondisplay = condition.snomedName
-      ? `${condition.display} - ${condition.snomedName}  -  ${condition.code}`
+      ? `${condition.display} - ${condition.snomedName} - ${condition.code}`
       : `${condition.display} - ${condition.code}`;
     return {
       value: condition.code,

--- a/frontend/src/app/universalReporting/LabReportFormUtils.tsx
+++ b/frontend/src/app/universalReporting/LabReportFormUtils.tsx
@@ -128,9 +128,12 @@ export const ResultScaleTypeOptions: {
 
 export const buildConditionsOptionList = (conditions: Condition[]) => {
   const options = conditions.map((condition) => {
+    const fullConditiondisplay = condition.snomedName
+      ? `${condition.display}  -  ${condition.snomedName}  -  ${condition.code}`
+      : `${condition.display}  -  ${condition.code}`;
     return {
       value: condition.code,
-      label: `${condition.display} - ${condition.code}`,
+      label: fullConditiondisplay,
     };
   });
   options.sort((a, b) => a.label.localeCompare(b.label));

--- a/frontend/src/app/universalReporting/operations.graphql
+++ b/frontend/src/app/universalReporting/operations.graphql
@@ -2,6 +2,7 @@ query GetConditions {
   conditions {
     code
     display
+    snomedName
   }
 }
 

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -125,6 +125,7 @@ export type Condition = {
   __typename?: "Condition";
   code: Scalars["String"]["output"];
   display: Scalars["String"]["output"];
+  snomedName?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type CreateDeviceType = {

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -3076,6 +3076,7 @@ export type GetConditionsQuery = {
     __typename?: "Condition";
     code: string;
     display: string;
+    snomedName?: string | null;
   }>;
 };
 
@@ -9629,6 +9630,7 @@ export const GetConditionsDocument = gql`
     conditions {
       code
       display
+      snomedName
     }
   }
 `;


### PR DESCRIPTION
## Related Issue

- Resolves https://github.com/CDCgov/prime-simplereport/issues/9103

## Changes Proposed

- Retrieves the condition's SNOMED name as part of the condition sync from API endpoint (ex: `https://uts-ws.nlm.nih.gov/rest/content/current/source/SNOMEDCT_US/3738000`) 
- Adds the retrieved SNOMED condition name to a new `snomed_name` column in the `condition` table
- Displays the existing name and the new SNOMED condition name together, separated by a dash (ex: `Hepatitis C Virus Infection - Chronic hepatitis C - 128302006`) in the condition dropdown of Step 4 of 5 in SimpleReport 2.0
- Updates tests

## Additional Information

- In some scenarios, the existing display name that we use and the new SNOMED condition name are identical (ex: `Brucellosis - Brucellosis - 75702008`. I thought about removing the SNOMED condition name from the dropdown display value when it's identical with the existing display name, but kept it in for the sake of uniformity in the dropdown display values.

## Testing

- dev2 has the new condition dropdown display and the condition sync has already run there to populate the new `snomed_name` column
- To comprehensively test, I'd run the app locally and then run the condition sync (assuming you've already run the other syncs (lab, specimen etc.) in the past). Then check that the dropdown displays the expected values.

## Screenshots / Demos
<img width="956" height="498" alt="Screenshot 2025-08-29 at 12 17 22 PM" src="https://github.com/user-attachments/assets/9241bdc0-a538-43e7-8863-f01ecff4ca6d" />

