### PR TITLE
Update mid-turbinate nasal swab coding

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/ResultsUploaderCachingService.java
@@ -52,7 +52,7 @@ public class ResultsUploaderCachingService {
           Map.entry("nasal", NASAL_SWAB_SNOMED),
           Map.entry("varied", NASAL_SWAB_SNOMED),
           Map.entry("nasopharyngeal swab", "258500001"),
-          Map.entry("mid-turbinate nasal swab", "871810001"),
+          Map.entry("mid-turbinate nasal swab", "1293160008"),
           Map.entry("anterior nares swab", "697989009"),
           Map.entry("anterior nasal swab", "697989009"),
           Map.entry("nasopharyngeal aspirate", "258411007"),


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Addressing [feedback from AIMS](https://teams.microsoft.com/l/message/19:74e04fd8733445c784114a8b89fa3884@thread.v2/1760381829861?context=%7B%22contextType%22%3A%22chat%22%7D)

> 871810001 SCT was not a valid SNOMED CT code. Looking at description - we propose mapping that to this valid code:	1293160008	Swab from middle region of inferior nasal meatus (specimen) or Nasal mid-turbinate swab

## Changes Proposed

- Updates the entry in the hardcoded specimen snomed map.

## Additional Information

- `specimenTypeNameSNOMEDMap` is a cached map that "combines specimen name to SNOMED maps from the database and those hardcoded in the service, favoring the DB result on conflicts"
- To complete this fix, we'll also need to update the specimen type code in production to use the new code.