### PR TITLE
Add sunset banner to header

### DIFF
--- a/frontend/src/app/commonComponents/Header.scss
+++ b/frontend/src/app/commonComponents/Header.scss
@@ -1,5 +1,9 @@
 @use "../../scss/settings";
 
+.sunset-alert-body {
+  max-width: settings.$site-max-width !important;
+}
+
 .usa-nav-container.prime-header {
   max-width: settings.$site-max-width;
 

--- a/frontend/src/app/commonComponents/Header.test.tsx
+++ b/frontend/src/app/commonComponents/Header.test.tsx
@@ -39,6 +39,8 @@ jest.mock("react-router-dom", () => {
   };
 });
 
+jest.mock("uuid", () => ({ v4: () => "12345" }));
+
 describe("Header", () => {
   it("displays correctly", async () => {
     render(

--- a/frontend/src/app/commonComponents/Header.tsx
+++ b/frontend/src/app/commonComponents/Header.tsx
@@ -20,6 +20,7 @@ import Button from "./Button/Button";
 import ChangeUser from "./ChangeUser";
 import Dropdown from "./Dropdown";
 import USAGovBanner from "./USAGovBanner";
+import Alert from "./Alert";
 
 const Header: React.FC<{}> = () => {
   const appInsights = getAppInsights();
@@ -314,6 +315,22 @@ const Header: React.FC<{}> = () => {
   return (
     <header className="usa-header usa-header--basic">
       <USAGovBanner />
+
+      <div className="border-top border-base-lighter">
+        <Alert
+          type="warning"
+          role="alert"
+          className={"margin-left-auto margin-right-auto"}
+          bodyClassName={"sunset-alert-body"}
+        >
+          SimpleReport is being sunset and service will end at 5:00 pm (ET) on
+          August 31, 2026. For more information, see{" "}
+          <a href={"https://www.simplereport.gov/sunset"}>
+            simplereport.gov/sunset
+          </a>
+          .
+        </Alert>
+      </div>
 
       <div className="usa-nav-container prime-header">
         <div className="usa-navbar">

--- a/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
@@ -57,6 +57,33 @@ exports[`Header displays correctly 1`] = `
         </div>
       </div>
       <div
+        class="border-top border-base-lighter"
+      >
+        <div
+          class="usa-alert usa-alert--warning margin-left-auto margin-right-auto"
+          id="3cbe3e54-2383-4e28-8c70-8552ad489e9d"
+          role="alert"
+        >
+          <div
+            class="usa-alert__body sunset-alert-body"
+          >
+            <div
+              class="usa-alert__text"
+              id="596be4a5-c981-48c1-8c96-a220a0df4841"
+            >
+              SimpleReport is being sunset and service will end at 5:00 pm (ET) on August 31, 2026. For more information, see
+               
+              <a
+                href="https://www.simplereport.gov/sunset"
+              >
+                simplereport.gov/sunset
+              </a>
+              .
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         class="usa-nav-container prime-header"
       >
         <div

--- a/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/app/commonComponents/__snapshots__/Header.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Header displays correctly 1`] = `
       >
         <div
           class="usa-alert usa-alert--warning margin-left-auto margin-right-auto"
-          id="3cbe3e54-2383-4e28-8c70-8552ad489e9d"
+          id="12345"
           role="alert"
         >
           <div
@@ -69,7 +69,7 @@ exports[`Header displays correctly 1`] = `
           >
             <div
               class="usa-alert__text"
-              id="596be4a5-c981-48c1-8c96-a220a0df4841"
+              id="12345"
             >
               SimpleReport is being sunset and service will end at 5:00 pm (ET) on August 31, 2026. For more information, see
                

--- a/frontend/src/patientApp/PatientHeader.scss
+++ b/frontend/src/patientApp/PatientHeader.scss
@@ -2,4 +2,8 @@
   .header {
     display: none;
   }
+
+  .sunset-alert-body {
+    max-width: 1200px !important;
+  }
 }

--- a/frontend/src/patientApp/PatientHeader.tsx
+++ b/frontend/src/patientApp/PatientHeader.tsx
@@ -8,6 +8,7 @@ import siteLogo from "../img/simplereport-logomark-color.svg";
 import { RootState } from "../app/store";
 import { Patient } from "../app/patients/ManagePatients";
 import USAGovBanner from "../app/commonComponents/USAGovBanner";
+import Alert from "../app/commonComponents/Alert";
 
 import LanguageToggler from "./LanguageToggler";
 
@@ -25,6 +26,22 @@ const PatientHeader = () => {
   return (
     <header className="header border-bottom border-base-lighter">
       <USAGovBanner />
+
+      <div className="border-top border-base-lighter">
+        <Alert
+          type="warning"
+          role="alert"
+          className={"margin-left-auto margin-right-auto"}
+          bodyClassName={"sunset-alert-body"}
+        >
+          SimpleReport is being sunset and service will end at 5:00 pm (ET) on
+          August 31, 2026. For more information, see{" "}
+          <a href={"https://www.simplereport.gov/sunset"}>
+            simplereport.gov/sunset
+          </a>
+          .
+        </Alert>
+      </div>
 
       <div className="display-flex flex-align-center maxw-tablet grid-container patient-header">
         <div className="padding-y-1">


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue

- [See this Slack thread for more details and link to clearer content](https://skylight-hq.slack.com/archives/C065V4DHBQF/p1777301034233219)

## Changes Proposed

- Adds banner to header with info about SimpleReport sunsetting

## Additional Information

- This should be merged after the [static site changes are merged](https://github.com/CDCgov/prime-simplereport-site/pull/862)

## Testing

- Deployed on [dev1](https://dev.simplereport.gov/)

## Screenshots / Demos

<img width="1177" height="105" alt="image" src="https://github.com/user-attachments/assets/3955e2a9-c69a-4e54-9c3b-517600abe58d" />
