### PR TITLE
Move SPM segment to the last order group within HL7 message

### DIFF
--- a/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/HL7Converter.java
+++ b/backend/src/main/java/gov/cdc/usds/simplereport/api/converter/HL7Converter.java
@@ -249,9 +249,9 @@ public class HL7Converter {
       // in a message as long as each specimen is associated with only one observation request (aka
       // test ordered LOINC). With how the app currently works, we will only ever have one specimen
       // in the entire HL7 message. That is only due to how the app is currently designed, not a
-      // constraint of HL7.
+      // constraint of HL7. This SPM segment should be attached to the last order group.
       // See page 83, HL7 v2.5.1 IG
-      if (orderObservationIndex == 0) {
+      if (orderObservationIndex == testOrderLoincToTestDetailsMap.size() - 1) {
         SPM specimen = orderGroup.getSPECIMEN().getSPM();
         populateSpecimen(specimen, 1, specimenId, specimenInput);
       }

--- a/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/HL7ConverterTest.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/api/converter/HL7ConverterTest.java
@@ -223,6 +223,10 @@ class HL7ConverterTest {
     Parser parser = hapiContext.getPipeParser();
     String encodedMessage = parser.encode(message);
     assertThat(StringUtils.countMatches(encodedMessage, "OBR|")).isEqualTo(2);
+
+    assertThat(StringUtils.countMatches(encodedMessage, "SPM|")).isEqualTo(1);
+    String[] lines = encodedMessage.replace("\r", "\n").split("\n");
+    assertThat(lines[lines.length - 1]).contains("SPM|");
   }
 
   @Test


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Los Angeles received a lab report with multiple test orders and is requesting that the common SPM segment be moved to after the last order group of OBR/OBX so that SPM appears as the last line.

## Changes Proposed

- Only attach SPM segment to the last order group of an HL7 message

## Additional Information

- Los Angeles ideally wants SPM added to every OBR, but AIMS cannot currently process messages with multiple SPM segments. We [previously updated](https://github.com/CDCgov/prime-simplereport/pull/9080#issue-3322554835) our code to only send a single SPM segment due to that issue.
- [Link to discussion with APHL on Teams](https://teams.microsoft.com/l/message/19:74e04fd8733445c784114a8b89fa3884@thread.v2/1766162453037?context=%7B%22contextType%22%3A%22chat%22%7D)
## Testing

- Run locally in debug mode
- Set a breakpoint [here in AzureTestEventReportingQueueConfiguration.java](https://github.com/CDCgov/prime-simplereport/blob/94ab0e2ddc5df3200d2ffb46b383a6b420f19eca/backend/src/main/java/gov/cdc/usds/simplereport/config/AzureTestEventReportingQueueConfiguration.java#L260)
- Submit a single entry test
- Check that the SPM segment in the generated HL7 message appears at the end and is the only SPM segment