### PR TITLE
Use facility name for MSH-4.1 Namespace ID

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/HL7Converter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/HL7Converter.java
@@ -154,7 +154,11 @@ public class HL7Converter {
 
     MSH messageHeader = message.getMSH();
     populateMessageHeader(
-        messageHeader, performingFacility.getClia(), processingId, messageTimestamp);
+        messageHeader,
+        performingFacility.getName(),
+        performingFacility.getClia(),
+        processingId,
+        messageTimestamp);
 
     SFT softwareSegment = message.getSFT();
     populateSoftwareSegment(softwareSegment, gitProperties);
@@ -253,6 +257,7 @@ public class HL7Converter {
    * timestamp, etc. See page 90, HL7 v2.5.1 IG.
    *
    * @param msh the Message Header Segment (MSH) object from the message
+   * @param sendingFacilityName facility name
    * @param sendingFacilityClia CLIA number for the facility sending the lab report
    * @param processingId Indicates intent for processing. Must be either T for training, D for
    *     debugging, or P for production (see HL7 table 0103)
@@ -264,7 +269,11 @@ public class HL7Converter {
    *     processing id is not T, D, or P
    */
   void populateMessageHeader(
-      MSH msh, String sendingFacilityClia, String processingId, Date messageTimestamp)
+      MSH msh,
+      String sendingFacilityName,
+      String sendingFacilityClia,
+      String processingId,
+      Date messageTimestamp)
       throws DataTypeException, IllegalArgumentException {
     if (!sendingFacilityClia.matches(CLIA_REGEX)) {
       throw new IllegalArgumentException("Sending facility CLIA number must match CLIA format");
@@ -280,6 +289,7 @@ public class HL7Converter {
     msh.getMsh3_SendingApplication().getHd2_UniversalID().setValue(SIMPLE_REPORT_ORG_OID);
     msh.getMsh3_SendingApplication().getHd3_UniversalIDType().setValue("ISO");
 
+    msh.getMsh4_SendingFacility().getHd1_NamespaceID().setValue(sendingFacilityName);
     msh.getMsh4_SendingFacility().getHd2_UniversalID().setValue(sendingFacilityClia);
     // CLIA is allowed for MSH-4 even though it is not in the Universal ID Type value set of HL70301
     msh.getMsh4_SendingFacility().getHd3_UniversalIDType().setValue("CLIA");

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/HL7ConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/HL7ConverterTest.java
@@ -279,10 +279,13 @@ class HL7ConverterTest {
   @Test
   void populateMessageHeader_valid() throws DataTypeException {
     MSH msh = new ORU_R01().getMSH();
+    String facilityName = "Test Facility";
     String clia = "12D1234567";
 
-    hl7Converter.populateMessageHeader(msh, clia, "T", Date.from(STATIC_INSTANT));
+    hl7Converter.populateMessageHeader(msh, facilityName, clia, "T", Date.from(STATIC_INSTANT));
 
+    assertThat(msh.getMsh4_SendingFacility().getHd1_NamespaceID().getValue())
+        .isEqualTo(facilityName);
     assertThat(msh.getMsh4_SendingFacility().getHd2_UniversalID().getValue()).isEqualTo(clia);
     assertThat(msh.getMsh7_DateTimeOfMessage().getTs1_Time().getValue())
         .isEqualTo(STATIC_INSTANT_HL7_STRING);
@@ -293,12 +296,15 @@ class HL7ConverterTest {
   @Test
   void populateMessageHeader_throwsExceptionFor_invalidProcessingId() {
     MSH msh = new ORU_R01().getMSH();
+    String facilityName = "Test Facility";
     String clia = "12D1234567";
 
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> hl7Converter.populateMessageHeader(msh, clia, "F", Date.from(STATIC_INSTANT)));
+            () ->
+                hl7Converter.populateMessageHeader(
+                    msh, facilityName, clia, "F", Date.from(STATIC_INSTANT)));
     assertThat(exception.getMessage())
         .isEqualTo(
             "Processing id must be one of 'T' for testing, 'D' for debugging, or 'P' for production");


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #9244 

## Changes Proposed

- Use facility name for MSH-4.1 Namespace ID

## Additional Information

- Facility name is marked with a `@NonNull` lombok annotation on FacilityReportInput will throw an exception if being constructed with a null value.

## Testing

- Verify `aimsReportingEnabled` is set to true locally
- Verify you don't have `simple-report.azure-reporting-queue.hl7-queue-enabled` set to true
- Run the backend locally
- Submit a single entry test
- You should see the serialized HL7 message in the backend logs by searching for "TestEvent converted to HL7 as"
- Verify MSH-4 contains the facility name