### PR TITLE
Update Slack alert, give Alis a break

### DIFF
--- a/.github/actions/slack-message/action.yml
+++ b/.github/actions/slack-message/action.yml
@@ -16,7 +16,7 @@ inputs:
   default_github_user:
     description: Default GitHub user to use if the user is not found in the map
     required: false
-    default: "alismx"
+    default: "default"
 
 runs:
   using: composite


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- No Open issue atm.

## Changes Proposed

- Remove @alismx as the tagged individual for slack alerts
- Replace them with "default" which will point to the SR eng group alias instead.
- [Update the slack user map](https://github.com/cdcent/simplereport_docs/blob/23e626702d543e45dc41014d7d811f8ec43eafab/ops/runbooks/Update-Github-Slack-user-map.md) to include the sr engineering team group tag with the key "default"

## Additional Information

- Because we are using the merge queue, the github user will be the bot every time (instead of the engineer who triggered the merge).  The bot is not in the map and doesn't have a slack account 🤖.  
- Realistically we can have the map be _just_ the default alias because it will never find an actual user.
- Using a slack user map that looks like
`'"{ "default": "SR-GROUP-ALIAS", "alismx": "SR-GROUP-ALIAS" }"'
`
So we don't have to wait to stop tagging alis

## Testing

- Would need to trigger a slack message (i.e. a failed deployment).  Will figure that out later, just wanted to get a PR opened for the baseline change.

