### PR TITLE
Support abnormal flags on legacy reports

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/service/UniversalReportService.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/service/UniversalReportService.java
@@ -58,7 +58,8 @@ public class UniversalReportService {
               gitProperties,
               aimsProcessingModeCode,
               String.valueOf(UUID.randomUUID()),
-              TestCorrectionStatus.ORIGINAL);
+              TestCorrectionStatus.ORIGINAL,
+              false);
       return parser.encode(message);
     } catch (HL7Exception e) {
       log.error("Encountered an error converting the form data to HL7");

--- a/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToHL7.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToHL7.java
@@ -163,7 +163,8 @@ public class BulkUploadResultsToHL7 {
             gitProperties,
             aimsProcessingModeCode,
             testId,
-            testStatus);
+            testStatus,
+            true);
 
     return parser.encode(labReportMessage);
   }


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #9323 

## Changes Proposed

- Adds OBX-8 abnormal flags to only legacy SR lab reports which safely assume that positive is an abnormal result while negative or inconclusive are normal.

## Additional Information

- How we implement abnormal flags in 2.0 is still TBD.
- HL7 implementation guide indicates OBX-8 should be a CWE data type (Coded with Exceptions), but the HAPI dependency handles it as an IS data type (Coded Value for User-Defined Tables). This means we can get the dependency to set the value for OBX-8.1, but it can't populate the other fields like OBX-8.2 description, OBX-8.3 name of coding system, or OBX-8.7 coding system version id.
- [AIMS has said](https://teams.microsoft.com/l/message/19:74e04fd8733445c784114a8b89fa3884@thread.v2/1765563782887?context=%7B%22contextType%22%3A%22chat%22%7D) only passing in the value in OBX-8.1 is fine and they are able to populate the additional details on their end.

> Got the files -- we have transformed that OBX and it looks like:
OBX|1|CWE|94500-6^SARS-CoV-2 (COVID-19) RNA [Presence] in Respiratory system specimen by NAA with probe detection^LN^^^^2.7.1||260373001^Detected^SCT^^^^20240301|||A^Abnormal (applies to non-numeric results)^HL70078^^^^2.5.1|||F|||20211220220000+0000|01D1058442^My Urgent Care^CLIA||||20211220||||My Urgent Care^^^^^&2.16.840.1.113883.4.7&ISO^FI^^^01D1058442|400 Main Street^^Los Angeles^CA^90001^USA

AIMS will replace the values A and N with the following

```
A^Abnormal (applies to non-numeric results)^HL70078^^^^2.5.1
N^Normal (applies to non-numeric results)^HL70078^^^^2.5.1
```

## Testing

- Run locally in debug mode
- Set a breakpoint [here in AzureTestEventReportingQueueConfiguration.java](https://github.com/CDCgov/prime-simplereport/blob/94ab0e2ddc5df3200d2ffb46b383a6b420f19eca/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTestEventReportingQueueConfiguration.java#L260)
- Submit a single entry test
- Check that the OBX-8 segment in the generated HL7 message contains the appropriate abnormal flag