### PR TITLE
Conditional toast copy

### DIFF
--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.tsx
@@ -7,6 +7,7 @@ import {
   Label,
 } from "@trussworks/react-uswds";
 import React, { useEffect, useReducer, useState } from "react";
+import { useFeature } from "flagged";
 
 import TextInput from "../../commonComponents/TextInput";
 import { formatDate } from "../../utils/date";
@@ -124,6 +125,9 @@ const TestCardForm = ({
     useSpecimenTypeOptions(state);
 
   const { patientFullName } = useTestOrderPatient(testOrder);
+  const dataRetentionLimitsEnabled = useFeature(
+    "dataRetentionLimitsEnabled"
+  ) as boolean;
 
   /**
    * When backend sends an updated test order, update the form state
@@ -367,7 +371,8 @@ const TestCardForm = ({
     });
     showTestResultDeliveryStatusAlert(
       result.data?.submitQueueItem?.deliverySuccess,
-      testOrder.patient
+      testOrder.patient,
+      dataRetentionLimitsEnabled
     );
     if (startTestPatientId === testOrder.patient.internalId) {
       setStartTestPatientId(null);

--- a/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
+++ b/frontend/src/app/testQueue/TestCardForm/TestCardForm.utils.tsx
@@ -448,7 +448,8 @@ export function areSymptomAoeQuestionsAnswered(
 
 export const showTestResultDeliveryStatusAlert = (
   deliverySuccess: boolean | null | undefined,
-  patient: SomeoneWithName
+  patient: SomeoneWithName,
+  dataRetentionLimitsEnabled: boolean
 ) => {
   if (deliverySuccess === false) {
     const { title, body } = {
@@ -460,7 +461,9 @@ export const showTestResultDeliveryStatusAlert = (
   }
   const { title, body } = {
     ...ALERT_CONTENT[QUEUE_NOTIFICATION_TYPES.SUBMITTED_RESULT__SUCCESS](
-      patient
+      patient,
+      true,
+      dataRetentionLimitsEnabled
     ),
   };
   showSuccess(body, title);

--- a/frontend/src/app/testQueue/constants.ts
+++ b/frontend/src/app/testQueue/constants.ts
@@ -35,8 +35,12 @@ export const ALERT_CONTENT = {
     T extends SomeoneWithName
   >(
     patient: T,
-    startWithLastName: boolean = true
+    startWithLastName: boolean = true,
+    dataRetentionLimitsEnabled: boolean = false
   ): AlertContent => {
+    const resultText = dataRetentionLimitsEnabled
+      ? "has been sent."
+      : "was saved and reported.";
     return {
       type: "success",
       title: `Result for ${displayFullName(
@@ -44,7 +48,7 @@ export const ALERT_CONTENT = {
         patient.middleName,
         patient.lastName,
         startWithLastName
-      )} was saved and reported.`,
+      )} ${resultText}`,
       body: "See Results to view all test submissions",
     };
   },


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves https://github.com/CDCgov/prime-simplereport/issues/9076

## Changes Proposed

- Makes the success toast's text conditional on the dataRetentionLimitsEnabled flag 

## Additional Information

- Since useFeature is a hook, it had to be called within the component. It couldn't be used directly in the utils file.
- I didn't see any other places where the word "saved" was seen by the user and needed to be replaced with "sent" vis a vis whether we save their info or not.

## Testing

- Toggle the dataRetentionLimitsEnabled locally and submit one test with it set to true and another test with it set to false. Observe the different toast text.