### PR TITLE
Add page title and h1 to session timeout

### DIFF
--- a/frontend/src/app/accountCreation/SessionTimeout.tsx
+++ b/frontend/src/app/accountCreation/SessionTimeout.tsx
@@ -1,11 +1,17 @@
 import CardBackground from "../commonComponents/CardBackground/CardBackground";
 import Card from "../commonComponents/Card/Card";
+import { useDocumentTitle } from "../utils/hooks";
 
 const SessionTimeout = () => {
+  useDocumentTitle("Session timeout");
+
   return (
     <main>
       <CardBackground>
-        <Card logo bodyKicker={"Your session has expired"}>
+        <Card logo>
+          <h1 className={"font-ui-md text-bold margin-top-3"}>
+            Your session has expired
+          </h1>
           <p>
             Please contact your account administrator to request a new
             activation link.


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- Resolves #8539 

## Changes Proposed

- Adds page title and h1 header to session timeout

## Testing

- Run locally and check http://localhost:3000/session-timeout

## Screenshots / Demos

<img width="232" height="34" alt="image" src="https://github.com/user-attachments/assets/c84b16e4-6518-48e0-b1a5-8b612839c5c8" />

<img width="458" height="281" alt="image" src="https://github.com/user-attachments/assets/a16f5eeb-a974-40a6-963c-ab0bb482abad" />

<!---
## Checklist for Author and Reviewer
### Accessibility
- [x] Any large changes have been run through Deque manual testing
- [x] All changes have run through the Deque automated testing
-->
