### PR TITLE
Modify vulnerable workflows

### DIFF
--- a/.github/workflows/dependabotClosePRIssue.yml
+++ b/.github/workflows/dependabotClosePRIssue.yml
@@ -2,7 +2,6 @@ name: Dependabot Close Issue
 on:
   pull_request:
     types: [closed]
-  workflow_dispatch:
 
 jobs:
   issue:

--- a/.github/workflows/updateGradleLocks.yml
+++ b/.github/workflows/updateGradleLocks.yml
@@ -20,7 +20,7 @@ jobs:
 
   update_locks:
     # Run when manually requested or when dependabot creates/updates a PR
-    # if: github.event.pull_request.user.login  == 'dependabot[bot]'
+    if: github.event.pull_request.user.login  == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

> Combining pull_request_target workflow trigger with an explicit checkout of an untrusted PR is a dangerous practice that may lead to repository compromise.

## Changes Proposed

- Use `pull_request` workflow trigger, which by default prevents secrets access.

## Additional Information

- Left `permissions: contents: write` and `permissions: issues: write` to not break these workflows.

## Testing

N/A

<!---
## Checklist for Primary Reviewer
### Infrastructure
- [ ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Cloud
- [ ] Oncall has been notified if this change is going in after-hours
- [ ] If there are changes that cannot be tested locally, this has been deployed to our Azure `test`, `dev`, or `pentest` environment for verification

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README