### PR TITLE
Add jws resolution for trivy vulnerability

### DIFF
--- a/ops/services/app_functions/report_stream_batched_publisher/functions/package.json
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/package.json
@@ -32,7 +32,8 @@
   },
   "resolutions": {
     "semver": "7.5.2",
-    "undici": "5.26.2"
+    "undici": "5.26.2",
+    "jws": "^3.2.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/ops/services/app_functions/report_stream_batched_publisher/functions/yarn.lock
+++ b/ops/services/app_functions/report_stream_batched_publisher/functions/yarn.lock
@@ -1930,7 +1930,7 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
-buffer-equal-constant-time@1.0.1:
+buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
@@ -3316,21 +3316,21 @@ jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
-  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+jwa@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.2.tgz#16011ac6db48de7b102777e57897901520eec7b9"
+  integrity sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==
   dependencies:
-    buffer-equal-constant-time "1.0.1"
+    buffer-equal-constant-time "^1.0.1"
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+jws@^3.2.2, jws@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.3.tgz#5ac0690b460900a27265de24520526853c0b8ca1"
+  integrity sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==
   dependencies:
-    jwa "^1.4.1"
+    jwa "^1.4.2"
     safe-buffer "^5.0.1"
 
 kleur@^3.0.3:

--- a/ops/services/app_functions/test_data_publisher/functions/package.json
+++ b/ops/services/app_functions/test_data_publisher/functions/package.json
@@ -35,7 +35,8 @@
     "typescript": "^5.8.3"
   },
   "resolutions": {
-    "json-bigint": "^1.0.0"
+    "json-bigint": "^1.0.0",
+    "jws": "^3.2.3"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/ops/services/app_functions/test_data_publisher/functions/yarn.lock
+++ b/ops/services/app_functions/test_data_publisher/functions/yarn.lock
@@ -4812,7 +4812,7 @@ jsonwebtoken@^9.0.0:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jwa@^1.4.1:
+jwa@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.2.tgz#16011ac6db48de7b102777e57897901520eec7b9"
   integrity sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==
@@ -4821,12 +4821,12 @@ jwa@^1.4.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+jws@^3.2.2, jws@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.3.tgz#5ac0690b460900a27265de24520526853c0b8ca1"
+  integrity sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==
   dependencies:
-    jwa "^1.4.1"
+    jwa "^1.4.2"
     safe-buffer "^5.0.1"
 
 keyv@^4.5.3:


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Resolves blocking issue with high severity vulnerability in JWS [identified by Trivy](https://github.com/CDCgov/prime-simplereport/actions/runs/19966158962/job/57258383152)
```
services/app_functions/report_stream_batched_publisher/functions/yarn.lock (yarn)
=================================================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                       Title                       │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────┤
│ jws     │ CVE-2025-65945 │ HIGH     │ fixed  │ 3.2.2             │ 3.2.3, 4.0.1  │ auth0/node-jws Improperly Verifies HMAC Signature │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-65945        │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────┘

services/app_functions/test_data_publisher/functions/yarn.lock (yarn)
=====================================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                       Title                       │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────┤
│ jws     │ CVE-2025-65945 │ HIGH     │ fixed  │ 3.2.2             │ 3.2.3, 4.0.1  │ auth0/node-jws Improperly Verifies HMAC Signature │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-65945        │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────┘
Error: Process completed with exit code 1.
```

## Changes Proposed

- Adds resolution to the function app package.json files that requires jws `^3.2.3`

## Additional Information

- `jws` needs to be updated because it is used by `applicationinsights`