### PR TITLE
Fix bulk upload bugs with empty non-required fields

### DIFF
--- a/backend/src/test/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToHL7Test.java
+++ b/backend/src/test/java/gov/cdc/usds/simplereport/utils/BulkUploadResultsToHL7Test.java
@@ -102,6 +102,25 @@ public class BulkUploadResultsToHL7Test {
   }
 
   @Test
+  void requiredFieldsOnlyCsv_success() {
+    InputStream input = loadCsv("testResultUpload/test-results-upload-valid-required-only.csv");
+    HL7BatchMessage batchMessage = sut.convertToHL7BatchMessage(input);
+
+    assertThat(batchMessage.message()).isNotEmpty();
+    assertThat(batchMessage.recordsCount()).isEqualTo(2);
+    assertThat(batchMessage.reportedDiseases()).isNotNull();
+
+    String[] lines = getHL7Lines(batchMessage);
+    assertThat(lines).isNotEmpty();
+
+    assertThat(hasSegment(lines, "FHS")).isTrue();
+    assertThat(hasSegment(lines, "BHS")).isTrue();
+    assertThat(hasSegment(lines, "MSH")).isTrue();
+    assertThat(hasSegment(lines, "BTS")).isTrue();
+    assertThat(hasSegment(lines, "FTS")).isTrue();
+  }
+
+  @Test
   void convertExistingCsv_TestOrderedCodeMapped() {
     InputStream input = loadCsv("testResultUpload/test-results-upload-all-fields.csv");
     HL7BatchMessage batchMessage = sut.convertToHL7BatchMessage(input);


### PR DESCRIPTION
# BACKEND PULL REQUEST

## Related Issue

- Resolves #9381 

## Changes Proposed

- If `test_result_status` is empty, defaults to `TestCorrectionStatus.ORIGINAL`
- If `testing_lab_phone_number` is empty, defaults to `ordering_provider_phone_number` which is a required field
- If `ordering_facility_phone_number` is empty, defaults to `ordering_provider_phone_number` which is a required field

## Additional Information

- Added test to verify bulk upload to HL7 works when only submitting required fields.

## Testing

- Run main locally and submit bulk upload file [backend/src/test/resources/testResultUpload/test-results-upload-valid-required-only.csv](https://github.com/CDCgov/prime-simplereport/blob/main/backend/src/test/resources/testResultUpload/test-results-upload-valid-required-only.csv)
- Observe the server error
- Switch to this branch and resubmit the same file
- Verify no errors are shown when submitting required only fields