### PR TITLE
Removing ops global from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -121,13 +121,6 @@ updates:
       day: "sunday"
 
   - package-ecosystem: "terraform"
-    directory: "/ops/global"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-
-  - package-ecosystem: "terraform"
     directory: "/ops/services/okta-global"
     open-pull-requests-limit: 2
     schedule:


### PR DESCRIPTION
## Related Issue

- We want any updates in `ops/global` to be handled by our devops people outside of the dependabot update process.

## Changes Proposed

- Removes `ops/global` from the dependabot scan