### PR TITLE
Enable AIMS reporting in prod

### DIFF
--- a/backend/src/main/resources/application-azure-prod.yaml
+++ b/backend/src/main/resources/application-azure-prod.yaml
@@ -2,6 +2,7 @@ simple-report:
   azure-reporting-queue:
     enabled: true
     fhir-queue-enabled: true
+    hl7-queue-enabled: true
     exception-webhook-enabled: true
   patient-link-url: https://www.simplereport.gov/app/pxp?plid=
   twilio-callback-url: https://www.simplereport.gov/api/pxp/callback
@@ -36,4 +37,4 @@ features:
   syphilisEnabled: false
   hivEnabled: false
   universalReportingEnabled: false
-  aimsReportingEnabled: false
+  aimsReportingEnabled: true


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Enable AIMS in prod [after 12pm ET on 12/4/2025](https://docs.google.com/document/d/1wYqf3zhV0JS1uMQUrWlYbXfjWyBW4g1WCT77rY6OG7M/edit?tab=t.0)

## Changes Proposed

- Sets the `aimsReportingEnabled` flag to true so single entry and bulk upload submissions will be routed to AIMS
- Sets the `hl7-queue-enabled` flag to true so that single entry submissions get sent to the HL7 reporting queue on Azure where they will be picked up by the `test_data_publisher` function app to send to AIMS

## Additional Information

- APHL confirmed that #9271 is _**not a blocker**_ for us to enable reporting on prod.
- STLTs will still receive data from ReportStream until 12/31 so in the meantime the STLTs will be responsible for deduplication of results