### PR TITLE
Increase gradle test max heap size

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -289,5 +289,5 @@ tasks.named('test') {
         dependsOn testDbStart
         finalizedBy testDbStop
     }
-    maxHeapSize = "1024m"
+    maxHeapSize = "2048m"
 }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves recent non-deterministic test failures caused by out of memory errors.

## Changes Proposed

- Increase max heap size from 1 to 2 GB

## Additional Information

- Backend test performance and memory usage is worth additional investigation. Even if we are removing legacy backend tests when we eventually transition to SR 2.0, it would still be valuable to identify any testing patterns we would like to keep or remove for future 2.0 tests.